### PR TITLE
feat(tui): add 'r' hotkey to toggle reverse sort order

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -151,6 +151,18 @@ pub fn run_tui(
     result
 }
 
+/// Result state from running the TUI in test mode.
+#[cfg(test)]
+#[derive(Debug, Clone)]
+pub struct TestRunResult {
+    /// Whether sort order is currently reversed.
+    pub sort_reversed: bool,
+    /// The day filter for each tab (set when drilling into a specific day).
+    pub session_day_filters: Vec<Option<String>>,
+    /// The selected row index for each tab.
+    pub selected_rows: Vec<Option<usize>>,
+}
+
 #[cfg(test)]
 #[allow(clippy::too_many_arguments)]
 async fn run_app_for_tests<B, FPoll, FRead>(
@@ -167,7 +179,7 @@ async fn run_app_for_tests<B, FPoll, FRead>(
     mut poll: FPoll,
     mut read: FRead,
     max_iterations: usize,
-) -> Result<()>
+) -> Result<TestRunResult>
 where
     B: ratatui::backend::Backend,
     FPoll: FnMut(Duration) -> std::io::Result<bool>,
@@ -663,7 +675,11 @@ where
         }
     }
 
-    Ok(())
+    Ok(TestRunResult {
+        sort_reversed,
+        session_day_filters,
+        selected_rows: table_states.iter().map(|ts| ts.selected()).collect(),
+    })
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,6 +1,6 @@
 use crate::tui::logic::*;
 use crate::tui::{
-    StatsViewMode, UploadStatus, create_upload_progress_callback, run_app_for_tests,
+    StatsViewMode, TestRunResult, UploadStatus, create_upload_progress_callback, run_app_for_tests,
     show_upload_error, show_upload_success, update_day_filters, update_table_states,
     update_window_offsets,
 };
@@ -103,11 +103,17 @@ fn make_multi_single_tool_two_days() -> MultiAnalyzerStats {
     }
 }
 
+struct TuiTestResult {
+    selected_tab: usize,
+    stats_view_mode: StatsViewMode,
+    test_state: TestRunResult,
+}
+
 fn run_tui_with_events(
     stats: MultiAnalyzerStats,
     events: Vec<Event>,
     max_iterations: usize,
-) -> (usize, StatsViewMode) {
+) -> TuiTestResult {
     let backend = TestBackend::new(80, 24);
     let mut terminal = Terminal::new(backend).expect("terminal");
 
@@ -136,7 +142,7 @@ fn run_tui_with_events(
         .build()
         .expect("runtime");
 
-    rt.block_on(async {
+    let test_state = rt.block_on(async {
         run_app_for_tests(
             &mut terminal,
             rx,
@@ -157,10 +163,14 @@ fn run_tui_with_events(
             max_iterations,
         )
         .await
-        .expect("run_app_for_tests ok");
+        .expect("run_app_for_tests ok")
     });
 
-    (selected_tab, stats_view_mode)
+    TuiTestResult {
+        selected_tab,
+        stats_view_mode,
+        test_state,
+    }
 }
 
 #[test]
@@ -1175,9 +1185,9 @@ fn test_tui_quit_behavior() {
         KeyModifiers::empty(),
     ))];
 
-    let (selected_tab, view_mode) = run_tui_with_events(multi, events, 10);
-    assert_eq!(selected_tab, 0);
-    assert_eq!(view_mode, StatsViewMode::Daily);
+    let result = run_tui_with_events(multi, events, 10);
+    assert_eq!(result.selected_tab, 0);
+    assert_eq!(result.stats_view_mode, StatsViewMode::Daily);
 }
 
 #[test]
@@ -1190,9 +1200,9 @@ fn test_tui_tab_switch_and_session_toggle() {
         Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty())),
     ];
 
-    let (selected_tab, view_mode) = run_tui_with_events(multi, events, 50);
-    assert_eq!(selected_tab, 1);
-    assert_eq!(view_mode, StatsViewMode::Session);
+    let result = run_tui_with_events(multi, events, 50);
+    assert_eq!(result.selected_tab, 1);
+    assert_eq!(result.stats_view_mode, StatsViewMode::Session);
 }
 
 #[test]
@@ -1212,8 +1222,8 @@ fn test_tui_date_jump_behavior() {
         Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty())),
     ];
 
-    let (_selected_tab, view_mode) = run_tui_with_events(multi, events, 80);
-    assert_eq!(view_mode, StatsViewMode::Daily);
+    let result = run_tui_with_events(multi, events, 80);
+    assert_eq!(result.stats_view_mode, StatsViewMode::Daily);
 }
 
 #[test]
@@ -1226,8 +1236,8 @@ fn test_tui_drill_into_session_with_enter() {
         Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty())),
     ];
 
-    let (_selected_tab, view_mode) = run_tui_with_events(multi, events, 80);
-    assert_eq!(view_mode, StatsViewMode::Session);
+    let result = run_tui_with_events(multi, events, 80);
+    assert_eq!(result.stats_view_mode, StatsViewMode::Session);
 }
 
 #[test]
@@ -1426,5 +1436,81 @@ fn test_single_message_single_session_state() {
     assert_eq!(
         sessions[0].session_name,
         Some("Single Message Session".to_string())
+    );
+}
+
+// ============================================================================
+// REVERSE SORT ('r' KEY) INTEGRATION TESTS
+// ============================================================================
+
+#[test]
+fn test_tui_r_key_toggles_sort_order() {
+    // make_multi_single_tool_two_days has "2025-01-01" and "2025-02-01"
+    // Normal: row 0 = "2025-01-01", Reversed: row 0 = "2025-02-01"
+
+    // Toggle once and drill - selection stays at row 0, but item changes
+    let events = vec![
+        Event::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty())),
+        Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty())),
+        Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty())),
+    ];
+    let result = run_tui_with_events(make_multi_single_tool_two_days(), events, 50);
+    assert!(result.test_state.sort_reversed);
+    assert_eq!(
+        result.test_state.selected_rows[0],
+        Some(0),
+        "Selection should stay at row 0"
+    );
+    assert_eq!(
+        result.test_state.session_day_filters[0],
+        Some("2025-02-01".to_string()),
+        "Row 0 should now be latest date after reverse"
+    );
+
+    // Toggle twice and drill - back to normal order
+    let events = vec![
+        Event::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty())),
+        Event::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty())),
+        Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty())),
+        Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty())),
+    ];
+    let result = run_tui_with_events(make_multi_single_tool_two_days(), events, 50);
+    assert!(!result.test_state.sort_reversed);
+    assert_eq!(result.test_state.selected_rows[0], Some(0));
+    assert_eq!(
+        result.test_state.session_day_filters[0],
+        Some("2025-01-01".to_string()),
+        "Row 0 should be earliest date after double toggle"
+    );
+}
+
+#[test]
+fn test_tui_drill_selects_correct_day_for_sort_order() {
+    // make_multi_single_tool_two_days has dates "2025-01-01" and "2025-02-01"
+    // Normal: row 0 = earliest, Reversed: row 0 = latest
+
+    // Normal order - first row is earliest
+    let events = vec![
+        Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty())),
+        Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty())),
+    ];
+    let result = run_tui_with_events(make_multi_single_tool_two_days(), events, 80);
+    assert_eq!(
+        result.test_state.session_day_filters[0],
+        Some("2025-01-01".to_string()),
+        "Normal order: first row should be earliest date"
+    );
+
+    // Reversed order - first row is latest
+    let events = vec![
+        Event::Key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty())),
+        Event::Key(KeyEvent::new(KeyCode::Enter, KeyModifiers::empty())),
+        Event::Key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty())),
+    ];
+    let result = run_tui_with_events(make_multi_single_tool_two_days(), events, 80);
+    assert_eq!(
+        result.test_state.session_day_filters[0],
+        Some("2025-02-01".to_string()),
+        "Reversed order: first row should be latest date"
     );
 }


### PR DESCRIPTION
## Summary
- Adds 'r' hotkey to toggle between ascending and descending sort order in the TUI
- Provides a quick way to reverse the current sort without changing the sort column

## Context

When you have a long message history- in my case, 4656, it can be a chore to scroll down using PgDown/PgUp.
[For me it's also disorienting when watching live]

This adds a simple hotkey `r` to reverse the order the items are drawn.

This reverse is not at the data level; rather, we reverse at the rendering stage- and in the cases where items are referenced by index. Where possible, we opt to just iterate in reverse where we're already using iteration.
