### PR TITLE
Performance overhaul: persistent cache, parallel processing, and optimized utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,6 +154,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +214,29 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecheck"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0caa33a2c0edca0419d15ac723dff03f1956f7978329b1e3b5fdaaaed9d3ca8b"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "rancor",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89385e82b5d1821d2219e0b095efa2cc1f246cbf99080f3be46a1a85c0d392d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bytes"
@@ -261,6 +293,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
 ]
 
 [[package]]
@@ -348,6 +390,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,6 +426,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -496,6 +569,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,6 +611,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -774,9 +882,15 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.4",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1039,7 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1129,6 +1243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1283,16 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1206,7 +1340,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -1220,6 +1354,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1240,6 +1383,26 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "munge"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e17401f259eba956ca16491461b6e8f72913a0a114e39736ce404410f915a0c"
+dependencies = [
+ "munge_macro",
+]
+
+[[package]]
+name = "munge_macro"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4568f25ccbd45ab5d5603dc34318c1ec56b117531781260002151b8530a9f931"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1305,6 +1468,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -1424,6 +1593,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1681,15 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rancor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a063ea72381527c2a0561da9c80000ef822bdd7c3241b1cc1b12100e3df081ee"
+dependencies = [
+ "ptr_meta",
+]
 
 [[package]]
 name = "rand"
@@ -1573,6 +1771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1829,15 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rend"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cadadef317c2f20755a64d7fdc48f9e7178ee6b0e1f7fce33fa60f1d68a276e6"
+dependencies = [
+ "bytecheck",
+]
 
 [[package]]
 name = "reqwest"
@@ -1671,6 +1889,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a640b26f007713818e9a9b65d34da1cf58538207b052916a83d80e43f3ffa4"
+dependencies = [
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.15.4",
+ "indexmap",
+ "munge",
+ "ptr_meta",
+ "rancor",
+ "rend",
+ "rkyv_derive",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd83f5f173ff41e00337d97f6572e416d022ef8a19f371817259ae960324c482"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2015,17 +2263,26 @@ version = "2.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "chrono",
+ "chrono-tz",
  "clap",
  "crossterm 0.29.0",
+ "dashmap",
+ "dirs",
+ "futures",
  "glob",
+ "jwalk",
+ "memmap2",
  "notify",
  "notify-types",
  "num-format",
+ "parking_lot",
  "phf",
  "ratatui",
  "rayon",
  "reqwest",
+ "rkyv",
  "rmcp",
  "schemars",
  "serde",
@@ -2037,6 +2294,7 @@ dependencies = [
  "tiktoken-rs",
  "tokio",
  "toml",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -2432,6 +2690,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "value-trait"
@@ -2850,6 +3118,12 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,13 @@ authors = ["Piebald LLC <support@piebald.ai>"]
 serde = { version = "1.0.219", features = ["derive"] }
 anyhow = "1.0"
 glob = "0.3"
+jwalk = "0.8"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 chrono = { version = "0.4", features = ["serde"] }
 tokio = { version = "1", features = ["full"] }
 rayon = "1.8"
+futures = "0.3"
+dashmap = "6"
 num-format = "0.4"
 ratatui = "0.29"
 crossterm = "0.29"
@@ -25,6 +29,13 @@ phf = { version = "0.12.1", features = ["macros"] }
 serde_bytes = "0.11.17"
 simd-json = { version = "0.15.1", features = ["serde"] }
 tiktoken-rs = "0.6"
+parking_lot = "0.12"
+bincode = "1.3"
+dirs = "6.0"
+chrono-tz = "0.10"
+# Zero-copy cache
+rkyv = "0.8"
+memmap2 = "0.9"
 
 # MCP server support
 rmcp = { version = "0.9.1", features = ["server", "macros", "transport-io"] }

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -1,8 +1,211 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use dashmap::DashMap;
+use jwalk::WalkDir;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::path::PathBuf;
 
-use crate::types::{AgenticCodingToolStats, ConversationMessage};
+use crate::cache::{FileCacheEntry, FileCacheKey, FileStatsCache};
+use crate::types::{AgenticCodingToolStats, ConversationMessage, DailyStats};
+
+/// Merge source DailyStats into destination aggregated map.
+/// This is a key optimization - we merge pre-computed aggregates instead of re-aggregating.
+fn merge_daily_stats(
+    dst: &mut std::collections::BTreeMap<String, DailyStats>,
+    date: &str,
+    src: &DailyStats,
+) {
+    dst.entry(date.to_string())
+        .and_modify(|existing| {
+            existing.user_messages += src.user_messages;
+            existing.ai_messages += src.ai_messages;
+            existing.conversations += src.conversations;
+
+            // Merge model counts
+            for (model, count) in &src.models {
+                *existing.models.entry(model.clone()).or_default() += count;
+            }
+
+            // Merge stats
+            existing.stats.input_tokens += src.stats.input_tokens;
+            existing.stats.output_tokens += src.stats.output_tokens;
+            existing.stats.reasoning_tokens += src.stats.reasoning_tokens;
+            existing.stats.cache_creation_tokens += src.stats.cache_creation_tokens;
+            existing.stats.cache_read_tokens += src.stats.cache_read_tokens;
+            existing.stats.cached_tokens += src.stats.cached_tokens;
+            existing.stats.cost += src.stats.cost;
+            existing.stats.tool_calls += src.stats.tool_calls;
+            existing.stats.terminal_commands += src.stats.terminal_commands;
+            existing.stats.file_searches += src.stats.file_searches;
+            existing.stats.file_content_searches += src.stats.file_content_searches;
+            existing.stats.files_read += src.stats.files_read;
+            existing.stats.files_added += src.stats.files_added;
+            existing.stats.files_edited += src.stats.files_edited;
+            existing.stats.files_deleted += src.stats.files_deleted;
+            existing.stats.lines_read += src.stats.lines_read;
+            existing.stats.lines_added += src.stats.lines_added;
+            existing.stats.lines_edited += src.stats.lines_edited;
+            existing.stats.lines_deleted += src.stats.lines_deleted;
+            existing.stats.bytes_read += src.stats.bytes_read;
+            existing.stats.bytes_added += src.stats.bytes_added;
+            existing.stats.bytes_edited += src.stats.bytes_edited;
+            existing.stats.bytes_deleted += src.stats.bytes_deleted;
+            existing.stats.todos_created += src.stats.todos_created;
+            existing.stats.todos_completed += src.stats.todos_completed;
+            existing.stats.todos_in_progress += src.stats.todos_in_progress;
+            existing.stats.todo_writes += src.stats.todo_writes;
+            existing.stats.todo_reads += src.stats.todo_reads;
+            existing.stats.code_lines += src.stats.code_lines;
+            existing.stats.docs_lines += src.stats.docs_lines;
+            existing.stats.data_lines += src.stats.data_lines;
+            existing.stats.media_lines += src.stats.media_lines;
+            existing.stats.config_lines += src.stats.config_lines;
+            existing.stats.other_lines += src.stats.other_lines;
+        })
+        .or_insert_with(|| src.clone());
+}
+
+/// VSCode GUI forks that might have extensions installed
+const VSCODE_GUI_FORKS: &[&str] = &[
+    "Code",
+    "Code - Insiders",
+    "Cursor",
+    "Windsurf",
+    "VSCodium",
+    "Positron",
+    "Antigravity",
+];
+
+/// VSCode CLI/server forks (remote development)
+const VSCODE_CLI_FORKS: &[&str] = &["vscode-server", "vscode-server-insiders"];
+
+/// Discover data sources for VSCode extension-based analyzers using jwalk.
+///
+/// This handles the complexity of multiple VSCode forks across different OSes:
+/// - Linux GUI: `~/.config/{fork}/User/globalStorage/{extension_id}/tasks/*/`
+/// - Linux CLI: `~/.{fork}/data/User/globalStorage/{extension_id}/tasks/*/`
+/// - macOS: `~/Library/Application Support/{fork}/User/globalStorage/{extension_id}/tasks/*/`
+/// - Windows: `%APPDATA%\{fork}\User\globalStorage\{extension_id}\tasks\*\`
+///
+/// # Arguments
+/// * `extension_id` - The VSCode extension ID (e.g., "saoudrizwan.claude-dev")
+/// * `target_filename` - The filename to search for (e.g., "ui_messages.json")
+/// * `return_parent_dir` - If true, returns the parent directory instead of the file path
+pub fn discover_vscode_extension_sources(
+    extension_id: &str,
+    target_filename: &str,
+    return_parent_dir: bool,
+) -> Result<Vec<DataSource>> {
+    let mut sources = Vec::new();
+
+    if let Some(home_dir) = dirs::home_dir() {
+        // Collect all potential tasks directories
+        let mut tasks_dirs = Vec::new();
+
+        // Linux GUI forks: ~/.config/{fork}/User/globalStorage/{ext}/tasks
+        for fork in VSCODE_GUI_FORKS {
+            let tasks_dir = home_dir
+                .join(".config")
+                .join(fork)
+                .join("User/globalStorage")
+                .join(extension_id)
+                .join("tasks");
+            if tasks_dir.is_dir() {
+                tasks_dirs.push(tasks_dir);
+            }
+        }
+
+        // Linux CLI forks: ~/.{fork}/data/User/globalStorage/{ext}/tasks
+        for fork in VSCODE_CLI_FORKS {
+            let tasks_dir = home_dir
+                .join(format!(".{fork}"))
+                .join("data/User/globalStorage")
+                .join(extension_id)
+                .join("tasks");
+            if tasks_dir.is_dir() {
+                tasks_dirs.push(tasks_dir);
+            }
+        }
+
+        // macOS GUI forks: ~/Library/Application Support/{fork}/User/globalStorage/{ext}/tasks
+        for fork in VSCODE_GUI_FORKS {
+            let tasks_dir = home_dir
+                .join("Library/Application Support")
+                .join(fork)
+                .join("User/globalStorage")
+                .join(extension_id)
+                .join("tasks");
+            if tasks_dir.is_dir() {
+                tasks_dirs.push(tasks_dir);
+            }
+        }
+
+        // Walk each tasks directory with jwalk (parallel)
+        for tasks_dir in tasks_dirs {
+            // Pattern: {task_id}/{target_filename}
+            for entry in WalkDir::new(&tasks_dir)
+                .min_depth(2)
+                .max_depth(2)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.file_type().is_file()
+                        && e.path()
+                            .file_name()
+                            .is_some_and(|name| name == target_filename)
+                })
+            {
+                let path = if return_parent_dir {
+                    entry.path().parent().map(|p| p.to_path_buf())
+                } else {
+                    Some(entry.path())
+                };
+
+                if let Some(p) = path {
+                    sources.push(DataSource { path: p });
+                }
+            }
+        }
+    }
+
+    // Windows GUI forks: %APPDATA%\{fork}\User\globalStorage\{ext}\tasks
+    if let Ok(appdata) = std::env::var("APPDATA") {
+        let appdata_path = PathBuf::from(appdata);
+        for fork in VSCODE_GUI_FORKS {
+            let tasks_dir = appdata_path
+                .join(fork)
+                .join("User\\globalStorage")
+                .join(extension_id)
+                .join("tasks");
+            if tasks_dir.is_dir() {
+                for entry in WalkDir::new(&tasks_dir)
+                    .min_depth(2)
+                    .max_depth(2)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .filter(|e| {
+                        e.file_type().is_file()
+                            && e.path()
+                                .file_name()
+                                .is_some_and(|name| name == target_filename)
+                    })
+                {
+                    let path = if return_parent_dir {
+                        entry.path().parent().map(|p| p.to_path_buf())
+                    } else {
+                        Some(entry.path())
+                    };
+
+                    if let Some(p) = path {
+                        sources.push(DataSource { path: p });
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(sources)
+}
 
 /// Represents a data source for an analyzer
 #[derive(Debug, Clone)]
@@ -33,20 +236,79 @@ pub trait Analyzer: Send + Sync {
 
     /// Check if this analyzer is available on the current system
     fn is_available(&self) -> bool;
+
+    /// Parse a single file and return a cache entry.
+    /// Default implementation returns an error - analyzers should override this
+    /// to enable incremental caching.
+    fn parse_single_file(&self, _source: &DataSource) -> Result<FileCacheEntry> {
+        Err(anyhow::anyhow!(
+            "parse_single_file not implemented for {}",
+            self.display_name()
+        ))
+    }
+
+    /// Whether this analyzer supports incremental caching.
+    /// Default is false - analyzers should override this to return true
+    /// after implementing parse_single_file.
+    fn supports_caching(&self) -> bool {
+        false
+    }
+
+    /// Whether this analyzer supports delta (append-only) parsing.
+    /// Default is false - JSONL-based analyzers should return true.
+    fn supports_delta_parsing(&self) -> bool {
+        false
+    }
+
+    /// Parse a single file incrementally, using cached data if available.
+    /// Default implementation falls back to full parse.
+    fn parse_single_file_incremental(
+        &self,
+        source: &DataSource,
+        _cached: Option<&FileCacheEntry>,
+    ) -> Result<FileCacheEntry> {
+        // Default: ignore cache, do full parse
+        self.parse_single_file(source)
+    }
 }
 
 /// Registry for managing multiple analyzers
-#[derive(Default)]
 pub struct AnalyzerRegistry {
     analyzers: Vec<Box<dyn Analyzer>>,
+    /// Cached data sources per analyzer (display_name -> sources)
+    data_source_cache: DashMap<String, Vec<DataSource>>,
+    /// Per-file stats cache for incremental updates
+    file_stats_cache: FileStatsCache,
+}
+
+impl Default for AnalyzerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl AnalyzerRegistry {
-    /// Create a new analyzer registry
+    /// Create a new analyzer registry, loading any persisted cache from disk
     pub fn new() -> Self {
+        // Try loading from disk, fall back to empty cache
+        let file_stats_cache =
+            FileStatsCache::load_from_disk().unwrap_or_else(|_| FileStatsCache::new());
+
         Self {
             analyzers: Vec::new(),
+            data_source_cache: DashMap::new(),
+            file_stats_cache,
         }
+    }
+
+    /// Get a reference to the file stats cache
+    pub fn file_cache(&self) -> &FileStatsCache {
+        &self.file_stats_cache
+    }
+
+    /// Persist the cache to disk (call on shutdown)
+    pub fn persist_cache(&self) -> Result<()> {
+        self.file_stats_cache.save_to_disk()
     }
 
     /// Register an analyzer
@@ -54,16 +316,45 @@ impl AnalyzerRegistry {
         self.analyzers.push(Box::new(analyzer));
     }
 
+    /// Get or discover data sources for an analyzer (cached)
+    pub fn get_cached_data_sources(&self, analyzer: &dyn Analyzer) -> Result<Vec<DataSource>> {
+        let name = analyzer.display_name().to_string();
+
+        // Check cache first
+        if let Some(cached) = self.data_source_cache.get(&name) {
+            return Ok(cached.clone());
+        }
+
+        // Discover and cache
+        let sources = analyzer.discover_data_sources()?;
+        self.data_source_cache.insert(name, sources.clone());
+        Ok(sources)
+    }
+
+    /// Invalidate cache for a specific analyzer
+    pub fn invalidate_cache(&self, analyzer_name: &str) {
+        self.data_source_cache.remove(analyzer_name);
+    }
+
+    /// Invalidate all caches
+    pub fn invalidate_all_caches(&self) {
+        self.data_source_cache.clear();
+    }
+
     /// Get available analyzers (those that are present on the system)
+    /// Uses cached data sources to check availability, avoiding redundant glob scans
     pub fn available_analyzers(&self) -> Vec<&dyn Analyzer> {
         self.analyzers
             .iter()
-            .filter(|a| a.is_available())
+            .filter(|a| {
+                self.get_cached_data_sources(a.as_ref())
+                    .is_ok_and(|sources| !sources.is_empty())
+            })
             .map(|a| a.as_ref())
             .collect()
     }
 
-    /// Get analyzer by display name  
+    /// Get analyzer by display name
     pub fn get_analyzer_by_display_name(&self, display_name: &str) -> Option<&dyn Analyzer> {
         self.analyzers
             .iter()
@@ -71,20 +362,255 @@ impl AnalyzerRegistry {
             .map(|a| a.as_ref())
     }
 
-    /// Load stats from all available analyzers
-    pub async fn load_all_stats(&self) -> Result<crate::types::MultiAnalyzerStats> {
-        let available_analyzers = self.available_analyzers();
-        let mut all_stats = Vec::new();
+    /// Load stats using incremental caching with deduplication.
+    ///
+    /// Strategy:
+    /// - WARM START: If files haven't changed, load cached snapshot instantly
+    /// - INCREMENTAL: Load cached messages for unchanged files, parse only changed files,
+    ///   then deduplicate and rebuild stats
+    ///
+    /// This gives both speed AND accuracy:
+    /// - Unchanged files: load pre-parsed messages from per-file cache (fast)
+    /// - Changed files: parse only those files (minimal work)
+    /// - Always: run deduplication on combined messages (accurate)
+    pub async fn load_stats_with_cache(
+        &self,
+        analyzer: &dyn Analyzer,
+    ) -> Result<AgenticCodingToolStats> {
+        use crate::analyzers::deduplicate_messages;
+        use crate::cache::{compute_sources_fingerprint, load_snapshot_hot_only, save_snapshot};
+        use rayon::prelude::*;
 
-        for analyzer in available_analyzers {
-            match analyzer.get_stats().await {
+        // If analyzer doesn't support caching, fall back to the regular method
+        if !analyzer.supports_caching() {
+            return analyzer.get_stats().await;
+        }
+
+        let analyzer_name = analyzer.display_name();
+        let sources = self.get_cached_data_sources(analyzer)?;
+
+        // Compute fingerprint of all source files
+        let fingerprint = compute_sources_fingerprint(&sources);
+
+        // Try to load cached snapshot (WARM START) - hot only for speed
+        if let Some(stats) = load_snapshot_hot_only(analyzer_name, fingerprint) {
+            return Ok(stats);
+        }
+
+        // INCREMENTAL COLD START: Load cached messages + parse only changed files
+        let mut all_messages = Vec::new();
+        let mut files_to_parse: Vec<(DataSource, Option<FileCacheEntry>)> = Vec::new();
+        let supports_delta = analyzer.supports_delta_parsing();
+
+        // Check each file against per-file cache (in parallel for speed)
+        let cache_results: Vec<_> = sources
+            .par_iter()
+            .map(|source| {
+                let cache_key = FileCacheKey::new(analyzer_name, &source.path);
+
+                // Get cached entry (if any)
+                let cached_entry = self.file_stats_cache.get_unchecked(&cache_key);
+
+                if let Ok(current_meta) = crate::types::FileMetadata::from_path(&source.path)
+                    && let Some(ref cached) = cached_entry
+                {
+                    // Check if file is unchanged
+                    if cached.metadata.is_unchanged(&current_meta) {
+                        // Exact match - use cached messages directly
+                        if let Ok(messages) = self.file_stats_cache.load_messages(&cache_key) {
+                            return (Some(messages), None);
+                        }
+                    }
+
+                    // For delta-capable analyzers, check if we can do incremental parsing
+                    if supports_delta {
+                        if cached.metadata.is_append_only(&current_meta) {
+                            // Append detected - pass cached entry for delta parsing
+                            return (None, Some((source.clone(), cached_entry)));
+                        }
+                        // Truncation or other change - full reparse
+                        return (None, Some((source.clone(), None)));
+                    }
+                }
+                // Cache miss or non-delta analyzer - need to parse this file
+                (None, Some((source.clone(), cached_entry)))
+            })
+            .collect();
+
+        // Collect results
+        for (cached_msgs, to_parse) in cache_results {
+            if let Some(msgs) = cached_msgs {
+                all_messages.extend(msgs);
+            }
+            if let Some((source, cached)) = to_parse {
+                files_to_parse.push((source, cached));
+            }
+        }
+
+        // Parse only the changed files in parallel
+        if !files_to_parse.is_empty() {
+            let new_entries: Vec<_> = files_to_parse
+                .par_iter()
+                .filter_map(|(source, cached)| {
+                    // Use incremental parsing if analyzer supports it
+                    let entry = if supports_delta {
+                        analyzer
+                            .parse_single_file_incremental(source, cached.as_ref())
+                            .ok()
+                    } else {
+                        analyzer.parse_single_file(source).ok()
+                    };
+                    entry.map(|e| (source.path.clone(), e))
+                })
+                .collect();
+
+            // Add messages from newly parsed files and update per-file cache
+            for (path, entry) in new_entries {
+                all_messages.extend(entry.messages.clone());
+                let cache_key = FileCacheKey::new(analyzer_name, &path);
+                self.file_stats_cache.insert(cache_key, entry);
+            }
+
+            // Persist per-file cache to disk
+            let _ = self.file_stats_cache.save_to_disk();
+        }
+
+        // Deduplicate all messages
+        let deduped_messages = deduplicate_messages(all_messages);
+
+        // Build stats from deduplicated messages
+        let mut daily_stats = crate::utils::aggregate_by_date(&deduped_messages);
+        daily_stats.retain(|date, _| date != "unknown");
+
+        let num_conversations = daily_stats
+            .values()
+            .map(|stats| stats.conversations as u64)
+            .sum();
+
+        let stats = AgenticCodingToolStats {
+            daily_stats,
+            num_conversations,
+            messages: deduped_messages,
+            analyzer_name: analyzer_name.to_string(),
+        };
+
+        // Save snapshot for next time
+        if let Err(e) = save_snapshot(analyzer_name, fingerprint, &stats) {
+            eprintln!("Warning: Failed to save snapshot cache: {e}");
+        }
+
+        Ok(stats)
+    }
+
+    // Keep the old per-file cache method for reference (unused but may be useful later)
+    #[allow(dead_code)]
+    async fn load_stats_with_perfile_cache(
+        &self,
+        analyzer: &dyn Analyzer,
+    ) -> Result<AgenticCodingToolStats> {
+        use crate::types::DailyStats;
+        use std::collections::BTreeMap;
+
+        if !analyzer.supports_caching() {
+            return analyzer.get_stats().await;
+        }
+
+        let sources = self.get_cached_data_sources(analyzer)?;
+        let source_paths: Vec<_> = sources.iter().map(|s| s.path.clone()).collect();
+
+        self.file_stats_cache
+            .prune_deleted_files(analyzer.display_name(), &source_paths);
+
+        let analyzer_name = analyzer.display_name();
+        let mut aggregated_daily: BTreeMap<String, DailyStats> = BTreeMap::new();
+        let mut all_messages = Vec::new();
+        let mut needs_parsing = Vec::new();
+
+        for source in &sources {
+            let cache_key = FileCacheKey::new(analyzer_name, &source.path);
+
+            if let Ok(current_meta) = crate::types::FileMetadata::from_path(&source.path)
+                && !self.file_stats_cache.is_stale(&cache_key, &current_meta)
+            {
+                if let Some(contributions) =
+                    self.file_stats_cache.get_daily_contributions(&cache_key)
+                {
+                    for (date, stats) in contributions {
+                        merge_daily_stats(&mut aggregated_daily, &date, &stats);
+                    }
+                }
+                continue;
+            }
+
+            needs_parsing.push(source.clone());
+        }
+
+        if !needs_parsing.is_empty() {
+            let new_entries: Vec<_> = needs_parsing
+                .par_iter()
+                .filter_map(|source| {
+                    analyzer
+                        .parse_single_file(source)
+                        .ok()
+                        .map(|entry| (source.path.clone(), entry))
+                })
+                .collect();
+
+            for (path, entry) in new_entries {
+                for (date, stats) in &entry.daily_contributions {
+                    merge_daily_stats(&mut aggregated_daily, date, stats);
+                }
+                all_messages.extend(entry.messages.clone());
+                let cache_key = FileCacheKey::new(analyzer_name, &path);
+                self.file_stats_cache.insert(cache_key, entry);
+            }
+        }
+
+        aggregated_daily.retain(|date, _| date != "unknown");
+
+        let num_conversations = aggregated_daily
+            .values()
+            .map(|stats| stats.conversations as u64)
+            .sum();
+
+        Ok(AgenticCodingToolStats {
+            daily_stats: aggregated_daily,
+            num_conversations,
+            messages: all_messages,
+            analyzer_name: analyzer_name.to_string(),
+        })
+    }
+
+    /// Load stats from all available analyzers, using cache where supported
+    /// Loads all analyzers in PARALLEL for faster startup
+    pub async fn load_all_stats(&self) -> Result<crate::types::MultiAnalyzerStats> {
+        use futures::future::join_all;
+
+        let available_analyzers = self.available_analyzers();
+
+        // Create futures for all analyzers - they'll run concurrently
+        let futures: Vec<_> = available_analyzers
+            .into_iter()
+            .map(|analyzer| async move {
+                let name = analyzer.display_name().to_string();
+                let result = if analyzer.supports_caching() {
+                    self.load_stats_with_cache(analyzer).await
+                } else {
+                    analyzer.get_stats().await
+                };
+                (name, result)
+            })
+            .collect();
+
+        // Run all analyzers in parallel
+        let results = join_all(futures).await;
+
+        let mut all_stats = Vec::new();
+        for (name, result) in results {
+            match result {
                 Ok(stats) => all_stats.push(stats),
                 Err(e) => {
-                    eprintln!(
-                        "⚠️  Error analyzing {} data: {}",
-                        analyzer.display_name(),
-                        e
-                    );
+                    eprintln!("⚠️  Error analyzing {} data: {}", name, e);
                 }
             }
         }
@@ -95,11 +621,13 @@ impl AnalyzerRegistry {
     }
 
     /// Get a mapping of data directories to analyzer names for file watching
+    /// Uses cached data sources to avoid redundant glob scans
     pub fn get_directory_to_analyzer_mapping(&self) -> std::collections::HashMap<PathBuf, String> {
         let mut dir_to_analyzer = std::collections::HashMap::new();
 
         for analyzer in self.available_analyzers() {
-            if let Ok(sources) = analyzer.discover_data_sources() {
+            // Use cached sources instead of calling discover_data_sources() again
+            if let Ok(sources) = self.get_cached_data_sources(analyzer) {
                 for source in sources {
                     if let Some(parent) = source.path.parent()
                         && parent.exists()
@@ -204,14 +732,17 @@ mod tests {
     async fn registry_filters_available_analyzers_and_loads_stats() {
         let mut registry = AnalyzerRegistry::new();
 
+        // Analyzers with non-empty sources are considered "available"
+        // (availability is determined by having data sources, not by is_available())
         let analyzer_ok = TestAnalyzer {
             name: "ok",
             available: true,
             stats: Some(sample_stats("ok")),
-            sources: Vec::new(),
+            sources: vec![PathBuf::from("/fake/path.jsonl")],
             fail_stats: false,
         };
 
+        // Analyzer with empty sources is "unavailable"
         let analyzer_unavailable = TestAnalyzer {
             name: "unavailable",
             available: false,
@@ -224,7 +755,7 @@ mod tests {
             name: "fails",
             available: true,
             stats: None,
-            sources: Vec::new(),
+            sources: vec![PathBuf::from("/fake/path2.jsonl")],
             fail_stats: true,
         };
 
@@ -233,7 +764,7 @@ mod tests {
         registry.register(analyzer_fails);
 
         let avail = registry.available_analyzers();
-        assert_eq!(avail.len(), 2); // "ok" and "fails"
+        assert_eq!(avail.len(), 2); // "ok" and "fails" (have non-empty sources)
 
         let by_name = registry
             .get_analyzer_by_display_name("ok")
@@ -269,5 +800,111 @@ mod tests {
         let mapping = registry.get_directory_to_analyzer_mapping();
         // Parent directory of the source should be mapped to "mapper".
         assert_eq!(mapping.get(&base).map(String::as_str), Some("mapper"));
+    }
+
+    // =========================================================================
+    // MERGE_DAILY_STATS TESTS
+    // =========================================================================
+
+    fn make_test_daily_stats(
+        date: &str,
+        ai_msgs: u32,
+        input_tokens: u64,
+    ) -> crate::types::DailyStats {
+        let mut models = BTreeMap::new();
+        models.insert("model-a".to_string(), 2);
+
+        crate::types::DailyStats {
+            date: date.to_string(),
+            user_messages: 5,
+            ai_messages: ai_msgs,
+            conversations: 1,
+            models,
+            stats: Stats {
+                input_tokens,
+                output_tokens: 50,
+                cost: 0.01,
+                tool_calls: 3,
+                ..Stats::default()
+            },
+        }
+    }
+
+    #[test]
+    fn test_merge_daily_stats_into_empty() {
+        let mut dst: BTreeMap<String, crate::types::DailyStats> = BTreeMap::new();
+        let src = make_test_daily_stats("2025-01-15", 10, 100);
+
+        merge_daily_stats(&mut dst, "2025-01-15", &src);
+
+        assert_eq!(dst.len(), 1);
+        let merged = dst.get("2025-01-15").expect("should have entry");
+        assert_eq!(merged.ai_messages, 10);
+        assert_eq!(merged.stats.input_tokens, 100);
+    }
+
+    #[test]
+    fn test_merge_daily_stats_combines_correctly() {
+        let mut dst: BTreeMap<String, crate::types::DailyStats> = BTreeMap::new();
+
+        // Insert first entry
+        let src1 = make_test_daily_stats("2025-01-15", 10, 100);
+        merge_daily_stats(&mut dst, "2025-01-15", &src1);
+
+        // Merge second entry with same date
+        let mut src2 = make_test_daily_stats("2025-01-15", 5, 200);
+        src2.models.insert("model-b".to_string(), 3);
+        merge_daily_stats(&mut dst, "2025-01-15", &src2);
+
+        assert_eq!(dst.len(), 1);
+        let merged = dst.get("2025-01-15").expect("should have entry");
+
+        // Values should be summed
+        assert_eq!(merged.ai_messages, 15); // 10 + 5
+        assert_eq!(merged.user_messages, 10); // 5 + 5
+        assert_eq!(merged.conversations, 2); // 1 + 1
+        assert_eq!(merged.stats.input_tokens, 300); // 100 + 200
+        assert_eq!(merged.stats.output_tokens, 100); // 50 + 50
+        assert_eq!(merged.stats.tool_calls, 6); // 3 + 3
+
+        // Models should be merged
+        assert_eq!(merged.models.get("model-a"), Some(&4)); // 2 + 2
+        assert_eq!(merged.models.get("model-b"), Some(&3)); // only in src2
+    }
+
+    // =========================================================================
+    // DISCOVER_VSCODE_EXTENSION_SOURCES TESTS
+    // =========================================================================
+
+    #[test]
+    fn test_discover_vscode_extension_sources_no_panic() {
+        // Should handle non-existent extension gracefully
+        let result = discover_vscode_extension_sources(
+            "nonexistent.extension.id",
+            "ui_messages.json",
+            false,
+        );
+
+        // Should return Ok with empty vec, not panic
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_discover_vscode_extension_sources_return_parent_option() {
+        // Both options should work without panic
+        let result1 = discover_vscode_extension_sources(
+            "nonexistent.ext",
+            "file.json",
+            false, // return file path
+        );
+        let result2 = discover_vscode_extension_sources(
+            "nonexistent.ext",
+            "file.json",
+            true, // return parent dir
+        );
+
+        assert!(result1.is_ok());
+        assert!(result2.is_ok());
     }
 }

--- a/src/analyzers/cline.rs
+++ b/src/analyzers/cline.rs
@@ -1,15 +1,18 @@
-use crate::analyzer::{Analyzer, DataSource};
-use crate::types::{AgenticCodingToolStats, Application, ConversationMessage, MessageRole, Stats};
+use crate::analyzer::{Analyzer, DataSource, discover_vscode_extension_sources};
+use crate::cache::FileCacheEntry;
+use crate::types::{
+    AgenticCodingToolStats, Application, ConversationMessage, FileMetadata, MessageRole, Stats,
+};
 use crate::utils::hash_text;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use glob::glob;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
-use std::collections::HashSet;
 use std::path::Path;
+
+const CLINE_EXTENSION_ID: &str = "saoudrizwan.claude-dev";
 
 pub struct ClineAnalyzer;
 
@@ -274,7 +277,7 @@ impl Analyzer for ClineAnalyzer {
         // VSCode forks that might have Cline installed: Code, Cursor, Windsurf, VSCodium, Positron
         let vscode_forks = ["Code", "Cursor", "Windsurf", "VSCodium", "Positron"];
 
-        if let Some(home_dir) = std::env::home_dir() {
+        if let Some(home_dir) = dirs::home_dir() {
             let home_str = home_dir.to_string_lossy();
 
             // Linux paths for all VSCode forks
@@ -299,26 +302,7 @@ impl Analyzer for ClineAnalyzer {
     }
 
     fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
-        let patterns = self.get_data_glob_patterns();
-        let mut sources = Vec::new();
-
-        for pattern in patterns {
-            for path in glob(&pattern)
-                .unwrap_or_else(|_| glob("").unwrap())
-                .flatten()
-            {
-                if path.is_file() {
-                    // Store the parent directory (task directory) as the source
-                    if let Some(parent) = path.parent() {
-                        sources.push(DataSource {
-                            path: parent.to_path_buf(),
-                        });
-                    }
-                }
-            }
-        }
-
-        Ok(sources)
+        discover_vscode_extension_sources(CLINE_EXTENSION_ID, "ui_messages.json", true)
     }
 
     async fn parse_conversations(
@@ -340,14 +324,10 @@ impl Analyzer for ClineAnalyzer {
             })
             .collect();
 
-        // Deduplicate by global hash
-        let mut seen_hashes = HashSet::new();
-        let deduplicated: Vec<ConversationMessage> = all_entries
-            .into_iter()
-            .filter(|msg| seen_hashes.insert(msg.global_hash.clone()))
-            .collect();
-
-        Ok(deduplicated)
+        // Parallel deduplicate by global hash
+        Ok(crate::utils::deduplicate_by_global_hash_parallel(
+            all_entries,
+        ))
     }
 
     async fn get_stats(&self) -> Result<AgenticCodingToolStats> {
@@ -374,6 +354,25 @@ impl Analyzer for ClineAnalyzer {
     fn is_available(&self) -> bool {
         self.discover_data_sources()
             .is_ok_and(|sources| !sources.is_empty())
+    }
+
+    fn supports_caching(&self) -> bool {
+        true
+    }
+
+    fn parse_single_file(&self, source: &DataSource) -> Result<FileCacheEntry> {
+        // Cline sources are directories - use directory metadata for caching
+        // Note: Directory mtime may not update on all systems when files inside change
+        let metadata = FileMetadata::from_path(&source.path)?;
+        let messages = parse_cline_task_directory(&source.path)?;
+        let daily_contributions = crate::utils::aggregate_by_date_simple(&messages);
+
+        Ok(FileCacheEntry {
+            metadata,
+            messages,
+            daily_contributions,
+            cached_model: None,
+        })
     }
 }
 

--- a/src/analyzers/kilo_code.rs
+++ b/src/analyzers/kilo_code.rs
@@ -1,15 +1,18 @@
-use crate::analyzer::{Analyzer, DataSource};
-use crate::types::{AgenticCodingToolStats, Application, ConversationMessage, MessageRole, Stats};
+use crate::analyzer::{Analyzer, DataSource, discover_vscode_extension_sources};
+use crate::cache::FileCacheEntry;
+use crate::types::{
+    AgenticCodingToolStats, Application, ConversationMessage, FileMetadata, MessageRole, Stats,
+};
 use crate::utils::hash_text;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use glob::glob;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
-use std::collections::HashSet;
 use std::path::Path;
+
+const KILO_CODE_EXTENSION_ID: &str = "kilocode.kilo-code";
 
 pub struct KiloCodeAnalyzer;
 
@@ -266,7 +269,7 @@ impl Analyzer for KiloCodeAnalyzer {
         ];
         let vscode_cli_forks = ["vscode-server-insiders", "vscode-server"];
 
-        if let Some(home_dir) = std::env::home_dir() {
+        if let Some(home_dir) = dirs::home_dir() {
             let home_str = home_dir.to_string_lossy();
 
             // Linux paths for all VSCode GUI forks
@@ -294,26 +297,7 @@ impl Analyzer for KiloCodeAnalyzer {
     }
 
     fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
-        let patterns = self.get_data_glob_patterns();
-        let mut sources = Vec::new();
-
-        for pattern in patterns {
-            for path in glob(&pattern)
-                .unwrap_or_else(|_| glob("").unwrap())
-                .flatten()
-            {
-                if path.is_file() {
-                    // Store the parent directory (task directory) as the source
-                    if let Some(parent) = path.parent() {
-                        sources.push(DataSource {
-                            path: parent.to_path_buf(),
-                        });
-                    }
-                }
-            }
-        }
-
-        Ok(sources)
+        discover_vscode_extension_sources(KILO_CODE_EXTENSION_ID, "ui_messages.json", true)
     }
 
     async fn parse_conversations(
@@ -337,14 +321,10 @@ impl Analyzer for KiloCodeAnalyzer {
             )
             .collect();
 
-        // Deduplicate by global hash
-        let mut seen_hashes = HashSet::new();
-        let deduplicated: Vec<ConversationMessage> = all_entries
-            .into_iter()
-            .filter(|msg| seen_hashes.insert(msg.global_hash.clone()))
-            .collect();
-
-        Ok(deduplicated)
+        // Parallel deduplicate by global hash
+        Ok(crate::utils::deduplicate_by_global_hash_parallel(
+            all_entries,
+        ))
     }
 
     async fn get_stats(&self) -> Result<AgenticCodingToolStats> {
@@ -371,6 +351,24 @@ impl Analyzer for KiloCodeAnalyzer {
     fn is_available(&self) -> bool {
         self.discover_data_sources()
             .is_ok_and(|sources| !sources.is_empty())
+    }
+
+    fn supports_caching(&self) -> bool {
+        true
+    }
+
+    fn parse_single_file(&self, source: &DataSource) -> Result<FileCacheEntry> {
+        // Kilo Code sources are directories - use directory metadata for caching
+        let metadata = FileMetadata::from_path(&source.path)?;
+        let messages = parse_kilo_code_task_directory(&source.path)?;
+        let daily_contributions = crate::utils::aggregate_by_date_simple(&messages);
+
+        Ok(FileCacheEntry {
+            metadata,
+            messages,
+            daily_contributions,
+            cached_model: None,
+        })
     }
 }
 

--- a/src/analyzers/mod.rs
+++ b/src/analyzers/mod.rs
@@ -8,7 +8,7 @@ pub mod opencode;
 pub mod qwen_code;
 pub mod roo_code;
 
-pub use claude_code::ClaudeCodeAnalyzer;
+pub use claude_code::{ClaudeCodeAnalyzer, deduplicate_messages};
 pub use cline::ClineAnalyzer;
 pub use codex_cli::CodexCliAnalyzer;
 pub use copilot::CopilotAnalyzer;

--- a/src/analyzers/qwen_code.rs
+++ b/src/analyzers/qwen_code.rs
@@ -1,17 +1,18 @@
 use crate::analyzer::{Analyzer, DataSource};
+use crate::cache::FileCacheEntry;
 use crate::models::{calculate_cache_cost, calculate_input_cost, calculate_output_cost};
 use crate::types::{
-    AgenticCodingToolStats, Application, ConversationMessage, FileCategory, MessageRole, Stats,
+    AgenticCodingToolStats, Application, ConversationMessage, FileCategory, FileMetadata,
+    MessageRole, Stats,
 };
 use crate::utils::{deserialize_utc_timestamp, hash_text};
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use glob::glob;
+use jwalk::WalkDir;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
-use std::collections::HashSet;
 use std::path::Path;
 
 pub struct QwenCodeAnalyzer;
@@ -291,7 +292,7 @@ impl Analyzer for QwenCodeAnalyzer {
     fn get_data_glob_patterns(&self) -> Vec<String> {
         let mut patterns = Vec::new();
 
-        if let Some(home_dir) = std::env::home_dir() {
+        if let Some(home_dir) = dirs::home_dir() {
             let home_str = home_dir.to_string_lossy();
             patterns.push(format!("{home_str}/.qwen/tmp/*/chats/*.json"));
         }
@@ -300,14 +301,29 @@ impl Analyzer for QwenCodeAnalyzer {
     }
 
     fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
-        let patterns = self.get_data_glob_patterns();
         let mut sources = Vec::new();
 
-        for pattern in patterns {
-            for entry in glob(&pattern)? {
-                let path = entry?;
-                if path.is_file() {
-                    sources.push(DataSource { path });
+        if let Some(home_dir) = dirs::home_dir() {
+            let tmp_dir = home_dir.join(".qwen").join("tmp");
+
+            if tmp_dir.is_dir() {
+                // Pattern: ~/.qwen/tmp/*/chats/*.json
+                // jwalk walks directories in parallel
+                for entry in WalkDir::new(&tmp_dir)
+                    .min_depth(3) // */chats/*.json
+                    .max_depth(3)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .filter(|e| {
+                        e.file_type().is_file()
+                            && e.path().extension().is_some_and(|ext| ext == "json")
+                            && e.path()
+                                .parent()
+                                .and_then(|p| p.file_name())
+                                .is_some_and(|name| name == "chats")
+                    })
+                {
+                    sources.push(DataSource { path: entry.path() });
                 }
             }
         }
@@ -335,22 +351,10 @@ impl Analyzer for QwenCodeAnalyzer {
             .flat_map(|messages| messages)
             .collect();
 
-        // Deduplicate based on hash
-        let mut seen_hashes = HashSet::new();
-        let deduplicated_entries: Vec<ConversationMessage> = all_entries
-            .into_iter()
-            .filter(|entry| {
-                if let Some(local_hash) = &entry.local_hash {
-                    if seen_hashes.contains(local_hash) {
-                        return false;
-                    }
-                    seen_hashes.insert(local_hash.clone());
-                }
-                true
-            })
-            .collect();
-
-        Ok(deduplicated_entries)
+        // Parallel deduplicate by local hash
+        Ok(crate::utils::deduplicate_by_local_hash_parallel(
+            all_entries,
+        ))
     }
 
     async fn get_stats(&self) -> Result<AgenticCodingToolStats> {
@@ -374,5 +378,22 @@ impl Analyzer for QwenCodeAnalyzer {
     fn is_available(&self) -> bool {
         self.discover_data_sources()
             .is_ok_and(|sources| !sources.is_empty())
+    }
+
+    fn supports_caching(&self) -> bool {
+        true
+    }
+
+    fn parse_single_file(&self, source: &DataSource) -> Result<FileCacheEntry> {
+        let metadata = FileMetadata::from_path(&source.path)?;
+        let messages = parse_json_session_file(&source.path)?;
+        let daily_contributions = crate::utils::aggregate_by_date_simple(&messages);
+
+        Ok(FileCacheEntry {
+            metadata,
+            messages,
+            daily_contributions,
+            cached_model: None,
+        })
     }
 }

--- a/src/analyzers/tests/cline.rs
+++ b/src/analyzers/tests/cline.rs
@@ -1,0 +1,32 @@
+use crate::analyzer::Analyzer;
+use crate::analyzers::cline::ClineAnalyzer;
+
+#[test]
+fn test_cline_analyzer_creation() {
+    let analyzer = ClineAnalyzer::new();
+    assert_eq!(analyzer.display_name(), "Cline");
+}
+
+#[test]
+fn test_cline_is_available() {
+    let analyzer = ClineAnalyzer::new();
+    // is_available depends on whether Cline extension data exists
+    // Just verify it doesn't panic
+    let _ = analyzer.is_available();
+}
+
+#[test]
+fn test_cline_discover_data_sources_no_panic() {
+    let analyzer = ClineAnalyzer::new();
+    // Should return Ok even if no data exists
+    let result = analyzer.discover_data_sources();
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_cline_parse_empty_sources() {
+    let analyzer = ClineAnalyzer::new();
+    let result = analyzer.parse_conversations(vec![]).await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}

--- a/src/analyzers/tests/kilo_code.rs
+++ b/src/analyzers/tests/kilo_code.rs
@@ -1,0 +1,32 @@
+use crate::analyzer::Analyzer;
+use crate::analyzers::kilo_code::KiloCodeAnalyzer;
+
+#[test]
+fn test_kilo_code_analyzer_creation() {
+    let analyzer = KiloCodeAnalyzer::new();
+    assert_eq!(analyzer.display_name(), "Kilo Code");
+}
+
+#[test]
+fn test_kilo_code_is_available() {
+    let analyzer = KiloCodeAnalyzer::new();
+    // is_available depends on whether Kilo Code extension data exists
+    // Just verify it doesn't panic
+    let _ = analyzer.is_available();
+}
+
+#[test]
+fn test_kilo_code_discover_data_sources_no_panic() {
+    let analyzer = KiloCodeAnalyzer::new();
+    // Should return Ok even if no data exists
+    let result = analyzer.discover_data_sources();
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_kilo_code_parse_empty_sources() {
+    let analyzer = KiloCodeAnalyzer::new();
+    let result = analyzer.parse_conversations(vec![]).await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}

--- a/src/analyzers/tests/mod.rs
+++ b/src/analyzers/tests/mod.rs
@@ -1,4 +1,9 @@
 mod claude_code;
+mod cline;
 mod codex_cli;
 mod copilot;
 mod gemini_cli;
+mod kilo_code;
+mod opencode;
+mod qwen_code;
+mod roo_code;

--- a/src/analyzers/tests/opencode.rs
+++ b/src/analyzers/tests/opencode.rs
@@ -1,0 +1,32 @@
+use crate::analyzer::Analyzer;
+use crate::analyzers::opencode::OpenCodeAnalyzer;
+
+#[test]
+fn test_opencode_analyzer_creation() {
+    let analyzer = OpenCodeAnalyzer::new();
+    assert_eq!(analyzer.display_name(), "OpenCode");
+}
+
+#[test]
+fn test_opencode_is_available() {
+    let analyzer = OpenCodeAnalyzer::new();
+    // is_available depends on whether OpenCode data exists
+    // Just verify it doesn't panic
+    let _ = analyzer.is_available();
+}
+
+#[test]
+fn test_opencode_discover_data_sources_no_panic() {
+    let analyzer = OpenCodeAnalyzer::new();
+    // Should return Ok even if no data exists
+    let result = analyzer.discover_data_sources();
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_opencode_parse_empty_sources() {
+    let analyzer = OpenCodeAnalyzer::new();
+    let result = analyzer.parse_conversations(vec![]).await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}

--- a/src/analyzers/tests/qwen_code.rs
+++ b/src/analyzers/tests/qwen_code.rs
@@ -1,0 +1,32 @@
+use crate::analyzer::Analyzer;
+use crate::analyzers::qwen_code::QwenCodeAnalyzer;
+
+#[test]
+fn test_qwen_code_analyzer_creation() {
+    let analyzer = QwenCodeAnalyzer::new();
+    assert_eq!(analyzer.display_name(), "Qwen Code");
+}
+
+#[test]
+fn test_qwen_code_is_available() {
+    let analyzer = QwenCodeAnalyzer::new();
+    // is_available depends on whether Qwen Code extension data exists
+    // Just verify it doesn't panic
+    let _ = analyzer.is_available();
+}
+
+#[test]
+fn test_qwen_code_discover_data_sources_no_panic() {
+    let analyzer = QwenCodeAnalyzer::new();
+    // Should return Ok even if no data exists
+    let result = analyzer.discover_data_sources();
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_qwen_code_parse_empty_sources() {
+    let analyzer = QwenCodeAnalyzer::new();
+    let result = analyzer.parse_conversations(vec![]).await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}

--- a/src/analyzers/tests/roo_code.rs
+++ b/src/analyzers/tests/roo_code.rs
@@ -1,0 +1,32 @@
+use crate::analyzer::Analyzer;
+use crate::analyzers::roo_code::RooCodeAnalyzer;
+
+#[test]
+fn test_roo_code_analyzer_creation() {
+    let analyzer = RooCodeAnalyzer::new();
+    assert_eq!(analyzer.display_name(), "Roo Code");
+}
+
+#[test]
+fn test_roo_code_is_available() {
+    let analyzer = RooCodeAnalyzer::new();
+    // is_available depends on whether Roo Code extension data exists
+    // Just verify it doesn't panic
+    let _ = analyzer.is_available();
+}
+
+#[test]
+fn test_roo_code_discover_data_sources_no_panic() {
+    let analyzer = RooCodeAnalyzer::new();
+    // Should return Ok even if no data exists
+    let result = analyzer.discover_data_sources();
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_roo_code_parse_empty_sources() {
+    let analyzer = RooCodeAnalyzer::new();
+    let result = analyzer.parse_conversations(vec![]).await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty());
+}

--- a/src/cache/mmap_repository.rs
+++ b/src/cache/mmap_repository.rs
@@ -1,0 +1,960 @@
+//! High-performance memory-mapped cache repository using rkyv.
+//!
+//! This module provides a high-performance cache implementation that:
+//! - Uses rkyv for fast serialization/deserialization (10-100x faster than JSON)
+//! - Stores messages separately for lazy loading (cold data)
+//! - Memory-maps message files for efficient access
+
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use parking_lot::RwLock;
+use rkyv::rancor::BoxedError;
+use rkyv::{Archive, Deserialize, Serialize};
+
+use crate::types::{
+    Application, ConversationMessage, DailyStats, FileMetadata, MessageRole, Stats,
+};
+
+use super::{CacheStats, FileCacheEntry, FileCacheKey};
+
+// =============================================================================
+// Archived Types (for rkyv zero-copy)
+// =============================================================================
+
+/// Cache index - the "hot" data kept in memory-mapped file
+#[derive(Archive, Serialize, Deserialize, Debug)]
+#[rkyv(derive(Debug))]
+pub struct CacheIndex {
+    pub version: u32,
+    pub entries: Vec<CacheMetaEntry>,
+}
+
+/// Metadata + pre-aggregated stats for a single file
+#[derive(Archive, Serialize, Deserialize, Debug, Clone)]
+#[rkyv(derive(Debug))]
+pub struct CacheMetaEntry {
+    pub analyzer_name: String,
+    pub file_path: String,
+    pub file_size: u64,
+    pub file_modified: i64,
+    /// Byte offset of last successfully parsed position (for delta parsing)
+    pub last_parsed_offset: u64,
+    /// Pre-aggregated daily contributions from this file
+    pub daily_contributions: Vec<(String, CacheDailyStats)>,
+    /// Number of messages (for stats display)
+    pub message_count: u32,
+    /// Cached session model name (for delta parsing context)
+    pub cached_model: Option<String>,
+}
+
+/// Archived version of DailyStats (uses primitive types only)
+#[derive(Archive, Serialize, Deserialize, Debug, Clone, Default)]
+#[rkyv(derive(Debug))]
+pub struct CacheDailyStats {
+    pub date: String,
+    pub user_messages: u32,
+    pub ai_messages: u32,
+    pub conversations: u32,
+    pub models: Vec<(String, u32)>, // BTreeMap as Vec for rkyv
+    pub stats: CacheStats_,
+}
+
+/// Archived version of Stats (all primitive types)
+#[derive(Archive, Serialize, Deserialize, Debug, Clone, Default)]
+#[rkyv(derive(Debug))]
+pub struct CacheStats_ {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub reasoning_tokens: u64,
+    pub cache_creation_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cached_tokens: u64,
+    pub cost_millicents: i64, // Store as integer to avoid float issues
+    pub tool_calls: u32,
+    pub terminal_commands: u64,
+    pub file_searches: u64,
+    pub file_content_searches: u64,
+    pub files_read: u64,
+    pub files_added: u64,
+    pub files_edited: u64,
+    pub files_deleted: u64,
+    pub lines_read: u64,
+    pub lines_added: u64,
+    pub lines_edited: u64,
+    pub lines_deleted: u64,
+    pub bytes_read: u64,
+    pub bytes_added: u64,
+    pub bytes_edited: u64,
+    pub bytes_deleted: u64,
+    pub todos_created: u64,
+    pub todos_completed: u64,
+    pub todos_in_progress: u64,
+    pub todo_writes: u64,
+    pub todo_reads: u64,
+    pub code_lines: u64,
+    pub docs_lines: u64,
+    pub data_lines: u64,
+    pub media_lines: u64,
+    pub config_lines: u64,
+    pub other_lines: u64,
+}
+
+/// Archived message for cold storage
+#[derive(Archive, Serialize, Deserialize, Debug, Clone)]
+#[rkyv(derive(Debug))]
+pub struct CacheMessage {
+    pub application: u8, // Application enum as u8
+    pub date_timestamp: i64,
+    pub project_hash: String,
+    pub conversation_hash: String,
+    pub local_hash: Option<String>,
+    pub global_hash: String,
+    pub model: Option<String>,
+    pub stats: CacheStats_,
+    pub role: u8, // MessageRole enum as u8
+    pub uuid: Option<String>,
+    pub session_name: Option<String>,
+}
+
+/// Container for messages (cold data file)
+#[derive(Archive, Serialize, Deserialize, Debug)]
+#[rkyv(derive(Debug))]
+pub struct CacheMessages {
+    pub messages: Vec<CacheMessage>,
+}
+
+// =============================================================================
+// Conversion Functions
+// =============================================================================
+
+impl From<&Stats> for CacheStats_ {
+    fn from(s: &Stats) -> Self {
+        Self {
+            input_tokens: s.input_tokens,
+            output_tokens: s.output_tokens,
+            reasoning_tokens: s.reasoning_tokens,
+            cache_creation_tokens: s.cache_creation_tokens,
+            cache_read_tokens: s.cache_read_tokens,
+            cached_tokens: s.cached_tokens,
+            // Store cost as integer with 0.00001 precision (micro-cents, not millicents)
+            // This gives us 5 decimal places of precision for dollar amounts
+            cost_millicents: (s.cost * 100_000.0) as i64,
+            tool_calls: s.tool_calls,
+            terminal_commands: s.terminal_commands,
+            file_searches: s.file_searches,
+            file_content_searches: s.file_content_searches,
+            files_read: s.files_read,
+            files_added: s.files_added,
+            files_edited: s.files_edited,
+            files_deleted: s.files_deleted,
+            lines_read: s.lines_read,
+            lines_added: s.lines_added,
+            lines_edited: s.lines_edited,
+            lines_deleted: s.lines_deleted,
+            bytes_read: s.bytes_read,
+            bytes_added: s.bytes_added,
+            bytes_edited: s.bytes_edited,
+            bytes_deleted: s.bytes_deleted,
+            todos_created: s.todos_created,
+            todos_completed: s.todos_completed,
+            todos_in_progress: s.todos_in_progress,
+            todo_writes: s.todo_writes,
+            todo_reads: s.todo_reads,
+            code_lines: s.code_lines,
+            docs_lines: s.docs_lines,
+            data_lines: s.data_lines,
+            media_lines: s.media_lines,
+            config_lines: s.config_lines,
+            other_lines: s.other_lines,
+        }
+    }
+}
+
+impl From<&CacheStats_> for Stats {
+    fn from(s: &CacheStats_) -> Self {
+        Self {
+            input_tokens: s.input_tokens,
+            output_tokens: s.output_tokens,
+            reasoning_tokens: s.reasoning_tokens,
+            cache_creation_tokens: s.cache_creation_tokens,
+            cache_read_tokens: s.cache_read_tokens,
+            cached_tokens: s.cached_tokens,
+            cost: s.cost_millicents as f64 / 100_000.0,
+            tool_calls: s.tool_calls,
+            terminal_commands: s.terminal_commands,
+            file_searches: s.file_searches,
+            file_content_searches: s.file_content_searches,
+            files_read: s.files_read,
+            files_added: s.files_added,
+            files_edited: s.files_edited,
+            files_deleted: s.files_deleted,
+            lines_read: s.lines_read,
+            lines_added: s.lines_added,
+            lines_edited: s.lines_edited,
+            lines_deleted: s.lines_deleted,
+            bytes_read: s.bytes_read,
+            bytes_added: s.bytes_added,
+            bytes_edited: s.bytes_edited,
+            bytes_deleted: s.bytes_deleted,
+            todos_created: s.todos_created,
+            todos_completed: s.todos_completed,
+            todos_in_progress: s.todos_in_progress,
+            todo_writes: s.todo_writes,
+            todo_reads: s.todo_reads,
+            code_lines: s.code_lines,
+            docs_lines: s.docs_lines,
+            data_lines: s.data_lines,
+            media_lines: s.media_lines,
+            config_lines: s.config_lines,
+            other_lines: s.other_lines,
+        }
+    }
+}
+
+impl From<&ArchivedCacheStats_> for Stats {
+    fn from(s: &ArchivedCacheStats_) -> Self {
+        Self {
+            input_tokens: s.input_tokens.into(),
+            output_tokens: s.output_tokens.into(),
+            reasoning_tokens: s.reasoning_tokens.into(),
+            cache_creation_tokens: s.cache_creation_tokens.into(),
+            cache_read_tokens: s.cache_read_tokens.into(),
+            cached_tokens: s.cached_tokens.into(),
+            cost: i64::from(s.cost_millicents) as f64 / 100_000.0,
+            tool_calls: s.tool_calls.into(),
+            terminal_commands: s.terminal_commands.into(),
+            file_searches: s.file_searches.into(),
+            file_content_searches: s.file_content_searches.into(),
+            files_read: s.files_read.into(),
+            files_added: s.files_added.into(),
+            files_edited: s.files_edited.into(),
+            files_deleted: s.files_deleted.into(),
+            lines_read: s.lines_read.into(),
+            lines_added: s.lines_added.into(),
+            lines_edited: s.lines_edited.into(),
+            lines_deleted: s.lines_deleted.into(),
+            bytes_read: s.bytes_read.into(),
+            bytes_added: s.bytes_added.into(),
+            bytes_edited: s.bytes_edited.into(),
+            bytes_deleted: s.bytes_deleted.into(),
+            todos_created: s.todos_created.into(),
+            todos_completed: s.todos_completed.into(),
+            todos_in_progress: s.todos_in_progress.into(),
+            todo_writes: s.todo_writes.into(),
+            todo_reads: s.todo_reads.into(),
+            code_lines: s.code_lines.into(),
+            docs_lines: s.docs_lines.into(),
+            data_lines: s.data_lines.into(),
+            media_lines: s.media_lines.into(),
+            config_lines: s.config_lines.into(),
+            other_lines: s.other_lines.into(),
+        }
+    }
+}
+
+/// Convert Application enum to u8 for serialization
+pub(crate) fn application_to_u8(app: &Application) -> u8 {
+    match app {
+        Application::ClaudeCode => 0,
+        Application::GeminiCli => 1,
+        Application::QwenCode => 2,
+        Application::CodexCli => 3,
+        Application::Cline => 4,
+        Application::RooCode => 5,
+        Application::KiloCode => 6,
+        Application::Copilot => 7,
+        Application::OpenCode => 8,
+    }
+}
+
+/// Convert u8 back to Application enum, with ClaudeCode as fallback
+pub(crate) fn u8_to_application(v: u8) -> Application {
+    match v {
+        0 => Application::ClaudeCode,
+        1 => Application::GeminiCli,
+        2 => Application::QwenCode,
+        3 => Application::CodexCli,
+        4 => Application::Cline,
+        5 => Application::RooCode,
+        6 => Application::KiloCode,
+        7 => Application::Copilot,
+        8 => Application::OpenCode,
+        _ => Application::ClaudeCode, // Fallback for unknown values
+    }
+}
+
+/// Convert MessageRole enum to u8 for serialization
+pub(crate) fn role_to_u8(role: &MessageRole) -> u8 {
+    match role {
+        MessageRole::User => 0,
+        MessageRole::Assistant => 1,
+    }
+}
+
+/// Convert u8 back to MessageRole enum, with Assistant as fallback
+pub(crate) fn u8_to_role(v: u8) -> MessageRole {
+    match v {
+        0 => MessageRole::User,
+        _ => MessageRole::Assistant,
+    }
+}
+
+impl From<&DailyStats> for CacheDailyStats {
+    fn from(d: &DailyStats) -> Self {
+        Self {
+            date: d.date.clone(),
+            user_messages: d.user_messages,
+            ai_messages: d.ai_messages,
+            conversations: d.conversations,
+            models: d.models.iter().map(|(k, v)| (k.clone(), *v)).collect(),
+            stats: CacheStats_::from(&d.stats),
+        }
+    }
+}
+
+impl From<&CacheDailyStats> for DailyStats {
+    fn from(d: &CacheDailyStats) -> Self {
+        Self {
+            date: d.date.clone(),
+            user_messages: d.user_messages,
+            ai_messages: d.ai_messages,
+            conversations: d.conversations,
+            models: d.models.iter().cloned().collect(),
+            stats: Stats::from(&d.stats),
+        }
+    }
+}
+
+impl From<&ArchivedCacheDailyStats> for DailyStats {
+    fn from(d: &ArchivedCacheDailyStats) -> Self {
+        Self {
+            date: d.date.to_string(),
+            user_messages: d.user_messages.into(),
+            ai_messages: d.ai_messages.into(),
+            conversations: d.conversations.into(),
+            models: d
+                .models
+                .iter()
+                .map(|entry| (entry.0.to_string(), u32::from(entry.1)))
+                .collect(),
+            stats: Stats::from(&d.stats),
+        }
+    }
+}
+
+impl From<&ConversationMessage> for CacheMessage {
+    fn from(m: &ConversationMessage) -> Self {
+        Self {
+            application: application_to_u8(&m.application),
+            date_timestamp: m.date.timestamp(),
+            project_hash: m.project_hash.clone(),
+            conversation_hash: m.conversation_hash.clone(),
+            local_hash: m.local_hash.clone(),
+            global_hash: m.global_hash.clone(),
+            model: m.model.clone(),
+            stats: CacheStats_::from(&m.stats),
+            role: role_to_u8(&m.role),
+            uuid: m.uuid.clone(),
+            session_name: m.session_name.clone(),
+        }
+    }
+}
+
+impl From<&CacheMessage> for ConversationMessage {
+    fn from(m: &CacheMessage) -> Self {
+        use chrono::TimeZone;
+        Self {
+            application: u8_to_application(m.application),
+            // Use single() to handle invalid timestamps gracefully (falls back to Unix epoch)
+            date: chrono::Utc
+                .timestamp_opt(m.date_timestamp, 0)
+                .single()
+                .unwrap_or_else(|| chrono::Utc.timestamp_opt(0, 0).single().unwrap()),
+            project_hash: m.project_hash.clone(),
+            conversation_hash: m.conversation_hash.clone(),
+            local_hash: m.local_hash.clone(),
+            global_hash: m.global_hash.clone(),
+            model: m.model.clone(),
+            stats: Stats::from(&m.stats),
+            role: u8_to_role(m.role),
+            uuid: m.uuid.clone(),
+            session_name: m.session_name.clone(),
+        }
+    }
+}
+
+impl From<&ArchivedCacheMessage> for ConversationMessage {
+    fn from(m: &ArchivedCacheMessage) -> Self {
+        use chrono::TimeZone;
+        Self {
+            application: u8_to_application(m.application),
+            // Use single() to handle invalid timestamps gracefully (falls back to Unix epoch)
+            date: chrono::Utc
+                .timestamp_opt(i64::from(m.date_timestamp), 0)
+                .single()
+                .unwrap_or_else(|| chrono::Utc.timestamp_opt(0, 0).single().unwrap()),
+            project_hash: m.project_hash.to_string(),
+            conversation_hash: m.conversation_hash.to_string(),
+            local_hash: m.local_hash.as_ref().map(|s| s.to_string()),
+            global_hash: m.global_hash.to_string(),
+            model: m.model.as_ref().map(|s| s.to_string()),
+            stats: Stats::from(&m.stats),
+            role: u8_to_role(m.role),
+            uuid: m.uuid.as_ref().map(|s| s.to_string()),
+            session_name: m.session_name.as_ref().map(|s| s.to_string()),
+        }
+    }
+}
+
+// =============================================================================
+// Repository Implementation
+// =============================================================================
+
+const CACHE_VERSION: u32 = 2;
+
+/// High-performance cache repository using rkyv serialization
+pub struct MmapCacheRepository {
+    /// Deserialized index (hot data) - loaded once at startup
+    index: RwLock<CacheIndex>,
+    /// Fast O(1) lookup index - maps keys to entries
+    index_map: RwLock<HashMap<FileCacheKey, CacheMetaEntry>>,
+    /// In-memory dirty entries awaiting persist
+    dirty_entries: RwLock<HashMap<FileCacheKey, CacheMetaEntry>>,
+    /// In-memory dirty messages awaiting persist
+    dirty_messages: RwLock<HashMap<FileCacheKey, Vec<CacheMessage>>>,
+    /// Entries marked for removal
+    removed_keys: RwLock<Vec<FileCacheKey>>,
+    /// Path to cache directory
+    cache_dir: PathBuf,
+}
+
+impl MmapCacheRepository {
+    /// Create an empty in-memory cache (no persistence)
+    /// Used as fallback when disk cache cannot be opened
+    pub fn empty() -> Self {
+        Self {
+            index: RwLock::new(CacheIndex {
+                version: CACHE_VERSION,
+                entries: Vec::new(),
+            }),
+            index_map: RwLock::new(HashMap::new()),
+            dirty_entries: RwLock::new(HashMap::new()),
+            dirty_messages: RwLock::new(HashMap::new()),
+            removed_keys: RwLock::new(Vec::new()),
+            cache_dir: PathBuf::new(), // Empty path - persist() will be a no-op
+        }
+    }
+
+    /// Open or create the cache repository
+    pub fn open() -> Result<Self> {
+        let cache_dir = Self::cache_dir()?;
+        fs::create_dir_all(&cache_dir)?;
+
+        let index_path = cache_dir.join("cache.meta");
+        let index = if index_path.exists() {
+            // Load and deserialize index (fast - rkyv is 10-100x faster than JSON)
+            let data = fs::read(&index_path)?;
+            match rkyv::from_bytes::<CacheIndex, BoxedError>(&data) {
+                Ok(loaded_index) => {
+                    if loaded_index.version != CACHE_VERSION {
+                        // Version mismatch - clear old cache and start fresh
+                        // This handles migration from v1 (without last_parsed_offset) to v2
+                        eprintln!(
+                            "Cache version {} -> {}: clearing old cache",
+                            loaded_index.version, CACHE_VERSION
+                        );
+                        CacheIndex {
+                            version: CACHE_VERSION,
+                            entries: Vec::new(),
+                        }
+                    } else {
+                        loaded_index
+                    }
+                }
+                Err(_) => {
+                    // Corrupted or incompatible cache - start fresh
+                    CacheIndex {
+                        version: CACHE_VERSION,
+                        entries: Vec::new(),
+                    }
+                }
+            }
+        } else {
+            CacheIndex {
+                version: CACHE_VERSION,
+                entries: Vec::new(),
+            }
+        };
+
+        // Build O(1) lookup HashMap from Vec for fast find_entry
+        let index_map: HashMap<FileCacheKey, CacheMetaEntry> = index
+            .entries
+            .iter()
+            .map(|e| {
+                let key = FileCacheKey {
+                    analyzer_name: e.analyzer_name.clone(),
+                    file_path: PathBuf::from(&e.file_path),
+                };
+                (key, e.clone())
+            })
+            .collect();
+
+        Ok(Self {
+            index: RwLock::new(index),
+            index_map: RwLock::new(index_map),
+            dirty_entries: RwLock::new(HashMap::new()),
+            dirty_messages: RwLock::new(HashMap::new()),
+            removed_keys: RwLock::new(Vec::new()),
+            cache_dir,
+        })
+    }
+
+    fn cache_dir() -> Result<PathBuf> {
+        let home = dirs::home_dir()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+        Ok(home.join(".splitrail"))
+    }
+
+    fn index_path(&self) -> PathBuf {
+        self.cache_dir.join("cache.meta")
+    }
+
+    fn messages_dir(&self) -> PathBuf {
+        self.cache_dir.join("messages")
+    }
+
+    fn message_file_path(&self, key: &FileCacheKey) -> PathBuf {
+        let hash = crate::utils::fast_hash(&format!(
+            "{}:{}",
+            key.analyzer_name,
+            key.file_path.display()
+        ));
+        self.messages_dir().join(format!("{}.msg", hash))
+    }
+
+    /// Find entry in index - O(1) HashMap lookup
+    fn find_entry(&self, key: &FileCacheKey) -> Option<CacheMetaEntry> {
+        self.index_map.read().get(key).cloned()
+    }
+
+    /// Check if a file's cache entry is stale
+    pub fn is_stale(&self, key: &FileCacheKey, current_meta: &FileMetadata) -> bool {
+        // Check dirty entries first
+        if let Some(entry) = self.dirty_entries.read().get(key) {
+            return entry.file_size != current_meta.size
+                || entry.file_modified != current_meta.modified;
+        }
+
+        // Check index
+        if let Some(entry) = self.find_entry(key) {
+            return entry.file_size != current_meta.size
+                || entry.file_modified != current_meta.modified;
+        }
+
+        true // Not in cache = stale
+    }
+
+    /// Get pre-aggregated daily contributions for a file
+    pub fn get_daily_contributions(&self, key: &FileCacheKey) -> Option<Vec<(String, DailyStats)>> {
+        // Check dirty entries first
+        if let Some(entry) = self.dirty_entries.read().get(key) {
+            return Some(
+                entry
+                    .daily_contributions
+                    .iter()
+                    .map(|(date, stats)| (date.clone(), DailyStats::from(stats)))
+                    .collect(),
+            );
+        }
+
+        // Check index_map (O(1) lookup)
+        self.find_entry(key).map(|entry| {
+            entry
+                .daily_contributions
+                .iter()
+                .map(|(date, stats)| (date.clone(), DailyStats::from(stats)))
+                .collect()
+        })
+    }
+
+    /// Lazy load messages from cold storage
+    pub fn load_messages(&self, key: &FileCacheKey) -> Result<Vec<ConversationMessage>> {
+        // Check dirty messages first
+        if let Some(messages) = self.dirty_messages.read().get(key) {
+            return Ok(messages.iter().map(ConversationMessage::from).collect());
+        }
+
+        // Load from disk using rkyv deserialization
+        let msg_path = self.message_file_path(key);
+        if !msg_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let data = fs::read(&msg_path)?;
+        let container: CacheMessages = rkyv::from_bytes::<CacheMessages, BoxedError>(&data)
+            .map_err(|e| anyhow::anyhow!("Failed to deserialize messages: {}", e))?;
+        Ok(container
+            .messages
+            .iter()
+            .map(ConversationMessage::from)
+            .collect())
+    }
+
+    /// Insert or update a cache entry
+    pub fn insert(&self, key: FileCacheKey, entry: FileCacheEntry) {
+        // Convert to cache format
+        let meta_entry = CacheMetaEntry {
+            analyzer_name: key.analyzer_name.clone(),
+            file_path: key.file_path.to_string_lossy().to_string(),
+            file_size: entry.metadata.size,
+            file_modified: entry.metadata.modified,
+            last_parsed_offset: entry.metadata.last_parsed_offset,
+            daily_contributions: entry
+                .daily_contributions
+                .iter()
+                .map(|(date, stats)| (date.clone(), CacheDailyStats::from(stats)))
+                .collect(),
+            message_count: entry.messages.len() as u32,
+            cached_model: entry.cached_model.clone(),
+        };
+
+        let cache_messages: Vec<CacheMessage> =
+            entry.messages.iter().map(CacheMessage::from).collect();
+
+        // Store in dirty maps
+        self.dirty_entries.write().insert(key.clone(), meta_entry);
+        self.dirty_messages.write().insert(key, cache_messages);
+    }
+
+    /// Remove an entry from the cache
+    pub fn remove(&self, key: &FileCacheKey) {
+        self.dirty_entries.write().remove(key);
+        self.dirty_messages.write().remove(key);
+        self.removed_keys.write().push(key.clone());
+    }
+
+    /// Get a cache entry if valid (metadata matches)
+    pub fn get(&self, key: &FileCacheKey, current_path: &Path) -> Option<FileCacheEntry> {
+        let current_meta = FileMetadata::from_path(current_path).ok()?;
+
+        if self.is_stale(key, &current_meta) {
+            return None;
+        }
+
+        // Load full entry
+        let daily_contributions = self.get_daily_contributions(key)?;
+        let messages = self.load_messages(key).ok()?;
+
+        // Get cached last_parsed_offset and cached_model (current_meta has 0 from from_path())
+        let (last_parsed_offset, cached_model) =
+            if let Some(entry) = self.dirty_entries.read().get(key) {
+                (entry.last_parsed_offset, entry.cached_model.clone())
+            } else if let Some(entry) = self.find_entry(key) {
+                (entry.last_parsed_offset, entry.cached_model.clone())
+            } else {
+                (current_meta.size, None) // Fallback: assume fully parsed
+            };
+
+        Some(FileCacheEntry {
+            metadata: FileMetadata {
+                size: current_meta.size,
+                modified: current_meta.modified,
+                last_parsed_offset,
+            },
+            messages,
+            daily_contributions: daily_contributions.into_iter().collect(),
+            cached_model,
+        })
+    }
+
+    /// Get cache entry without validation
+    pub fn get_unchecked(&self, key: &FileCacheKey) -> Option<FileCacheEntry> {
+        let daily_contributions = self.get_daily_contributions(key)?;
+        let messages = self.load_messages(key).ok()?;
+
+        // Get metadata from cache
+        let (size, modified, last_parsed_offset, cached_model) =
+            if let Some(entry) = self.dirty_entries.read().get(key) {
+                (
+                    entry.file_size,
+                    entry.file_modified,
+                    entry.last_parsed_offset,
+                    entry.cached_model.clone(),
+                )
+            } else if let Some(entry) = self.find_entry(key) {
+                (
+                    entry.file_size,
+                    entry.file_modified,
+                    entry.last_parsed_offset,
+                    entry.cached_model.clone(),
+                )
+            } else {
+                return None;
+            };
+
+        Some(FileCacheEntry {
+            metadata: FileMetadata {
+                size,
+                modified,
+                last_parsed_offset,
+            },
+            messages,
+            daily_contributions: daily_contributions.into_iter().collect(),
+            cached_model,
+        })
+    }
+
+    /// Get all entries for an analyzer
+    pub fn get_analyzer_entries(&self, analyzer_name: &str) -> Vec<(PathBuf, FileCacheEntry)> {
+        let mut entries = Vec::new();
+
+        // From dirty entries
+        for (key, _) in self.dirty_entries.read().iter() {
+            if key.analyzer_name == analyzer_name
+                && let Some(entry) = self.get_unchecked(key)
+            {
+                entries.push((key.file_path.clone(), entry));
+            }
+        }
+
+        // From index
+        let index = self.index.read();
+        for cache_entry in index.entries.iter() {
+            if cache_entry.analyzer_name == analyzer_name {
+                let key = FileCacheKey {
+                    analyzer_name: analyzer_name.to_string(),
+                    file_path: PathBuf::from(&cache_entry.file_path),
+                };
+                // Skip if already in dirty entries
+                if !self.dirty_entries.read().contains_key(&key)
+                    && let Some(entry) = self.get_unchecked(&key)
+                {
+                    entries.push((key.file_path, entry));
+                }
+            }
+        }
+
+        entries
+    }
+
+    /// Remove entries for deleted files
+    pub fn prune_deleted_files(&self, analyzer_name: &str, current_paths: &[PathBuf]) {
+        let current_set: std::collections::HashSet<_> = current_paths.iter().collect();
+
+        // Find keys to remove
+        let mut keys_to_remove = Vec::new();
+
+        // Check dirty entries
+        for key in self.dirty_entries.read().keys() {
+            if key.analyzer_name == analyzer_name && !current_set.contains(&key.file_path) {
+                keys_to_remove.push(key.clone());
+            }
+        }
+
+        // Check index
+        let index = self.index.read();
+        for entry in index.entries.iter() {
+            if entry.analyzer_name == analyzer_name {
+                let path = PathBuf::from(&entry.file_path);
+                if !current_set.contains(&path) {
+                    keys_to_remove.push(FileCacheKey {
+                        analyzer_name: analyzer_name.to_string(),
+                        file_path: path,
+                    });
+                }
+            }
+        }
+        drop(index);
+
+        // Remove
+        for key in keys_to_remove {
+            self.remove(&key);
+        }
+    }
+
+    /// Invalidate all entries for an analyzer
+    pub fn invalidate_analyzer(&self, analyzer_name: &str) {
+        // Remove from dirty entries
+        self.dirty_entries
+            .write()
+            .retain(|k, _| k.analyzer_name != analyzer_name);
+        self.dirty_messages
+            .write()
+            .retain(|k, _| k.analyzer_name != analyzer_name);
+
+        // Mark index entries for removal
+        let index = self.index.read();
+        for entry in index.entries.iter() {
+            if entry.analyzer_name == analyzer_name {
+                self.removed_keys.write().push(FileCacheKey {
+                    analyzer_name: analyzer_name.to_string(),
+                    file_path: PathBuf::from(&entry.file_path),
+                });
+            }
+        }
+    }
+
+    /// Get cache statistics
+    pub fn stats(&self) -> CacheStats {
+        let mut total_entries = 0;
+        let mut by_analyzer: HashMap<String, usize> = HashMap::new();
+
+        // Count dirty entries
+        for key in self.dirty_entries.read().keys() {
+            total_entries += 1;
+            *by_analyzer.entry(key.analyzer_name.clone()).or_default() += 1;
+        }
+
+        // Count index entries (excluding those in dirty)
+        let index = self.index.read();
+        let dirty = self.dirty_entries.read();
+        for entry in index.entries.iter() {
+            let key = FileCacheKey {
+                analyzer_name: entry.analyzer_name.clone(),
+                file_path: PathBuf::from(&entry.file_path),
+            };
+            if !dirty.contains_key(&key) {
+                total_entries += 1;
+                *by_analyzer.entry(entry.analyzer_name.clone()).or_default() += 1;
+            }
+        }
+
+        let db_size = fs::metadata(self.index_path())
+            .map(|m| m.len())
+            .unwrap_or(0);
+
+        CacheStats {
+            total_entries,
+            by_analyzer,
+            db_size,
+        }
+    }
+
+    /// Persist all dirty data to disk
+    pub fn persist(&self) -> Result<()> {
+        // Skip persistence for in-memory fallback cache
+        if self.cache_dir.as_os_str().is_empty() {
+            return Ok(());
+        }
+
+        let dirty_entries = self.dirty_entries.read();
+        let dirty_messages = self.dirty_messages.read();
+        let removed_keys = self.removed_keys.read();
+
+        if dirty_entries.is_empty() && dirty_messages.is_empty() && removed_keys.is_empty() {
+            return Ok(());
+        }
+
+        // Build new index from existing + dirty - removed
+        let mut new_entries: Vec<CacheMetaEntry> = Vec::new();
+
+        // Add existing entries (not in dirty or removed)
+        let current_index = self.index.read();
+        for entry in current_index.entries.iter() {
+            let key = FileCacheKey {
+                analyzer_name: entry.analyzer_name.clone(),
+                file_path: PathBuf::from(&entry.file_path),
+            };
+            if !dirty_entries.contains_key(&key) && !removed_keys.contains(&key) {
+                new_entries.push(entry.clone());
+            }
+        }
+        drop(current_index);
+
+        // Add dirty entries
+        for (_, entry) in dirty_entries.iter() {
+            new_entries.push(entry.clone());
+        }
+
+        // Write new index
+        let new_index = CacheIndex {
+            version: CACHE_VERSION,
+            entries: new_entries.clone(),
+        };
+
+        let bytes = rkyv::to_bytes::<BoxedError>(&new_index)
+            .map_err(|e| anyhow::anyhow!("Failed to serialize cache index: {}", e))?;
+
+        // Atomic write via temp file + rename
+        let temp_path = self.index_path().with_extension("tmp");
+        let mut file = File::create(&temp_path)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        fs::rename(&temp_path, self.index_path())?;
+
+        // Write dirty messages to separate files
+        fs::create_dir_all(self.messages_dir())?;
+        for (key, messages) in dirty_messages.iter() {
+            let msg_container = CacheMessages {
+                messages: messages.clone(),
+            };
+            let bytes = rkyv::to_bytes::<BoxedError>(&msg_container)
+                .map_err(|e| anyhow::anyhow!("Failed to serialize messages: {}", e))?;
+
+            let msg_path = self.message_file_path(key);
+            let temp_path = msg_path.with_extension("tmp");
+            let mut file = File::create(&temp_path)?;
+            file.write_all(&bytes)?;
+            file.sync_all()?;
+            fs::rename(&temp_path, &msg_path)?;
+        }
+
+        // Delete message files for removed entries
+        for key in removed_keys.iter() {
+            let msg_path = self.message_file_path(key);
+            let _ = fs::remove_file(msg_path);
+        }
+
+        // Update in-memory index
+        drop(dirty_entries);
+        drop(dirty_messages);
+        drop(removed_keys);
+
+        // Rebuild index_map from new_entries
+        let new_index_map: HashMap<FileCacheKey, CacheMetaEntry> = new_entries
+            .iter()
+            .map(|e| {
+                let key = FileCacheKey {
+                    analyzer_name: e.analyzer_name.clone(),
+                    file_path: PathBuf::from(&e.file_path),
+                };
+                (key, e.clone())
+            })
+            .collect();
+
+        *self.index.write() = CacheIndex {
+            version: CACHE_VERSION,
+            entries: new_entries,
+        };
+        *self.index_map.write() = new_index_map;
+
+        // Clear dirty state
+        self.dirty_entries.write().clear();
+        self.dirty_messages.write().clear();
+        self.removed_keys.write().clear();
+
+        Ok(())
+    }
+
+    /// Clear all cache data
+    pub fn clear(&self) -> Result<()> {
+        self.dirty_entries.write().clear();
+        self.dirty_messages.write().clear();
+        self.removed_keys.write().clear();
+        *self.index.write() = CacheIndex {
+            version: CACHE_VERSION,
+            entries: Vec::new(),
+        };
+        self.index_map.write().clear();
+
+        // Delete files
+        let _ = fs::remove_file(self.index_path());
+        let _ = fs::remove_dir_all(self.messages_dir());
+
+        Ok(())
+    }
+}

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -1,0 +1,1279 @@
+//! Zero-copy memory-mapped persistent cache for incremental file parsing.
+//!
+//! This module provides per-file caching to avoid re-parsing unchanged files.
+//! It stores parsed messages and pre-aggregated daily statistics for each file,
+//! with metadata-based invalidation.
+//!
+//! ## Architecture
+//!
+//! - Hot data (metadata + aggregates) in memory-mapped rkyv archive
+//! - Cold data (messages) loaded lazily from separate files
+//! - Zero-copy access via rkyv for instant startup
+
+mod mmap_repository;
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+use crate::types::{ConversationMessage, DailyStats, FileMetadata};
+
+pub use mmap_repository::MmapCacheRepository;
+
+/// Cached data for a single file
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FileCacheEntry {
+    pub metadata: FileMetadata,
+    pub messages: Vec<ConversationMessage>,
+    /// Pre-aggregated stats contribution from this file
+    pub daily_contributions: HashMap<String, DailyStats>,
+    /// Cached session model name (for analyzers like Codex CLI where model is in header)
+    #[serde(default)]
+    pub cached_model: Option<String>,
+}
+
+/// Cache key combining analyzer name and file path
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
+pub struct FileCacheKey {
+    pub analyzer_name: String,
+    pub file_path: PathBuf,
+}
+
+impl FileCacheKey {
+    pub fn new(analyzer_name: &str, path: &Path) -> Self {
+        Self {
+            analyzer_name: analyzer_name.to_string(),
+            file_path: path.to_path_buf(),
+        }
+    }
+}
+
+/// Statistics about the cache
+#[derive(Debug)]
+pub struct CacheStats {
+    pub total_entries: usize,
+    pub by_analyzer: HashMap<String, usize>,
+    pub db_size: u64,
+}
+
+/// Get the path to the cache directory
+pub fn cache_db_path() -> anyhow::Result<PathBuf> {
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    Ok(home.join(".splitrail").join("cache.meta"))
+}
+
+/// Format bytes as human-readable string
+pub fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} bytes", bytes)
+    }
+}
+
+/// File stats cache using zero-copy mmap repository.
+pub struct FileStatsCache {
+    repo: RwLock<Option<Arc<MmapCacheRepository>>>,
+}
+
+impl Default for FileStatsCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FileStatsCache {
+    pub fn new() -> Self {
+        Self {
+            repo: RwLock::new(None),
+        }
+    }
+
+    /// Get or initialize the repository with lazy initialization
+    fn get_repo(&self) -> Arc<MmapCacheRepository> {
+        // Fast path: check if already initialized
+        {
+            let guard = self.repo.read();
+            if let Some(repo) = guard.as_ref() {
+                return Arc::clone(repo);
+            }
+        }
+
+        // Slow path: initialize
+        let mut guard = self.repo.write();
+        if guard.is_none() {
+            let repo = MmapCacheRepository::open().unwrap_or_else(|e| {
+                eprintln!("Warning: Failed to open cache: {e}");
+                // Fall back to empty in-memory cache (no persistence)
+                MmapCacheRepository::empty()
+            });
+            *guard = Some(Arc::new(repo));
+        }
+        Arc::clone(guard.as_ref().unwrap())
+    }
+
+    pub fn get(&self, key: &FileCacheKey, current_path: &Path) -> Option<FileCacheEntry> {
+        self.get_repo().get(key, current_path)
+    }
+
+    pub fn get_unchecked(&self, key: &FileCacheKey) -> Option<FileCacheEntry> {
+        self.get_repo().get_unchecked(key)
+    }
+
+    pub fn insert(&self, key: FileCacheKey, entry: FileCacheEntry) {
+        self.get_repo().insert(key, entry);
+    }
+
+    pub fn invalidate_analyzer(&self, analyzer_name: &str) {
+        self.get_repo().invalidate_analyzer(analyzer_name);
+    }
+
+    pub fn remove(&self, key: &FileCacheKey) {
+        self.get_repo().remove(key);
+    }
+
+    pub fn get_analyzer_entries(&self, analyzer_name: &str) -> Vec<(PathBuf, FileCacheEntry)> {
+        self.get_repo().get_analyzer_entries(analyzer_name)
+    }
+
+    pub fn prune_deleted_files(&self, analyzer_name: &str, current_paths: &[PathBuf]) {
+        self.get_repo()
+            .prune_deleted_files(analyzer_name, current_paths);
+    }
+
+    pub fn stats(&self) -> CacheStats {
+        self.get_repo().stats()
+    }
+
+    pub fn save_to_disk(&self) -> anyhow::Result<()> {
+        self.get_repo().persist()
+    }
+
+    pub fn load_from_disk() -> anyhow::Result<Self> {
+        let repo = MmapCacheRepository::open()?;
+        Ok(Self {
+            repo: RwLock::new(Some(Arc::new(repo))),
+        })
+    }
+
+    pub fn clear(&self) {
+        let _ = self.get_repo().clear();
+    }
+
+    /// Check if a file is stale (for use without loading full entry)
+    pub fn is_stale(&self, key: &FileCacheKey, current_meta: &FileMetadata) -> bool {
+        self.get_repo().is_stale(key, current_meta)
+    }
+
+    /// Get just the daily contributions without loading messages
+    pub fn get_daily_contributions(&self, key: &FileCacheKey) -> Option<Vec<(String, DailyStats)>> {
+        self.get_repo().get_daily_contributions(key)
+    }
+
+    /// Load messages on demand (for TUI session view)
+    pub fn load_messages(&self, key: &FileCacheKey) -> anyhow::Result<Vec<ConversationMessage>> {
+        self.get_repo().load_messages(key)
+    }
+}
+
+// Make FileStatsCache Debug
+impl std::fmt::Debug for FileStatsCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let initialized = self.repo.read().is_some();
+        f.debug_struct("FileStatsCache")
+            .field("initialized", &initialized)
+            .finish()
+    }
+}
+
+// =============================================================================
+// SNAPSHOT CACHE - Caches final deduplicated result for instant warm starts
+// =============================================================================
+
+use crate::types::AgenticCodingToolStats;
+use std::collections::BTreeMap;
+use std::fs;
+
+/// "Hot" snapshot - small, fast to load, enough for TUI display
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HotSnapshot {
+    pub fingerprint: u64,
+    pub daily_stats: BTreeMap<String, DailyStats>,
+    pub num_conversations: u64,
+    pub analyzer_name: String,
+}
+
+/// "Cold" snapshot - large, contains all messages for session detail view
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColdSnapshot {
+    pub fingerprint: u64,
+    pub messages: Vec<crate::types::ConversationMessage>,
+}
+
+/// Compute a fingerprint of source files for cache invalidation.
+/// Fingerprint changes if any file is added, removed, or modified.
+pub fn compute_sources_fingerprint(sources: &[crate::analyzer::DataSource]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+
+    // Sort for deterministic ordering
+    let mut sorted: Vec<_> = sources.iter().collect();
+    sorted.sort_by_key(|s| &s.path);
+
+    for source in sorted {
+        source.path.hash(&mut hasher);
+        if let Ok(meta) = fs::metadata(&source.path) {
+            if let Ok(modified) = meta.modified() {
+                modified.hash(&mut hasher);
+            }
+            meta.len().hash(&mut hasher);
+        }
+    }
+
+    hasher.finish()
+}
+
+/// Get the path to the snapshot cache files for an analyzer
+fn snapshot_paths(analyzer_name: &str) -> anyhow::Result<(PathBuf, PathBuf)> {
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not determine home directory"))?;
+    let cache_dir = home.join(".splitrail").join("snapshots");
+    fs::create_dir_all(&cache_dir)?;
+    let safe_name = analyzer_name.replace(['/', '\\', ' '], "_");
+    Ok((
+        cache_dir.join(format!("{}.hot", safe_name)),
+        cache_dir.join(format!("{}.cold", safe_name)),
+    ))
+}
+
+/// Load ONLY hot snapshot for ultra-fast startup (messages loaded lazily later)
+pub fn load_snapshot_hot_only(
+    analyzer_name: &str,
+    expected_fingerprint: u64,
+) -> Option<AgenticCodingToolStats> {
+    let (hot_path, _) = snapshot_paths(analyzer_name).ok()?;
+
+    if !hot_path.exists() {
+        return None;
+    }
+    let hot_data = fs::read(&hot_path).ok()?;
+    let hot: HotSnapshot = bincode::deserialize(&hot_data).ok()?;
+
+    if hot.fingerprint != expected_fingerprint {
+        return None;
+    }
+
+    Some(AgenticCodingToolStats {
+        daily_stats: hot.daily_stats,
+        num_conversations: hot.num_conversations,
+        messages: Vec::new(), // Lazy load later if needed
+        analyzer_name: hot.analyzer_name,
+    })
+}
+
+/// Save snapshot to disk (split into hot and cold)
+pub fn save_snapshot(
+    analyzer_name: &str,
+    fingerprint: u64,
+    stats: &AgenticCodingToolStats,
+) -> anyhow::Result<()> {
+    let (hot_path, cold_path) = snapshot_paths(analyzer_name)?;
+
+    // Save hot snapshot (small)
+    let hot = HotSnapshot {
+        fingerprint,
+        daily_stats: stats.daily_stats.clone(),
+        num_conversations: stats.num_conversations,
+        analyzer_name: stats.analyzer_name.clone(),
+    };
+    let hot_data = bincode::serialize(&hot)?;
+    fs::write(&hot_path, hot_data)?;
+
+    // Save cold snapshot (large)
+    let cold = ColdSnapshot {
+        fingerprint,
+        messages: stats.messages.clone(),
+    };
+    let cold_data = bincode::serialize(&cold)?;
+    fs::write(&cold_path, cold_data)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Application, MessageRole, Stats};
+    use chrono::{TimeZone, Utc};
+    use std::collections::BTreeMap;
+    use tempfile::TempDir;
+
+    // ==========================================================================
+    // TEST HELPERS
+    // ==========================================================================
+
+    fn make_test_stats() -> Stats {
+        Stats {
+            input_tokens: 100,
+            output_tokens: 50,
+            reasoning_tokens: 25,
+            cache_creation_tokens: 10,
+            cache_read_tokens: 5,
+            cached_tokens: 15,
+            cost: 0.12345,
+            tool_calls: 3,
+            terminal_commands: 2,
+            file_searches: 1,
+            file_content_searches: 1,
+            files_read: 5,
+            files_added: 2,
+            files_edited: 3,
+            files_deleted: 1,
+            lines_read: 500,
+            lines_added: 100,
+            lines_edited: 50,
+            lines_deleted: 25,
+            bytes_read: 10000,
+            bytes_added: 2000,
+            bytes_edited: 1000,
+            bytes_deleted: 500,
+            todos_created: 3,
+            todos_completed: 2,
+            todos_in_progress: 1,
+            todo_writes: 4,
+            todo_reads: 2,
+            code_lines: 200,
+            docs_lines: 50,
+            data_lines: 30,
+            media_lines: 10,
+            config_lines: 20,
+            other_lines: 5,
+        }
+    }
+
+    fn make_test_daily_stats(date: &str) -> DailyStats {
+        let mut models = BTreeMap::new();
+        models.insert("claude-sonnet-4".to_string(), 5);
+        models.insert("gpt-4o".to_string(), 3);
+
+        DailyStats {
+            date: date.to_string(),
+            user_messages: 10,
+            ai_messages: 8,
+            conversations: 2,
+            models,
+            stats: make_test_stats(),
+        }
+    }
+
+    fn make_test_message(conv_hash: &str, timestamp: i64) -> ConversationMessage {
+        ConversationMessage {
+            application: Application::ClaudeCode,
+            date: Utc.timestamp_opt(timestamp, 0).single().unwrap(),
+            project_hash: "proj_test".to_string(),
+            conversation_hash: conv_hash.to_string(),
+            local_hash: Some("local_hash_123".to_string()),
+            global_hash: format!("global_{}_{}", conv_hash, timestamp),
+            model: Some("claude-sonnet-4".to_string()),
+            stats: make_test_stats(),
+            role: MessageRole::Assistant,
+            uuid: Some("uuid-123".to_string()),
+            session_name: Some("Test Session".to_string()),
+        }
+    }
+
+    fn make_test_cache_entry() -> FileCacheEntry {
+        let mut daily_contributions = HashMap::new();
+        daily_contributions.insert(
+            "2025-01-15".to_string(),
+            make_test_daily_stats("2025-01-15"),
+        );
+        daily_contributions.insert(
+            "2025-01-16".to_string(),
+            make_test_daily_stats("2025-01-16"),
+        );
+
+        FileCacheEntry {
+            metadata: FileMetadata {
+                size: 12345,
+                modified: 1700000000,
+                last_parsed_offset: 12345,
+            },
+            messages: vec![
+                make_test_message("conv1", 1700000000),
+                make_test_message("conv1", 1700000100),
+            ],
+            daily_contributions,
+            cached_model: Some("claude-sonnet-4".to_string()),
+        }
+    }
+
+    // ==========================================================================
+    // BASIC FORMAT TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(500), "500 bytes");
+        assert_eq!(format_bytes(1024), "1.00 KB");
+        assert_eq!(format_bytes(1536), "1.50 KB");
+        assert_eq!(format_bytes(1048576), "1.00 MB");
+        assert_eq!(format_bytes(1073741824), "1.00 GB");
+    }
+
+    #[test]
+    fn test_file_cache_key() {
+        let key = FileCacheKey::new("Test", Path::new("/foo/bar.jsonl"));
+        assert_eq!(key.analyzer_name, "Test");
+        assert_eq!(key.file_path, PathBuf::from("/foo/bar.jsonl"));
+    }
+
+    // ==========================================================================
+    // CACHE REPOSITORY TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_cache_empty_fallback_persist_noop() {
+        let repo = MmapCacheRepository::empty();
+        // Persist on empty fallback should not panic and return Ok
+        assert!(repo.persist().is_ok());
+    }
+
+    #[test]
+    fn test_cache_insert_get_roundtrip() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+        let entry = make_test_cache_entry();
+
+        repo.insert(key.clone(), entry.clone());
+
+        // get_unchecked should return the entry
+        let retrieved = repo.get_unchecked(&key).expect("should retrieve entry");
+        assert_eq!(retrieved.metadata.size, 12345);
+        assert_eq!(retrieved.messages.len(), 2);
+        assert_eq!(retrieved.daily_contributions.len(), 2);
+        assert_eq!(retrieved.cached_model, Some("claude-sonnet-4".to_string()));
+    }
+
+    #[test]
+    fn test_cache_get_returns_none_for_missing() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/nonexistent.jsonl"));
+
+        assert!(repo.get_unchecked(&key).is_none());
+    }
+
+    #[test]
+    fn test_cache_remove_entry() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+        let entry = make_test_cache_entry();
+
+        repo.insert(key.clone(), entry);
+        assert!(repo.get_unchecked(&key).is_some());
+
+        repo.remove(&key);
+        assert!(repo.get_unchecked(&key).is_none());
+    }
+
+    #[test]
+    fn test_cache_get_daily_contributions() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+        let entry = make_test_cache_entry();
+
+        repo.insert(key.clone(), entry);
+
+        let contributions = repo
+            .get_daily_contributions(&key)
+            .expect("should get contributions");
+        assert_eq!(contributions.len(), 2);
+
+        // Verify stats are preserved
+        let jan15 = contributions
+            .iter()
+            .find(|(d, _)| d == "2025-01-15")
+            .map(|(_, s)| s)
+            .unwrap();
+        assert_eq!(jan15.ai_messages, 8);
+        assert_eq!(jan15.stats.input_tokens, 100);
+    }
+
+    #[test]
+    fn test_dirty_entries_override_index() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+
+        // Insert initial entry
+        let mut entry1 = make_test_cache_entry();
+        entry1.metadata.size = 1000;
+        repo.insert(key.clone(), entry1);
+
+        // Insert updated entry (dirty)
+        let mut entry2 = make_test_cache_entry();
+        entry2.metadata.size = 2000;
+        repo.insert(key.clone(), entry2);
+
+        // Should get the dirty (newer) entry
+        let retrieved = repo.get_unchecked(&key).unwrap();
+        assert_eq!(retrieved.metadata.size, 2000);
+    }
+
+    #[test]
+    fn test_removed_then_reinserted_key() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+
+        // Insert, remove, reinsert
+        let entry1 = make_test_cache_entry();
+        repo.insert(key.clone(), entry1);
+        repo.remove(&key);
+
+        let mut entry2 = make_test_cache_entry();
+        entry2.metadata.size = 9999;
+        repo.insert(key.clone(), entry2);
+
+        // Should get the reinserted entry
+        let retrieved = repo.get_unchecked(&key).unwrap();
+        assert_eq!(retrieved.metadata.size, 9999);
+    }
+
+    #[test]
+    fn test_invalidate_analyzer() {
+        let repo = MmapCacheRepository::empty();
+
+        // Insert entries for two analyzers
+        let key1 = FileCacheKey::new("Analyzer1", Path::new("/test/file1.jsonl"));
+        let key2 = FileCacheKey::new("Analyzer1", Path::new("/test/file2.jsonl"));
+        let key3 = FileCacheKey::new("Analyzer2", Path::new("/test/file3.jsonl"));
+
+        repo.insert(key1.clone(), make_test_cache_entry());
+        repo.insert(key2.clone(), make_test_cache_entry());
+        repo.insert(key3.clone(), make_test_cache_entry());
+
+        // Invalidate Analyzer1
+        repo.invalidate_analyzer("Analyzer1");
+
+        // Analyzer1 entries should be gone
+        assert!(repo.get_unchecked(&key1).is_none());
+        assert!(repo.get_unchecked(&key2).is_none());
+
+        // Analyzer2 entry should still exist
+        assert!(repo.get_unchecked(&key3).is_some());
+    }
+
+    #[test]
+    fn test_clear_removes_all() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+
+        repo.insert(key.clone(), make_test_cache_entry());
+        assert!(repo.get_unchecked(&key).is_some());
+
+        repo.clear().unwrap();
+        assert!(repo.get_unchecked(&key).is_none());
+    }
+
+    #[test]
+    fn test_cache_stats() {
+        let repo = MmapCacheRepository::empty();
+
+        let stats = repo.stats();
+        assert_eq!(stats.total_entries, 0);
+
+        let key1 = FileCacheKey::new("Analyzer1", Path::new("/test/file1.jsonl"));
+        let key2 = FileCacheKey::new("Analyzer2", Path::new("/test/file2.jsonl"));
+
+        repo.insert(key1, make_test_cache_entry());
+        repo.insert(key2, make_test_cache_entry());
+
+        let stats = repo.stats();
+        assert_eq!(stats.total_entries, 2);
+        assert_eq!(stats.by_analyzer.get("Analyzer1"), Some(&1));
+        assert_eq!(stats.by_analyzer.get("Analyzer2"), Some(&1));
+    }
+
+    // ==========================================================================
+    // STALENESS DETECTION TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_is_stale_not_in_cache() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/nonexistent.jsonl"));
+        let meta = FileMetadata {
+            size: 100,
+            modified: 1700000000,
+            last_parsed_offset: 0,
+        };
+
+        // Key not in cache should always be stale
+        assert!(repo.is_stale(&key, &meta));
+    }
+
+    #[test]
+    fn test_is_stale_unchanged_file() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+        let entry = make_test_cache_entry();
+
+        repo.insert(key.clone(), entry.clone());
+
+        let current_meta = FileMetadata {
+            size: entry.metadata.size,
+            modified: entry.metadata.modified,
+            last_parsed_offset: 0,
+        };
+
+        // Same size and modified time should not be stale
+        assert!(!repo.is_stale(&key, &current_meta));
+    }
+
+    #[test]
+    fn test_is_stale_size_change() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+        let entry = make_test_cache_entry();
+
+        repo.insert(key.clone(), entry.clone());
+
+        let current_meta = FileMetadata {
+            size: entry.metadata.size + 1000, // Size changed
+            modified: entry.metadata.modified,
+            last_parsed_offset: 0,
+        };
+
+        assert!(repo.is_stale(&key, &current_meta));
+    }
+
+    #[test]
+    fn test_is_stale_modified_change() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+        let entry = make_test_cache_entry();
+
+        repo.insert(key.clone(), entry.clone());
+
+        let current_meta = FileMetadata {
+            size: entry.metadata.size,
+            modified: entry.metadata.modified + 1, // Modified time changed
+            last_parsed_offset: 0,
+        };
+
+        assert!(repo.is_stale(&key, &current_meta));
+    }
+
+    // ==========================================================================
+    // PERSISTENCE TESTS (using tempdir)
+    // ==========================================================================
+
+    #[test]
+    fn test_cache_persist_and_reload() {
+        let temp_dir = TempDir::new().unwrap();
+        let cache_meta_path = temp_dir.path().join("cache.meta");
+
+        // Create and populate a repository
+        {
+            let repo = MmapCacheRepository::empty();
+            let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+            repo.insert(key, make_test_cache_entry());
+
+            // Manually write to the temp location for this test
+            // (In production, persist() writes to ~/.splitrail/)
+            // This test verifies the dirty entry tracking works
+            let stats = repo.stats();
+            assert_eq!(stats.total_entries, 1);
+        }
+
+        // Note: Full persist/reload test would require modifying cache_dir
+        // which is set in MmapCacheRepository::open(). For unit tests, we
+        // verify the dirty entry handling works correctly.
+        assert!(cache_meta_path.parent().unwrap().exists());
+    }
+
+    #[test]
+    fn test_persist_clears_dirty_state() {
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+
+        repo.insert(key.clone(), make_test_cache_entry());
+
+        // For empty fallback, persist is a no-op but should not error
+        repo.persist().unwrap();
+
+        // Entry should still be retrievable after "persist"
+        assert!(repo.get_unchecked(&key).is_some());
+    }
+
+    // ==========================================================================
+    // PRUNE DELETED FILES TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_prune_deleted_files() {
+        let repo = MmapCacheRepository::empty();
+
+        let key1 = FileCacheKey::new("TestAnalyzer", Path::new("/test/file1.jsonl"));
+        let key2 = FileCacheKey::new("TestAnalyzer", Path::new("/test/file2.jsonl"));
+        let key3 = FileCacheKey::new("TestAnalyzer", Path::new("/test/file3.jsonl"));
+
+        repo.insert(key1.clone(), make_test_cache_entry());
+        repo.insert(key2.clone(), make_test_cache_entry());
+        repo.insert(key3.clone(), make_test_cache_entry());
+
+        // Only file1 and file3 still exist
+        let current_paths = vec![
+            PathBuf::from("/test/file1.jsonl"),
+            PathBuf::from("/test/file3.jsonl"),
+        ];
+
+        repo.prune_deleted_files("TestAnalyzer", &current_paths);
+
+        // file2 should be removed
+        assert!(repo.get_unchecked(&key1).is_some());
+        assert!(repo.get_unchecked(&key2).is_none());
+        assert!(repo.get_unchecked(&key3).is_some());
+    }
+
+    // ==========================================================================
+    // CONVERSION ROUNDTRIP TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_stats_conversion_roundtrip() {
+        use super::mmap_repository::CacheStats_;
+
+        let original = make_test_stats();
+        let cached = CacheStats_::from(&original);
+        let recovered = Stats::from(&cached);
+
+        assert_eq!(recovered.input_tokens, original.input_tokens);
+        assert_eq!(recovered.output_tokens, original.output_tokens);
+        assert_eq!(recovered.reasoning_tokens, original.reasoning_tokens);
+        assert_eq!(
+            recovered.cache_creation_tokens,
+            original.cache_creation_tokens
+        );
+        assert_eq!(recovered.cache_read_tokens, original.cache_read_tokens);
+        assert_eq!(recovered.cached_tokens, original.cached_tokens);
+        assert_eq!(recovered.tool_calls, original.tool_calls);
+        assert_eq!(recovered.terminal_commands, original.terminal_commands);
+        assert_eq!(recovered.file_searches, original.file_searches);
+        assert_eq!(
+            recovered.file_content_searches,
+            original.file_content_searches
+        );
+        assert_eq!(recovered.files_read, original.files_read);
+        assert_eq!(recovered.files_added, original.files_added);
+        assert_eq!(recovered.files_edited, original.files_edited);
+        assert_eq!(recovered.files_deleted, original.files_deleted);
+        assert_eq!(recovered.lines_read, original.lines_read);
+        assert_eq!(recovered.lines_added, original.lines_added);
+        assert_eq!(recovered.lines_edited, original.lines_edited);
+        assert_eq!(recovered.lines_deleted, original.lines_deleted);
+        assert_eq!(recovered.bytes_read, original.bytes_read);
+        assert_eq!(recovered.bytes_added, original.bytes_added);
+        assert_eq!(recovered.bytes_edited, original.bytes_edited);
+        assert_eq!(recovered.bytes_deleted, original.bytes_deleted);
+        assert_eq!(recovered.todos_created, original.todos_created);
+        assert_eq!(recovered.todos_completed, original.todos_completed);
+        assert_eq!(recovered.todos_in_progress, original.todos_in_progress);
+        assert_eq!(recovered.todo_writes, original.todo_writes);
+        assert_eq!(recovered.todo_reads, original.todo_reads);
+        assert_eq!(recovered.code_lines, original.code_lines);
+        assert_eq!(recovered.docs_lines, original.docs_lines);
+        assert_eq!(recovered.data_lines, original.data_lines);
+        assert_eq!(recovered.media_lines, original.media_lines);
+        assert_eq!(recovered.config_lines, original.config_lines);
+        assert_eq!(recovered.other_lines, original.other_lines);
+    }
+
+    #[test]
+    fn test_cost_precision_roundtrip() {
+        use super::mmap_repository::CacheStats_;
+
+        // Test various cost values
+        let test_costs = [
+            0.0, 0.00001, 0.001, 0.01, 0.12345, 1.0, 123.456789, 9999.99999,
+        ];
+
+        for &cost in &test_costs {
+            let original = Stats {
+                cost,
+                ..Default::default()
+            };
+            let cached = CacheStats_::from(&original);
+            let recovered = Stats::from(&cached);
+
+            // Should preserve 5 decimal places of precision
+            assert!(
+                (cost - recovered.cost).abs() < 0.00001,
+                "Cost {} did not roundtrip correctly, got {}",
+                cost,
+                recovered.cost
+            );
+        }
+    }
+
+    #[test]
+    fn test_cost_very_small_precision() {
+        use super::mmap_repository::CacheStats_;
+
+        // Test the smallest representable value (1 micro-cent)
+        let cost = 0.00001;
+        let original = Stats {
+            cost,
+            ..Default::default()
+        };
+        let cached = CacheStats_::from(&original);
+        assert_eq!(cached.cost_millicents, 1);
+
+        let recovered = Stats::from(&cached);
+        assert_eq!(recovered.cost, 0.00001);
+    }
+
+    #[test]
+    fn test_daily_stats_conversion_roundtrip() {
+        use super::mmap_repository::CacheDailyStats;
+
+        let original = make_test_daily_stats("2025-01-15");
+        let cached = CacheDailyStats::from(&original);
+        let recovered = DailyStats::from(&cached);
+
+        assert_eq!(recovered.date, original.date);
+        assert_eq!(recovered.user_messages, original.user_messages);
+        assert_eq!(recovered.ai_messages, original.ai_messages);
+        assert_eq!(recovered.conversations, original.conversations);
+        assert_eq!(recovered.models.len(), original.models.len());
+        assert_eq!(
+            recovered.models.get("claude-sonnet-4"),
+            original.models.get("claude-sonnet-4")
+        );
+    }
+
+    #[test]
+    fn test_message_conversion_roundtrip() {
+        use super::mmap_repository::CacheMessage;
+
+        let original = make_test_message("conv_test", 1700000000);
+        let cached = CacheMessage::from(&original);
+        let recovered = ConversationMessage::from(&cached);
+
+        assert_eq!(recovered.project_hash, original.project_hash);
+        assert_eq!(recovered.conversation_hash, original.conversation_hash);
+        assert_eq!(recovered.local_hash, original.local_hash);
+        assert_eq!(recovered.global_hash, original.global_hash);
+        assert_eq!(recovered.model, original.model);
+        assert_eq!(recovered.role, original.role);
+        assert_eq!(recovered.uuid, original.uuid);
+        assert_eq!(recovered.session_name, original.session_name);
+        assert_eq!(recovered.date.timestamp(), original.date.timestamp());
+    }
+
+    #[test]
+    fn test_application_all_variants_roundtrip() {
+        use super::mmap_repository::{application_to_u8, u8_to_application};
+
+        let variants = [
+            Application::ClaudeCode,
+            Application::GeminiCli,
+            Application::QwenCode,
+            Application::CodexCli,
+            Application::Cline,
+            Application::RooCode,
+            Application::KiloCode,
+            Application::Copilot,
+            Application::OpenCode,
+        ];
+
+        for app in variants {
+            let u8_val = application_to_u8(&app);
+            let recovered = u8_to_application(u8_val);
+            assert_eq!(
+                std::mem::discriminant(&recovered),
+                std::mem::discriminant(&app),
+                "Application variant {:?} did not roundtrip",
+                app
+            );
+        }
+    }
+
+    #[test]
+    fn test_role_all_variants_roundtrip() {
+        use super::mmap_repository::{role_to_u8, u8_to_role};
+
+        let variants = [MessageRole::User, MessageRole::Assistant];
+
+        for role in variants {
+            let u8_val = role_to_u8(&role);
+            let recovered = u8_to_role(u8_val);
+            assert_eq!(recovered, role);
+        }
+    }
+
+    #[test]
+    fn test_unknown_application_fallback() {
+        use super::mmap_repository::u8_to_application;
+
+        // Unknown u8 values should fallback to ClaudeCode
+        let recovered = u8_to_application(255);
+        assert!(matches!(recovered, Application::ClaudeCode));
+
+        let recovered = u8_to_application(100);
+        assert!(matches!(recovered, Application::ClaudeCode));
+    }
+
+    #[test]
+    fn test_timestamp_edge_cases() {
+        use super::mmap_repository::CacheMessage;
+
+        // Test Unix epoch (timestamp = 0)
+        let msg_epoch = make_test_message("conv", 0);
+        let cached = CacheMessage::from(&msg_epoch);
+        let recovered = ConversationMessage::from(&cached);
+        assert_eq!(recovered.date.timestamp(), 0);
+
+        // Test a typical modern timestamp
+        let msg_modern = make_test_message("conv", 1700000000);
+        let cached = CacheMessage::from(&msg_modern);
+        let recovered = ConversationMessage::from(&cached);
+        assert_eq!(recovered.date.timestamp(), 1700000000);
+
+        // Test far future (year 2100)
+        let msg_future = make_test_message("conv", 4102444800);
+        let cached = CacheMessage::from(&msg_future);
+        let recovered = ConversationMessage::from(&cached);
+        assert_eq!(recovered.date.timestamp(), 4102444800);
+    }
+
+    // ==========================================================================
+    // CONCURRENCY TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_lazy_initialization_race() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let cache = Arc::new(FileStatsCache::new());
+        let mut handles = vec![];
+
+        // Spawn multiple threads that all try to access the cache simultaneously
+        for i in 0..10 {
+            let cache_clone = Arc::clone(&cache);
+            handles.push(thread::spawn(move || {
+                let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+                // This triggers get_repo() initialization
+                let _ = cache_clone.get_unchecked(&key);
+                i
+            }));
+        }
+
+        // All threads should complete without panic
+        for handle in handles {
+            handle.join().expect("thread should not panic");
+        }
+    }
+
+    #[test]
+    fn test_concurrent_inserts_same_key() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let repo = Arc::new(MmapCacheRepository::empty());
+        let key = FileCacheKey::new("TestAnalyzer", Path::new("/test/file.jsonl"));
+        let mut handles = vec![];
+
+        // Spawn multiple threads that insert to the same key
+        for i in 0..10 {
+            let repo_clone = Arc::clone(&repo);
+            let key_clone = key.clone();
+            handles.push(thread::spawn(move || {
+                let mut entry = make_test_cache_entry();
+                entry.metadata.size = i as u64 * 1000;
+                repo_clone.insert(key_clone, entry);
+                i
+            }));
+        }
+
+        for handle in handles {
+            handle.join().expect("thread should not panic");
+        }
+
+        // Should have exactly one entry (last writer wins)
+        let stats = repo.stats();
+        assert_eq!(stats.total_entries, 1);
+
+        // Entry should exist
+        assert!(repo.get_unchecked(&key).is_some());
+    }
+
+    // ==========================================================================
+    // SNAPSHOT CACHE TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_compute_sources_fingerprint_deterministic() {
+        use crate::analyzer::DataSource;
+
+        let temp_dir = TempDir::new().unwrap();
+        let file1 = temp_dir.path().join("file1.jsonl");
+        let file2 = temp_dir.path().join("file2.jsonl");
+
+        std::fs::write(&file1, "content1").unwrap();
+        std::fs::write(&file2, "content2").unwrap();
+
+        let sources = vec![
+            DataSource {
+                path: file1.clone(),
+            },
+            DataSource {
+                path: file2.clone(),
+            },
+        ];
+
+        let fp1 = compute_sources_fingerprint(&sources);
+        let fp2 = compute_sources_fingerprint(&sources);
+
+        // Same sources should produce same fingerprint
+        assert_eq!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_compute_sources_fingerprint_changes_on_modification() {
+        use crate::analyzer::DataSource;
+
+        let temp_dir = TempDir::new().unwrap();
+        let file = temp_dir.path().join("file.jsonl");
+
+        std::fs::write(&file, "original content").unwrap();
+        let sources = vec![DataSource { path: file.clone() }];
+
+        let fp_before = compute_sources_fingerprint(&sources);
+
+        // Modify the file
+        std::thread::sleep(std::time::Duration::from_millis(10)); // Ensure mtime changes
+        std::fs::write(&file, "modified content - longer").unwrap();
+
+        let fp_after = compute_sources_fingerprint(&sources);
+
+        // Fingerprint should change when file is modified
+        assert_ne!(fp_before, fp_after);
+    }
+
+    #[test]
+    fn test_compute_sources_fingerprint_order_independent() {
+        use crate::analyzer::DataSource;
+
+        let temp_dir = TempDir::new().unwrap();
+        let file1 = temp_dir.path().join("aaa.jsonl");
+        let file2 = temp_dir.path().join("zzz.jsonl");
+
+        std::fs::write(&file1, "content1").unwrap();
+        std::fs::write(&file2, "content2").unwrap();
+
+        let sources_order1 = vec![
+            DataSource {
+                path: file1.clone(),
+            },
+            DataSource {
+                path: file2.clone(),
+            },
+        ];
+
+        let sources_order2 = vec![
+            DataSource {
+                path: file2.clone(),
+            },
+            DataSource {
+                path: file1.clone(),
+            },
+        ];
+
+        let fp1 = compute_sources_fingerprint(&sources_order1);
+        let fp2 = compute_sources_fingerprint(&sources_order2);
+
+        // Order shouldn't matter (internally sorted)
+        assert_eq!(fp1, fp2);
+    }
+
+    #[test]
+    fn test_load_snapshot_invalid_fingerprint_returns_none() {
+        // With no snapshot saved, should return None
+        let result = load_snapshot_hot_only("nonexistent_analyzer_xyz", 12345);
+        assert!(result.is_none());
+    }
+
+    // ==========================================================================
+    // INTEGRATION TESTS
+    // ==========================================================================
+
+    #[test]
+    fn test_cache_entry_roundtrip_preserves_stats() {
+        // Integration test: Insert entry, retrieve it, verify stats are identical
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("IntegrationTest", Path::new("/test/integration.jsonl"));
+
+        let original_stats = make_test_stats();
+        let original_entry = FileCacheEntry {
+            metadata: FileMetadata {
+                size: 5000,
+                modified: 1700000000,
+                last_parsed_offset: 5000,
+            },
+            messages: vec![make_test_message("conv_int", 1700000000)],
+            daily_contributions: {
+                let mut map = HashMap::new();
+                map.insert(
+                    "2025-01-15".to_string(),
+                    make_test_daily_stats("2025-01-15"),
+                );
+                map
+            },
+            cached_model: Some("test-model".to_string()),
+        };
+
+        repo.insert(key.clone(), original_entry.clone());
+
+        // Retrieve and verify
+        let retrieved = repo.get_unchecked(&key).expect("should get entry");
+
+        // Verify metadata
+        assert_eq!(retrieved.metadata.size, original_entry.metadata.size);
+        assert_eq!(
+            retrieved.metadata.modified,
+            original_entry.metadata.modified
+        );
+        assert_eq!(
+            retrieved.metadata.last_parsed_offset,
+            original_entry.metadata.last_parsed_offset
+        );
+
+        // Verify messages
+        assert_eq!(retrieved.messages.len(), 1);
+        assert_eq!(
+            retrieved.messages[0].stats.input_tokens,
+            original_stats.input_tokens
+        );
+        assert_eq!(retrieved.messages[0].stats.cost, original_stats.cost);
+
+        // Verify daily contributions
+        let daily = retrieved
+            .daily_contributions
+            .get("2025-01-15")
+            .expect("daily stats");
+        assert_eq!(daily.ai_messages, 8);
+        assert_eq!(daily.stats.input_tokens, original_stats.input_tokens);
+    }
+
+    #[test]
+    fn test_cache_invalidation_on_metadata_change() {
+        // Integration test: Verify that file changes are detected
+        let repo = MmapCacheRepository::empty();
+        let key = FileCacheKey::new("InvalidationTest", Path::new("/test/file.jsonl"));
+
+        // Insert original entry
+        let entry = FileCacheEntry {
+            metadata: FileMetadata {
+                size: 1000,
+                modified: 1700000000,
+                last_parsed_offset: 1000,
+            },
+            messages: vec![],
+            daily_contributions: HashMap::new(),
+            cached_model: None,
+        };
+        repo.insert(key.clone(), entry);
+
+        // Simulate file modification (size changed)
+        let new_metadata = FileMetadata {
+            size: 2000,           // File grew
+            modified: 1700000001, // Modified time changed
+            last_parsed_offset: 0,
+        };
+
+        // Should be stale
+        assert!(repo.is_stale(&key, &new_metadata));
+
+        // After updating with new entry, should not be stale
+        let updated_entry = FileCacheEntry {
+            metadata: new_metadata.clone(),
+            messages: vec![],
+            daily_contributions: HashMap::new(),
+            cached_model: None,
+        };
+        repo.insert(key.clone(), updated_entry);
+
+        let check_meta = FileMetadata {
+            size: 2000,
+            modified: 1700000001,
+            last_parsed_offset: 0,
+        };
+        assert!(!repo.is_stale(&key, &check_meta));
+    }
+
+    #[test]
+    fn test_multiple_analyzers_share_cache_without_interference() {
+        // Integration test: Multiple analyzers can use same cache without conflicts
+        let repo = MmapCacheRepository::empty();
+
+        // Insert entries for different analyzers
+        let analyzers = ["Claude Code", "Gemini CLI", "Codex CLI", "Copilot"];
+
+        for (i, analyzer_name) in analyzers.iter().enumerate() {
+            let key =
+                FileCacheKey::new(analyzer_name, Path::new(&format!("/test/{}/file.jsonl", i)));
+
+            let mut entry = make_test_cache_entry();
+            entry.metadata.size = (i as u64 + 1) * 1000;
+            entry.cached_model = Some(format!("model-{}", i));
+
+            repo.insert(key, entry);
+        }
+
+        // Verify each analyzer's entries are independent
+        for (i, analyzer_name) in analyzers.iter().enumerate() {
+            let key =
+                FileCacheKey::new(analyzer_name, Path::new(&format!("/test/{}/file.jsonl", i)));
+
+            let retrieved = repo.get_unchecked(&key).expect("should get entry");
+            assert_eq!(retrieved.metadata.size, (i as u64 + 1) * 1000);
+            assert_eq!(retrieved.cached_model, Some(format!("model-{}", i)));
+        }
+
+        // Verify stats
+        let stats = repo.stats();
+        assert_eq!(stats.total_entries, 4);
+
+        // Invalidate one analyzer shouldn't affect others
+        repo.invalidate_analyzer("Gemini CLI");
+
+        let stats_after = repo.stats();
+        assert_eq!(stats_after.total_entries, 3);
+
+        // Other analyzers should still have their entries
+        let claude_key = FileCacheKey::new("Claude Code", Path::new("/test/0/file.jsonl"));
+        assert!(repo.get_unchecked(&claude_key).is_some());
+    }
+
+    #[test]
+    fn test_empty_repo_stats_and_persist() {
+        let repo = MmapCacheRepository::empty();
+        let stats = repo.stats();
+        assert_eq!(stats.total_entries, 0);
+        assert!(stats.by_analyzer.is_empty());
+        assert!(repo.persist().is_ok());
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,7 +74,7 @@ impl Config {
             }
         }
 
-        Ok(std::env::home_dir()
+        Ok(dirs::home_dir()
             .context("Could not find home directory")?
             .join(".splitrail.toml"))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use analyzers::{
 
 mod analyzer;
 mod analyzers;
+mod cache;
 mod config;
 mod mcp;
 mod models;
@@ -59,6 +60,8 @@ enum Commands {
     Stats(StatsArgs),
     /// Run as an MCP (Model Context Protocol) server
     Mcp,
+    /// Manage the persistent cache
+    Cache(CacheArgs),
 }
 
 #[derive(Args)]
@@ -109,6 +112,28 @@ enum ConfigSubcommands {
         /// Configuration value
         value: String,
     },
+}
+
+#[derive(Args)]
+struct CacheArgs {
+    #[command(subcommand)]
+    subcommand: CacheSubcommands,
+}
+
+#[derive(Subcommand)]
+enum CacheSubcommands {
+    /// Show cache statistics
+    Stats,
+    /// Clear cache
+    Clear {
+        /// Clear only a specific analyzer's cache (e.g., "Claude Code")
+        #[arg(long)]
+        analyzer: Option<String>,
+    },
+    /// Rebuild cache from scratch
+    Rebuild,
+    /// Show cache database path
+    Path,
 }
 
 #[tokio::main]
@@ -166,6 +191,12 @@ async fn main() {
         Some(Commands::Mcp) => {
             if let Err(e) = mcp::run_mcp_server().await {
                 eprintln!("MCP server error: {e:#}");
+                std::process::exit(1);
+            }
+        }
+        Some(Commands::Cache(cache_args)) => {
+            if let Err(e) = handle_cache_subcommand(cache_args).await {
+                eprintln!("Cache error: {e:#}");
                 std::process::exit(1);
             }
         }
@@ -390,4 +421,66 @@ async fn handle_config_subcommand(config_args: ConfigArgs) {
             }
         }
     }
+}
+
+async fn handle_cache_subcommand(cache_args: CacheArgs) -> Result<()> {
+    use cache::{MmapCacheRepository, cache_db_path, format_bytes};
+
+    match cache_args.subcommand {
+        CacheSubcommands::Stats => {
+            let repo = MmapCacheRepository::open().context("Failed to open cache")?;
+            let stats = repo.stats();
+
+            println!("Cache Statistics:");
+            println!("  Total entries: {}", stats.total_entries);
+            println!("  Index size: {}", format_bytes(stats.db_size));
+            println!();
+
+            if stats.by_analyzer.is_empty() {
+                println!("  No cached data");
+            } else {
+                println!("  By analyzer:");
+                let mut analyzers: Vec<_> = stats.by_analyzer.iter().collect();
+                analyzers.sort_by_key(|(name, _)| name.as_str());
+                for (analyzer, count) in analyzers {
+                    println!("    {}: {} files", analyzer, count);
+                }
+            }
+        }
+        CacheSubcommands::Clear { analyzer } => {
+            let repo = MmapCacheRepository::open().context("Failed to open cache")?;
+
+            if let Some(name) = analyzer {
+                repo.invalidate_analyzer(&name);
+                repo.persist()?;
+                println!("Cleared cache for: {}", name);
+            } else {
+                repo.clear()?;
+                println!("Cleared all cache");
+            }
+        }
+        CacheSubcommands::Rebuild => {
+            let repo = MmapCacheRepository::open().context("Failed to open cache")?;
+            repo.clear()?;
+            println!("Cache cleared. Rebuilding...");
+
+            let registry = create_analyzer_registry();
+            let stats = registry.load_all_stats().await?;
+            registry.persist_cache()?;
+
+            let total_messages: usize = stats.analyzer_stats.iter().map(|s| s.messages.len()).sum();
+
+            println!(
+                "Cache rebuilt with {} messages from {} analyzers",
+                total_messages,
+                stats.analyzer_stats.len()
+            );
+        }
+        CacheSubcommands::Path => {
+            let path = cache_db_path()?;
+            println!("{}", path.display());
+        }
+    }
+
+    Ok(())
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -95,6 +95,8 @@ pub fn run_tui(
                 eprintln!("Error handling watcher event: {e}");
             }
         }
+        // Persist cache when TUI exits
+        stats_manager.persist_cache();
     });
 
     let result = tokio::task::block_in_place(|| {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,7 +1,54 @@
 use std::collections::BTreeMap;
+use std::time::SystemTime;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+
+/// Metadata for cache invalidation - tracks file size, modification time, and parse offset
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct FileMetadata {
+    pub size: u64,
+    pub modified: i64, // Unix timestamp (seconds)
+    /// Byte offset of last successfully parsed position (for delta parsing)
+    #[serde(default)]
+    pub last_parsed_offset: u64,
+}
+
+impl FileMetadata {
+    pub fn from_path(path: &std::path::Path) -> std::io::Result<Self> {
+        let metadata = std::fs::metadata(path)?;
+        let modified = metadata
+            .modified()?
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+
+        Ok(Self {
+            size: metadata.len(),
+            modified,
+            last_parsed_offset: 0, // Will be set after parsing
+        })
+    }
+
+    pub fn is_stale(&self, current: &FileMetadata) -> bool {
+        self.size != current.size || self.modified != current.modified
+    }
+
+    /// Check if the file has been appended to (new data added, no truncation)
+    pub fn is_append_only(&self, current: &FileMetadata) -> bool {
+        current.size > self.last_parsed_offset && current.size >= self.size
+    }
+
+    /// Check if the file was truncated or replaced (requires full reparse)
+    pub fn needs_full_reparse(&self, current: &FileMetadata) -> bool {
+        current.size < self.last_parsed_offset
+    }
+
+    /// Check if file is unchanged (no new data to parse)
+    pub fn is_unchanged(&self, current: &FileMetadata) -> bool {
+        current.size == self.last_parsed_offset && current.size == self.size
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -202,5 +249,78 @@ mod tests {
         assert_eq!(stats.output_tokens, 0);
         assert_eq!(stats.tool_calls, 0);
         assert_eq!(stats.code_lines, 0);
+    }
+
+    // =========================================================================
+    // FILE METADATA TESTS
+    // =========================================================================
+
+    #[test]
+    fn test_file_metadata_from_path() {
+        use tempfile::NamedTempFile;
+
+        let temp_file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(temp_file.path(), "hello world").expect("write to temp file");
+
+        let metadata = FileMetadata::from_path(temp_file.path()).expect("get metadata");
+
+        assert_eq!(metadata.size, 11); // "hello world" is 11 bytes
+        assert!(metadata.modified > 0); // Should have a valid timestamp
+        assert_eq!(metadata.last_parsed_offset, 0); // Default is 0
+    }
+
+    #[test]
+    fn test_file_metadata_from_path_missing_file() {
+        let result = FileMetadata::from_path(std::path::Path::new("/nonexistent/file.txt"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_file_metadata_last_parsed_offset_default() {
+        use tempfile::NamedTempFile;
+
+        let temp_file = NamedTempFile::new().expect("create temp file");
+        std::fs::write(temp_file.path(), "content").expect("write");
+
+        let metadata = FileMetadata::from_path(temp_file.path()).unwrap();
+
+        // from_path always sets last_parsed_offset to 0
+        assert_eq!(metadata.last_parsed_offset, 0);
+    }
+
+    #[test]
+    fn test_file_metadata_is_stale() {
+        let old = FileMetadata {
+            size: 100,
+            modified: 1000,
+            last_parsed_offset: 50,
+        };
+
+        let same = FileMetadata {
+            size: 100,
+            modified: 1000,
+            last_parsed_offset: 100, // Different offset doesn't matter
+        };
+
+        let different_size = FileMetadata {
+            size: 200,
+            modified: 1000,
+            last_parsed_offset: 0,
+        };
+
+        let different_modified = FileMetadata {
+            size: 100,
+            modified: 2000,
+            last_parsed_offset: 0,
+        };
+
+        // Same size and modified time = not stale
+        assert!(!old.is_stale(&same));
+
+        // Different size = stale
+        assert!(old.is_stale(&different_size));
+
+        // Different modified time = stale
+        assert!(old.is_stale(&different_modified));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,7 @@ use chrono::{DateTime, Datelike, Local, Utc};
 use num_format::{Locale, ToFormattedString};
 use serde::{Deserialize, Deserializer};
 use sha2::{Digest, Sha256};
+use xxhash_rust::xxh3::xxh3_64;
 
 use crate::types::{ConversationMessage, DailyStats};
 
@@ -243,6 +244,127 @@ pub fn aggregate_by_date(entries: &[ConversationMessage]) -> BTreeMap<String, Da
     daily_stats
 }
 
+/// Simple per-file aggregation for caching purposes.
+///
+/// Unlike `aggregate_by_date`, this function:
+/// - Does NOT fill in gaps between dates
+/// - Does NOT track conversation start dates (conversations counted per-message date)
+/// - Returns HashMap instead of BTreeMap for faster insertion
+///
+/// This is used by `parse_single_file` implementations to pre-compute daily contributions
+/// for a single file, which are then summed when building full stats.
+pub fn aggregate_by_date_simple(
+    messages: &[ConversationMessage],
+) -> std::collections::HashMap<String, DailyStats> {
+    use std::collections::{HashMap, HashSet};
+
+    let mut daily_stats: HashMap<String, DailyStats> = HashMap::new();
+    // Track conversation start dates to count conversations correctly
+    let mut conversation_start_dates: HashMap<String, String> = HashMap::new();
+
+    // First pass: find the earliest date for each conversation
+    for entry in messages {
+        let timestamp = &entry.date.with_timezone(&Local);
+        let date = timestamp.format("%Y-%m-%d").to_string();
+        let conv_hash = &entry.conversation_hash;
+
+        conversation_start_dates
+            .entry(conv_hash.clone())
+            .and_modify(|existing| {
+                if date < *existing {
+                    *existing = date.clone();
+                }
+            })
+            .or_insert(date);
+    }
+
+    // Track which conversations we've counted per day
+    let mut counted_conversations: HashSet<(String, String)> = HashSet::new();
+
+    for entry in messages {
+        let timestamp = &entry.date.with_timezone(&Local);
+        let date = timestamp.format("%Y-%m-%d").to_string();
+
+        let daily_stats_entry = daily_stats
+            .entry(date.clone())
+            .or_insert_with(|| DailyStats {
+                date: date.clone(),
+                ..Default::default()
+            });
+
+        // Count conversation on its start date (if not already counted)
+        if let Some(start_date) = conversation_start_dates.get(&entry.conversation_hash)
+            && start_date == &date
+        {
+            let key = (date.clone(), entry.conversation_hash.clone());
+            if !counted_conversations.contains(&key) {
+                counted_conversations.insert(key);
+                daily_stats_entry.conversations += 1;
+            }
+        }
+
+        match &entry.model {
+            Some(model) => {
+                // AI message
+                daily_stats_entry.ai_messages += 1;
+                *daily_stats_entry
+                    .models
+                    .entry(model.to_string())
+                    .or_insert(0) += 1;
+
+                // Aggregate all stats
+                daily_stats_entry.stats.cost += entry.stats.cost;
+                daily_stats_entry.stats.input_tokens += entry.stats.input_tokens;
+                daily_stats_entry.stats.output_tokens += entry.stats.output_tokens;
+                daily_stats_entry.stats.reasoning_tokens += entry.stats.reasoning_tokens;
+                daily_stats_entry.stats.cache_creation_tokens += entry.stats.cache_creation_tokens;
+                daily_stats_entry.stats.cache_read_tokens += entry.stats.cache_read_tokens;
+                daily_stats_entry.stats.cached_tokens += entry.stats.cached_tokens;
+                daily_stats_entry.stats.tool_calls += entry.stats.tool_calls;
+                daily_stats_entry.stats.terminal_commands += entry.stats.terminal_commands;
+                daily_stats_entry.stats.file_searches += entry.stats.file_searches;
+                daily_stats_entry.stats.file_content_searches += entry.stats.file_content_searches;
+                daily_stats_entry.stats.files_read += entry.stats.files_read;
+                daily_stats_entry.stats.files_added += entry.stats.files_added;
+                daily_stats_entry.stats.files_edited += entry.stats.files_edited;
+                daily_stats_entry.stats.files_deleted += entry.stats.files_deleted;
+                daily_stats_entry.stats.lines_read += entry.stats.lines_read;
+                daily_stats_entry.stats.lines_added += entry.stats.lines_added;
+                daily_stats_entry.stats.lines_edited += entry.stats.lines_edited;
+                daily_stats_entry.stats.lines_deleted += entry.stats.lines_deleted;
+                daily_stats_entry.stats.bytes_read += entry.stats.bytes_read;
+                daily_stats_entry.stats.bytes_added += entry.stats.bytes_added;
+                daily_stats_entry.stats.bytes_edited += entry.stats.bytes_edited;
+                daily_stats_entry.stats.bytes_deleted += entry.stats.bytes_deleted;
+                daily_stats_entry.stats.todos_created += entry.stats.todos_created;
+                daily_stats_entry.stats.todos_completed += entry.stats.todos_completed;
+                daily_stats_entry.stats.todos_in_progress += entry.stats.todos_in_progress;
+                daily_stats_entry.stats.todo_writes += entry.stats.todo_writes;
+                daily_stats_entry.stats.todo_reads += entry.stats.todo_reads;
+                daily_stats_entry.stats.code_lines += entry.stats.code_lines;
+                daily_stats_entry.stats.docs_lines += entry.stats.docs_lines;
+                daily_stats_entry.stats.data_lines += entry.stats.data_lines;
+                daily_stats_entry.stats.media_lines += entry.stats.media_lines;
+                daily_stats_entry.stats.config_lines += entry.stats.config_lines;
+                daily_stats_entry.stats.other_lines += entry.stats.other_lines;
+            }
+            None => {
+                // User message
+                daily_stats_entry.user_messages += 1;
+
+                // Aggregate user stats too (mostly todo-related)
+                daily_stats_entry.stats.todos_created += entry.stats.todos_created;
+                daily_stats_entry.stats.todos_completed += entry.stats.todos_completed;
+                daily_stats_entry.stats.todos_in_progress += entry.stats.todos_in_progress;
+                daily_stats_entry.stats.todo_writes += entry.stats.todo_writes;
+                daily_stats_entry.stats.todo_reads += entry.stats.todo_reads;
+            }
+        };
+    }
+
+    daily_stats
+}
+
 /// Filters messages to only include those created after a specific date
 pub async fn get_messages_later_than(
     date: i64,
@@ -271,6 +393,48 @@ pub fn hash_text(text: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(text);
     format!("{:x}", hasher.finalize())
+}
+
+/// Fast hash for local deduplication only (NOT for cloud - use hash_text for global_hash)
+pub fn fast_hash(text: &str) -> String {
+    format!("{:016x}", xxh3_64(text.as_bytes()))
+}
+
+/// Parallel deduplication by global_hash using DashMap.
+/// Used by copilot, cline, roo_code, kilo_code analyzers.
+pub fn deduplicate_by_global_hash_parallel(
+    messages: Vec<ConversationMessage>,
+) -> Vec<ConversationMessage> {
+    use dashmap::DashMap;
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+    let seen: DashMap<String, ()> = DashMap::with_capacity(messages.len() / 2);
+    messages
+        .into_par_iter()
+        .filter(|msg| seen.insert(msg.global_hash.clone(), ()).is_none())
+        .collect()
+}
+
+/// Parallel deduplication by local_hash using DashMap.
+/// Used by gemini_cli, qwen_code analyzers.
+/// Messages without local_hash are always kept.
+pub fn deduplicate_by_local_hash_parallel(
+    messages: Vec<ConversationMessage>,
+) -> Vec<ConversationMessage> {
+    use dashmap::DashMap;
+    use rayon::iter::{IntoParallelIterator, ParallelIterator};
+
+    let seen: DashMap<String, ()> = DashMap::with_capacity(messages.len() / 2);
+    messages
+        .into_par_iter()
+        .filter(|msg| {
+            if let Some(local_hash) = &msg.local_hash {
+                seen.insert(local_hash.clone(), ()).is_none()
+            } else {
+                true // Always keep messages without local_hash
+            }
+        })
+        .collect()
 }
 
 /// Custom serde deserializer for RFC3339 timestamp strings to DateTime<Utc>


### PR DESCRIPTION
Introduces caching, parallelization, faster file hashing, cache CLI commands to manipulate cache, and more. This improves performance so much that the warm cache is ~200ms (vs. previous 2s) and cold cache is around ~1s vs. 3s.

- Add persistent file cache with `mmap`/`rkyv` for zero-copy deserialization
- Add `xxhash` for fast local hashing, `DashMap` for parallel deduplication
- Replace glob with `jwalk` for parallel directory walking
- Add `aggregate_by_date_simple` for per-file pre-aggregation
- Add cache CLI commands (`stats`, `clear`, `rebuild`, `path`)
- Update all analyzers to use caching and new utilities
- Update watcher for incremental file change handling
- Add VSCode extension discovery helper for cross-platform support

New dependencies: `jwalk`, `xxhash-rust`, `dashmap`, `futures`, `parking_lot`, `bincode`, `dirs`, `chrono-tz`, `rkyv`, `memmap2`.