### PR TITLE
feat: add Claude Sonnet 4.6 pricing

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -401,6 +401,17 @@ static MODEL_INDEX: phf::Map<&'static str, ModelInfo> = phf_map! {
         },
         is_estimated: false,
     },
+    "claude-sonnet-4-6" => ModelInfo {
+        pricing: PricingStructure::Flat {
+            input_per_1m: 3.0,
+            output_per_1m: 15.0,
+        },
+        caching: CachingSupport::Anthropic {
+            cache_write_per_1m: 3.75,
+            cache_read_per_1m: 0.3,
+        },
+        is_estimated: false,
+    },
     "claude-sonnet-4-5" => ModelInfo {
         pricing: PricingStructure::Flat {
             input_per_1m: 3.0,
@@ -837,6 +848,8 @@ static MODEL_ALIASES: phf::Map<&'static str, &'static str> = phf_map! {
     "claude-sonnet-4" => "claude-sonnet-4",
     "claude-sonnet-4-20250514" => "claude-sonnet-4",
     "claude-sonnet-4-0" => "claude-sonnet-4",
+    "claude-sonnet-4.6" => "claude-sonnet-4-6",
+    "claude-sonnet-4-6" => "claude-sonnet-4-6",
     "claude-sonnet-4.5" => "claude-sonnet-4-5",
     "claude-sonnet-4-5" => "claude-sonnet-4-5",
     "claude-sonnet-4-5-20250929" => "claude-sonnet-4-5",


### PR DESCRIPTION
Adds Claude Sonnet 4.6 to the model index.

- Same pricing as Sonnet 4.5 ($3/1M input, $15/1M output)
- No date suffix, following the same pattern as Opus 4.6
- Aliases: `claude-sonnet-4-6`, `claude-sonnet-4.6`