### PR TITLE
fix(codex): include entry count in globalHash to prevent duplicates

### DIFF
--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -381,9 +381,10 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                             entries.push(ConversationMessage {
                                 date: wrapper.timestamp,
                                 global_hash: hash_text(&format!(
-                                    "{}_{}",
+                                    "{}_{}_user_{}",
                                     file_path_str,
-                                    wrapper.timestamp.to_rfc3339()
+                                    wrapper.timestamp.to_rfc3339(),
+                                    entries.len()
                                 )),
                                 local_hash: None,
                                 conversation_hash: hash_text(&file_path_str),
@@ -418,9 +419,10 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                                     application: Application::CodexCli,
                                     model: Some(model_state.name.clone()),
                                     global_hash: hash_text(&format!(
-                                        "{}_{}_assistant",
+                                        "{}_{}_assistant_{}",
                                         file_path_str,
-                                        wrapper.timestamp.to_rfc3339()
+                                        wrapper.timestamp.to_rfc3339(),
+                                        entries.len()
                                     )),
                                     local_hash: None,
                                     conversation_hash: hash_text(&file_path_str),
@@ -482,9 +484,10 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                                 application: Application::CodexCli,
                                 model: Some(model_state.name.clone()),
                                 global_hash: hash_text(&format!(
-                                    "{}_{}_token",
+                                    "{}_{}_token_{}",
                                     file_path_str,
-                                    wrapper.timestamp.to_rfc3339()
+                                    wrapper.timestamp.to_rfc3339(),
+                                    entries.len()
                                 )),
                                 local_hash: None,
                                 conversation_hash: hash_text(&file_path_str),


### PR DESCRIPTION
## Summary
- Messages with identical timestamps (within the same millisecond) were getting the same globalHash
- This caused `skipDuplicates` on the cloud to silently drop them during upload
- Result: ~10% data loss ($7.29 of $73.74 in one user's case, 660 messages dropped)

## Fix
Include `entries.len()` in the hash to ensure uniqueness even when timestamps collide:
- User messages: `{file}_{timestamp}_user_{count}`
- Assistant messages: `{file}_{timestamp}_assistant_{count}`
- Token events: `{file}_{timestamp}_token_{count}`

## Test plan
- [x] Verified no duplicate globalHash values after fix (was 99 duplicates, now 0)
- [x] Re-upload data and verify cloud totals match CLI totals