### PR TITLE
fix(gemini-cli): accept multi-modal content (string | Part | Part[])

### DIFF
--- a/src/analyzers/gemini_cli.rs
+++ b/src/analyzers/gemini_cli.rs
@@ -42,13 +42,15 @@ enum GeminiCliMessage {
         id: String,
         #[serde(deserialize_with = "deserialize_utc_timestamp")]
         timestamp: DateTime<Utc>,
-        content: String,
+        #[serde(default)]
+        content: Option<GeminiCliContent>,
     },
     Gemini {
         id: String,
         #[serde(deserialize_with = "deserialize_utc_timestamp")]
         timestamp: DateTime<Utc>,
-        content: String,
+        #[serde(default)]
+        content: Option<GeminiCliContent>,
         model: String,
         #[serde(default)]
         thoughts: Vec<simd_json::OwnedValue>,
@@ -60,20 +62,66 @@ enum GeminiCliMessage {
         id: String,
         #[serde(deserialize_with = "deserialize_utc_timestamp")]
         timestamp: DateTime<Utc>,
-        content: String,
+        #[serde(default)]
+        content: Option<GeminiCliContent>,
     },
     Error {
         id: String,
         #[serde(deserialize_with = "deserialize_utc_timestamp")]
         timestamp: DateTime<Utc>,
-        content: String,
+        #[serde(default)]
+        content: Option<GeminiCliContent>,
     },
     Info {
         id: String,
         #[serde(deserialize_with = "deserialize_utc_timestamp")]
         timestamp: DateTime<Utc>,
-        content: String,
+        #[serde(default)]
+        content: Option<GeminiCliContent>,
     },
+}
+
+/// A single `Part` from Gemini CLI's multi-modal content. Only `text` is
+/// consumed by splitrail; any other fields (e.g. `inlineData`, `fileData`,
+/// `functionCall`) are silently ignored by serde's default behaviour, which
+/// is what we want — the schema is still evolving upstream and we don't want
+/// unrecognised part kinds to abort parsing.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+struct GeminiCliPart {
+    #[serde(default)]
+    text: Option<String>,
+}
+
+/// The `content` field on a Gemini CLI message. Mirrors `PartListUnion` from
+/// `@google/genai`: it can be a plain string (legacy format), a single `Part`
+/// object, or an array of `Part` objects (current format, since Gemini CLI
+/// changed its schema — see issue #137).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+enum GeminiCliContent {
+    Text(String),
+    Part(GeminiCliPart),
+    Parts(Vec<GeminiCliPart>),
+}
+
+impl GeminiCliContent {
+    /// Extract a concatenated plain-text representation of the content,
+    /// ignoring non-text parts (images, function calls, etc.).
+    fn as_text(&self) -> String {
+        match self {
+            GeminiCliContent::Text(s) => s.clone(),
+            GeminiCliContent::Part(p) => p.text.clone().unwrap_or_default(),
+            GeminiCliContent::Parts(ps) => {
+                let mut out = String::new();
+                for p in ps {
+                    if let Some(t) = &p.text {
+                        out.push_str(t);
+                    }
+                }
+                out
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -216,15 +264,20 @@ fn parse_json_session_file(file_path: &Path) -> Result<Vec<ConversationMessage>>
                 timestamp,
                 content,
             } => {
-                if fallback_session_name.is_none() && !content.is_empty() {
-                    let text_str = content;
-                    let truncated = if text_str.chars().count() > 50 {
-                        let chars: String = text_str.chars().take(50).collect();
-                        format!("{}...", chars)
-                    } else {
-                        text_str
-                    };
-                    fallback_session_name = Some(truncated);
+                if fallback_session_name.is_none() {
+                    let text_str = content
+                        .as_ref()
+                        .map(GeminiCliContent::as_text)
+                        .unwrap_or_default();
+                    if !text_str.is_empty() {
+                        let truncated = if text_str.chars().count() > 50 {
+                            let chars: String = text_str.chars().take(50).collect();
+                            format!("{chars}...")
+                        } else {
+                            text_str
+                        };
+                        fallback_session_name = Some(truncated);
+                    }
                 }
 
                 entries.push(ConversationMessage {

--- a/src/analyzers/tests/gemini_cli.rs
+++ b/src/analyzers/tests/gemini_cli.rs
@@ -4,13 +4,18 @@ use std::fs::File;
 use std::io::Write;
 use tempfile::tempdir;
 
+fn write_session(session_dir: &std::path::Path, body: &str) -> std::path::PathBuf {
+    std::fs::create_dir_all(session_dir).unwrap();
+    let session_path = session_dir.join("session.json");
+    let mut file = File::create(&session_path).unwrap();
+    file.write_all(body.as_bytes()).unwrap();
+    session_path
+}
+
 #[tokio::test]
 async fn test_gemini_cli_reasoning_tokens() {
     let dir = tempdir().unwrap();
     let project_dir = dir.path().join("tmp").join("project-123").join("chats");
-    std::fs::create_dir_all(&project_dir).unwrap();
-    let session_path = project_dir.join("session.json");
-
     let json_content = r#"{
         "sessionId": "sess-123",
         "projectHash": "proj-hash",
@@ -40,9 +45,7 @@ async fn test_gemini_cli_reasoning_tokens() {
             }
         ]
     }"#;
-
-    let mut file = File::create(&session_path).unwrap();
-    file.write_all(json_content.as_bytes()).unwrap();
+    let session_path = write_session(&project_dir, json_content);
 
     let analyzer = GeminiCliAnalyzer::new();
 
@@ -59,4 +62,286 @@ async fn test_gemini_cli_reasoning_tokens() {
     assert_eq!(assistant_msg.stats.reasoning_tokens, 123);
     assert_eq!(assistant_msg.stats.input_tokens, 10);
     assert_eq!(assistant_msg.stats.output_tokens, 20);
+}
+
+/// Regression test for issue #137: Gemini CLI switched its `content` field
+/// from a plain string to a multi-modal `PartListUnion`. The parser must now
+/// accept arrays of `Part` objects for any message type (user, gemini,
+/// system, error, info).
+#[tokio::test]
+async fn test_gemini_cli_content_array_of_parts() {
+    let dir = tempdir().unwrap();
+    let project_dir = dir.path().join("tmp").join("project-array").join("chats");
+    let json_content = r#"{
+        "sessionId": "sess-array",
+        "projectHash": "proj-hash",
+        "startTime": "2025-11-20T10:00:00Z",
+        "lastUpdated": "2025-11-20T10:05:00Z",
+        "messages": [
+            {
+                "type": "user",
+                "id": "msg-1",
+                "timestamp": "2025-11-20T10:00:00Z",
+                "content": [
+                    {"text": "Summarise this file"}
+                ]
+            },
+            {
+                "type": "gemini",
+                "id": "msg-2",
+                "timestamp": "2025-11-20T10:00:05Z",
+                "content": [
+                    {"text": "Sure, here's the summary..."}
+                ],
+                "model": "gemini-2.5-pro",
+                "tokens": {
+                    "input": 42,
+                    "output": 17,
+                    "thoughts": 3,
+                    "cached": 0,
+                    "tool": 0,
+                    "total": 62
+                }
+            }
+        ]
+    }"#;
+    let session_path = write_session(&project_dir, json_content);
+
+    let analyzer = GeminiCliAnalyzer::new();
+    let source = crate::analyzer::DataSource { path: session_path };
+    let messages = analyzer.parse_sources_parallel(&[source]);
+
+    // Both messages must parse successfully.
+    assert_eq!(messages.len(), 2);
+
+    // The user's first-text is used as a session-name fallback. It must survive
+    // the array-of-parts shape.
+    let user_msg = messages
+        .iter()
+        .find(|m| m.role == crate::types::MessageRole::User)
+        .unwrap();
+    assert_eq!(
+        user_msg.session_name.as_deref(),
+        Some("Summarise this file")
+    );
+
+    // Assistant token counts must still be wired up.
+    let assistant_msg = messages
+        .iter()
+        .find(|m| m.role == crate::types::MessageRole::Assistant)
+        .unwrap();
+    assert_eq!(assistant_msg.stats.input_tokens, 42);
+    assert_eq!(assistant_msg.stats.output_tokens, 17);
+}
+
+/// A mixed array with non-text parts (e.g. `inlineData`) must still be
+/// accepted — unknown part fields are ignored and the text parts contribute
+/// to the session-name fallback.
+#[tokio::test]
+async fn test_gemini_cli_content_mixed_parts() {
+    let dir = tempdir().unwrap();
+    let project_dir = dir.path().join("tmp").join("project-mixed").join("chats");
+    let json_content = r#"{
+        "sessionId": "sess-mixed",
+        "projectHash": "proj-hash",
+        "startTime": "2025-11-20T10:00:00Z",
+        "lastUpdated": "2025-11-20T10:05:00Z",
+        "messages": [
+            {
+                "type": "user",
+                "id": "msg-1",
+                "timestamp": "2025-11-20T10:00:00Z",
+                "content": [
+                    {"text": "Look at this image: "},
+                    {"inlineData": {"mimeType": "image/png", "data": "iVBORw0..."}},
+                    {"text": "what is it?"}
+                ]
+            }
+        ]
+    }"#;
+    let session_path = write_session(&project_dir, json_content);
+
+    let analyzer = GeminiCliAnalyzer::new();
+    let source = crate::analyzer::DataSource { path: session_path };
+    let messages = analyzer.parse_sources_parallel(&[source]);
+
+    assert_eq!(messages.len(), 1);
+    let user_msg = &messages[0];
+    assert_eq!(user_msg.role, crate::types::MessageRole::User);
+    assert_eq!(
+        user_msg.session_name.as_deref(),
+        Some("Look at this image: what is it?"),
+    );
+}
+
+/// `PartListUnion` also allows a single `Part` object (not wrapped in an
+/// array). Accept it too.
+#[tokio::test]
+async fn test_gemini_cli_content_single_part_object() {
+    let dir = tempdir().unwrap();
+    let project_dir = dir
+        .path()
+        .join("tmp")
+        .join("project-singlepart")
+        .join("chats");
+    let json_content = r#"{
+        "sessionId": "sess-singlepart",
+        "projectHash": "proj-hash",
+        "startTime": "2025-11-20T10:00:00Z",
+        "lastUpdated": "2025-11-20T10:05:00Z",
+        "messages": [
+            {
+                "type": "user",
+                "id": "msg-1",
+                "timestamp": "2025-11-20T10:00:00Z",
+                "content": {"text": "single part hello"}
+            }
+        ]
+    }"#;
+    let session_path = write_session(&project_dir, json_content);
+
+    let analyzer = GeminiCliAnalyzer::new();
+    let source = crate::analyzer::DataSource { path: session_path };
+    let messages = analyzer.parse_sources_parallel(&[source]);
+
+    assert_eq!(messages.len(), 1);
+    assert_eq!(
+        messages[0].session_name.as_deref(),
+        Some("single part hello"),
+    );
+}
+
+/// A long user-message text must be truncated to the first 50 chars even when
+/// it arrives as an array of parts.
+#[tokio::test]
+async fn test_gemini_cli_content_array_session_name_truncated() {
+    let dir = tempdir().unwrap();
+    let project_dir = dir.path().join("tmp").join("project-trunc").join("chats");
+    let json_content = r#"{
+        "sessionId": "sess-trunc",
+        "projectHash": "proj-hash",
+        "startTime": "2025-11-20T10:00:00Z",
+        "lastUpdated": "2025-11-20T10:05:00Z",
+        "messages": [
+            {
+                "type": "user",
+                "id": "msg-1",
+                "timestamp": "2025-11-20T10:00:00Z",
+                "content": [
+                    {"text": "This prompt is definitely longer than fifty characters by design."}
+                ]
+            }
+        ]
+    }"#;
+    let session_path = write_session(&project_dir, json_content);
+
+    let analyzer = GeminiCliAnalyzer::new();
+    let source = crate::analyzer::DataSource { path: session_path };
+    let messages = analyzer.parse_sources_parallel(&[source]);
+
+    assert_eq!(messages.len(), 1);
+    let name = messages[0].session_name.as_deref().unwrap();
+    // 50 chars plus trailing "..."
+    assert!(name.ends_with("..."));
+    assert_eq!(
+        name,
+        "This prompt is definitely longer than fifty charac..."
+    );
+}
+
+/// An empty/missing/null content field should not crash parsing — the
+/// message is still recorded (without a session-name fallback from it).
+#[tokio::test]
+async fn test_gemini_cli_content_missing_or_null() {
+    let dir = tempdir().unwrap();
+    let project_dir = dir.path().join("tmp").join("project-missing").join("chats");
+    let json_content = r#"{
+        "sessionId": "sess-missing",
+        "projectHash": "proj-hash",
+        "startTime": "2025-11-20T10:00:00Z",
+        "lastUpdated": "2025-11-20T10:05:00Z",
+        "messages": [
+            {
+                "type": "user",
+                "id": "msg-1",
+                "timestamp": "2025-11-20T10:00:00Z"
+            },
+            {
+                "type": "user",
+                "id": "msg-2",
+                "timestamp": "2025-11-20T10:00:01Z",
+                "content": null
+            },
+            {
+                "type": "user",
+                "id": "msg-3",
+                "timestamp": "2025-11-20T10:00:02Z",
+                "content": "finally some text"
+            }
+        ]
+    }"#;
+    let session_path = write_session(&project_dir, json_content);
+
+    let analyzer = GeminiCliAnalyzer::new();
+    let source = crate::analyzer::DataSource { path: session_path };
+    let messages = analyzer.parse_sources_parallel(&[source]);
+
+    assert_eq!(messages.len(), 3);
+    // The empty/null messages do not contribute a session name; the last one does.
+    let names: Vec<_> = messages
+        .iter()
+        .filter_map(|m| m.session_name.clone())
+        .collect();
+    assert!(names.iter().any(|n| n == "finally some text"));
+}
+
+/// The exact failure case from issue #137: a session containing a user
+/// message whose `content` is an array of `{ "text": "..." }` parts.
+/// Before the fix this produced:
+///   `Serde("invalid type: sequence, expected a string")`.
+#[tokio::test]
+async fn test_gemini_cli_issue_137_regression() {
+    let dir = tempdir().unwrap();
+    let project_dir = dir.path().join("tmp").join("project-137").join("chats");
+    // Schema reproduced from the issue report.
+    let json_content = r#"{
+        "sessionId": "sess-137",
+        "projectHash": "proj-hash",
+        "startTime": "2025-11-20T10:00:00Z",
+        "lastUpdated": "2025-11-20T10:05:00Z",
+        "messages": [
+            {
+                "type": "user",
+                "id": "u-1",
+                "timestamp": "2025-11-20T10:00:00Z",
+                "content": [
+                    {"text": "my prompt..."}
+                ]
+            },
+            {
+                "type": "gemini",
+                "id": "g-1",
+                "timestamp": "2025-11-20T10:00:05Z",
+                "content": "response...",
+                "model": "gemini-3-pro",
+                "tokens": {
+                    "input": 1,
+                    "output": 2,
+                    "thoughts": 0,
+                    "cached": 0,
+                    "tool": 0,
+                    "total": 3
+                }
+            }
+        ]
+    }"#;
+    let session_path = write_session(&project_dir, json_content);
+
+    // The parse must succeed — prior to the fix, parse_source() returned Err.
+    let analyzer = GeminiCliAnalyzer::new();
+    let source = crate::analyzer::DataSource { path: session_path };
+    let parsed = analyzer
+        .parse_source(&source)
+        .expect("issue #137 regression: parse_source must accept array-of-parts content");
+    assert_eq!(parsed.len(), 2);
 }


### PR DESCRIPTION
Closes #137.

## Problem

Gemini CLI 0.35.x changed the `content` field of chat-session messages from a plain string to a `PartListUnion` (from `@google/genai`), which may be:

- a plain string (legacy form) — `"content": "my prompt..."`
- a single `Part` object — `"content": {"text": "my prompt..."}`
- an array of `Part` objects (current form) — `"content": [{"text": "my prompt..."}]`

The previous parser typed `content: String` and therefore failed on any session from the new format with:

```
Serde("invalid type: sequence, expected a string") at character 0
```

## Fix

Added a tiny untagged enum mirroring the upstream shape:

```rust
#[derive(Debug, Clone, Serialize, Deserialize)]
#[serde(untagged)]
enum GeminiCliContent {
    Text(String),
    Part(GeminiCliPart),
    Parts(Vec<GeminiCliPart>),
}
```

`GeminiCliPart` only consumes `text`; other part kinds (`inlineData`, `fileData`, `functionCall`, …) are silently ignored by serde's default behaviour so schema growth upstream doesn't break us again. All five `GeminiCliMessage` variants now carry `Option<GeminiCliContent>` with `#[serde(default)]`, which also handles `null` and missing content gracefully.

The only live text-consumer (`fallback_session_name` in the User arm) now calls `GeminiCliContent::as_text()` to build a plain-text preview across any of the three shapes, preserving the 50-char truncation.

## Tests

Added 6 regression tests in `src/analyzers/tests/gemini_cli.rs`:

- `test_gemini_cli_content_array_of_parts` — array on both user and gemini messages.
- `test_gemini_cli_content_mixed_parts` — array with `{"text": ...}` and `{"inlineData": ...}` interleaved; text is concatenated, non-text parts ignored.
- `test_gemini_cli_content_single_part_object` — single-object `PartListUnion` form.
- `test_gemini_cli_content_array_session_name_truncated` — long array-extracted text still truncates to 50 chars.
- `test_gemini_cli_content_missing_or_null` — missing and `null` content do not crash parsing.
- `test_gemini_cli_issue_137_regression` — exact failure schema from the issue report.

The original `test_gemini_cli_reasoning_tokens` (legacy string format) still passes unchanged.

## Verification

```
cargo build --quiet                             # clean
cargo test --quiet                              # 291 passed (was 285 + 6 new)
cargo clippy --all-targets -- -D warnings       # clean
cargo doc --quiet --no-deps                     # clean
cargo fmt --all --check                         # clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini CLI session file parsing to robustly handle missing, null, or multimodal content fields without crashing.

* **New Features**
  * Added support for flexible content formats in Gemini CLI sessions, including text arrays, single parts, and mixed content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->