### PR TITLE
fix(analyzers): use updated_at timestamp for accurate streaming token capture

### DIFF
--- a/src/upload.rs
+++ b/src/upload.rs
@@ -13,7 +13,7 @@ static HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 pub fn get_http_client() -> &'static reqwest::Client {
     HTTP_CLIENT.get_or_init(|| {
         reqwest::Client::builder()
-            .timeout(Duration::from_secs(30))
+            .timeout(Duration::from_secs(120))
             .danger_accept_invalid_certs(true)
             .build()
             .expect("Failed to create HTTP client")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced message timestamp accuracy by capturing when messages are updated, not just when created.
  * Extended upload timeout to improve reliability for users on slower network connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->