### PR TITLE
Fix file watcher to detect new sessions in nested directories

### DIFF
--- a/src/analyzers/cline.rs
+++ b/src/analyzers/cline.rs
@@ -1,4 +1,6 @@
-use crate::analyzer::{Analyzer, DataSource, discover_vscode_extension_sources};
+use crate::analyzer::{
+    Analyzer, DataSource, discover_vscode_extension_sources, get_vscode_extension_tasks_dirs,
+};
 use crate::types::{AgenticCodingToolStats, Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::hash_text;
 use anyhow::{Context, Result};
@@ -7,7 +9,7 @@ use chrono::{DateTime, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const CLINE_EXTENSION_ID: &str = "saoudrizwan.claude-dev";
 
@@ -352,12 +354,15 @@ impl Analyzer for ClineAnalyzer {
         self.discover_data_sources()
             .is_ok_and(|sources| !sources.is_empty())
     }
+
+    fn get_watch_directories(&self) -> Vec<PathBuf> {
+        get_vscode_extension_tasks_dirs(CLINE_EXTENSION_ID)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn test_extract_project_hash() {

--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::Read;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::analyzer::{Analyzer, DataSource};
 use crate::models::calculate_total_cost;
@@ -20,6 +20,11 @@ pub struct CodexCliAnalyzer;
 impl CodexCliAnalyzer {
     pub fn new() -> Self {
         Self
+    }
+
+    /// Returns the root directory for Codex CLI session data.
+    fn data_dir() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join(".codex").join("sessions"))
     }
 }
 
@@ -43,21 +48,19 @@ impl Analyzer for CodexCliAnalyzer {
     fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
         let mut sources = Vec::new();
 
-        if let Some(home_dir) = dirs::home_dir() {
-            let sessions_dir = home_dir.join(".codex").join("sessions");
-
-            if sessions_dir.is_dir() {
-                // jwalk walks directories in parallel, recursively
-                for entry in WalkDir::new(&sessions_dir)
-                    .into_iter()
-                    .filter_map(|e| e.ok())
-                    .filter(|e| {
-                        e.file_type().is_file()
-                            && e.path().extension().is_some_and(|ext| ext == "jsonl")
-                    })
-                {
-                    sources.push(DataSource { path: entry.path() });
-                }
+        if let Some(sessions_dir) = Self::data_dir()
+            && sessions_dir.is_dir()
+        {
+            // jwalk walks directories in parallel, recursively
+            for entry in WalkDir::new(&sessions_dir)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.file_type().is_file()
+                        && e.path().extension().is_some_and(|ext| ext == "jsonl")
+                })
+            {
+                sources.push(DataSource { path: entry.path() });
             }
         }
 
@@ -115,6 +118,13 @@ impl Analyzer for CodexCliAnalyzer {
     fn is_available(&self) -> bool {
         self.discover_data_sources()
             .is_ok_and(|sources| !sources.is_empty())
+    }
+
+    fn get_watch_directories(&self) -> Vec<PathBuf> {
+        Self::data_dir()
+            .filter(|d| d.is_dir())
+            .into_iter()
+            .collect()
     }
 }
 

--- a/src/analyzers/kilo_code.rs
+++ b/src/analyzers/kilo_code.rs
@@ -1,4 +1,6 @@
-use crate::analyzer::{Analyzer, DataSource, discover_vscode_extension_sources};
+use crate::analyzer::{
+    Analyzer, DataSource, discover_vscode_extension_sources, get_vscode_extension_tasks_dirs,
+};
 use crate::types::{AgenticCodingToolStats, Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::hash_text;
 use anyhow::{Context, Result};
@@ -7,7 +9,7 @@ use chrono::{DateTime, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const KILO_CODE_EXTENSION_ID: &str = "kilocode.kilo-code";
 
@@ -349,12 +351,15 @@ impl Analyzer for KiloCodeAnalyzer {
         self.discover_data_sources()
             .is_ok_and(|sources| !sources.is_empty())
     }
+
+    fn get_watch_directories(&self) -> Vec<PathBuf> {
+        get_vscode_extension_tasks_dirs(KILO_CODE_EXTENSION_ID)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn test_extract_project_hash() {

--- a/src/analyzers/qwen_code.rs
+++ b/src/analyzers/qwen_code.rs
@@ -11,13 +11,18 @@ use jwalk::WalkDir;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub struct QwenCodeAnalyzer;
 
 impl QwenCodeAnalyzer {
     pub fn new() -> Self {
         Self
+    }
+
+    /// Returns the root directory for Qwen Code data.
+    fn data_dir() -> Option<PathBuf> {
+        dirs::home_dir().map(|h| h.join(".qwen").join("tmp"))
     }
 }
 
@@ -301,28 +306,26 @@ impl Analyzer for QwenCodeAnalyzer {
     fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
         let mut sources = Vec::new();
 
-        if let Some(home_dir) = dirs::home_dir() {
-            let tmp_dir = home_dir.join(".qwen").join("tmp");
-
-            if tmp_dir.is_dir() {
-                // Pattern: ~/.qwen/tmp/*/chats/*.json
-                // jwalk walks directories in parallel
-                for entry in WalkDir::new(&tmp_dir)
-                    .min_depth(3) // */chats/*.json
-                    .max_depth(3)
-                    .into_iter()
-                    .filter_map(|e| e.ok())
-                    .filter(|e| {
-                        e.file_type().is_file()
-                            && e.path().extension().is_some_and(|ext| ext == "json")
-                            && e.path()
-                                .parent()
-                                .and_then(|p| p.file_name())
-                                .is_some_and(|name| name == "chats")
-                    })
-                {
-                    sources.push(DataSource { path: entry.path() });
-                }
+        if let Some(tmp_dir) = Self::data_dir()
+            && tmp_dir.is_dir()
+        {
+            // Pattern: ~/.qwen/tmp/*/chats/*.json
+            // jwalk walks directories in parallel
+            for entry in WalkDir::new(&tmp_dir)
+                .min_depth(3) // */chats/*.json
+                .max_depth(3)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| {
+                    e.file_type().is_file()
+                        && e.path().extension().is_some_and(|ext| ext == "json")
+                        && e.path()
+                            .parent()
+                            .and_then(|p| p.file_name())
+                            .is_some_and(|name| name == "chats")
+                })
+            {
+                sources.push(DataSource { path: entry.path() });
             }
         }
 
@@ -376,5 +379,12 @@ impl Analyzer for QwenCodeAnalyzer {
     fn is_available(&self) -> bool {
         self.discover_data_sources()
             .is_ok_and(|sources| !sources.is_empty())
+    }
+
+    fn get_watch_directories(&self) -> Vec<PathBuf> {
+        Self::data_dir()
+            .filter(|d| d.is_dir())
+            .into_iter()
+            .collect()
     }
 }

--- a/src/analyzers/roo_code.rs
+++ b/src/analyzers/roo_code.rs
@@ -1,4 +1,6 @@
-use crate::analyzer::{Analyzer, DataSource, discover_vscode_extension_sources};
+use crate::analyzer::{
+    Analyzer, DataSource, discover_vscode_extension_sources, get_vscode_extension_tasks_dirs,
+};
 use crate::types::{AgenticCodingToolStats, Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::hash_text;
 use anyhow::{Context, Result};
@@ -7,7 +9,7 @@ use chrono::{DateTime, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 const ROO_CODE_EXTENSION_ID: &str = "rooveterinaryinc.roo-cline";
 
@@ -376,12 +378,15 @@ impl Analyzer for RooCodeAnalyzer {
         self.discover_data_sources()
             .is_ok_and(|sources| !sources.is_empty())
     }
+
+    fn get_watch_directories(&self) -> Vec<PathBuf> {
+        get_vscode_extension_tasks_dirs(ROO_CODE_EXTENSION_ID)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn test_extract_project_hash() {


### PR DESCRIPTION
## Summary
- Adds `get_watch_directories()` to the `Analyzer` trait so analyzers can specify root data directories for file watching
- Enables detecting new conversation sessions/subdirectories in real-time (not just edits to existing files)

Previously, the file watcher only watched parent directories of already-discovered data sources. This meant new sessions created in nested structures (e.g., `~/.gemini/tmp/{session}/chats/*.json`) were missed until restart. Now you can see new sessions appear in real time.

## Testing
Manually verified with:
- Cline
- Gemini CLI
- Claude Code
- OpenCode
- Roo

Changes are trivial- but tested just in case.

I couldn't get copilot to show up though on my end, neither before or after PR. Maybe a NixOS thing, or maybe a VS change.