### PR TITLE
feat: add TUI defaults for sort and empty periods

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub upload: UploadConfig,
     pub formatting: FormattingConfig,
     #[serde(default)]
+    pub tui: TuiConfig,
+    #[serde(default)]
     pub models: HashMap<String, ModelInfo>,
     #[serde(default)]
     pub aliases: HashMap<String, String>,
@@ -39,6 +41,12 @@ pub struct FormattingConfig {
     pub decimal_places: usize,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct TuiConfig {
+    pub reverse_sort_default: bool,
+    pub hide_empty_periods: bool,
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -58,6 +66,7 @@ impl Default for Config {
                 locale: "en".to_string(),
                 decimal_places: 2,
             },
+            tui: TuiConfig::default(),
             models: HashMap::new(),
             aliases: HashMap::new(),
         }
@@ -179,6 +188,14 @@ pub fn show_config() -> Result<()> {
             println!("   Number Human: {}", config.formatting.number_human);
             println!("   Locale: {}", config.formatting.locale);
             println!("   Decimal Places: {}", config.formatting.decimal_places);
+            println!(
+                "   TUI Reverse Sort Default: {}",
+                config.tui.reverse_sort_default
+            );
+            println!(
+                "   TUI Hide Empty Periods: {}",
+                config.tui.hide_empty_periods
+            );
             if !config.models.is_empty() {
                 println!("   Custom Models: {}", config.models.len());
             }
@@ -229,6 +246,18 @@ pub fn set_config_value(key: &str, value: &str) -> Result<()> {
         "decimal-places" => {
             let places = value.parse::<usize>().context("Invalid number value")?;
             config.formatting.decimal_places = places;
+        }
+        "reverse-sort-default" => {
+            let enabled = value
+                .parse::<bool>()
+                .context("Invalid boolean value. Use 'true' or 'false'")?;
+            config.tui.reverse_sort_default = enabled;
+        }
+        "hide-empty-periods" => {
+            let enabled = value
+                .parse::<bool>()
+                .context("Invalid boolean value. Use 'true' or 'false'")?;
+            config.tui.hide_empty_periods = enabled;
         }
         _ => anyhow::bail!("Unknown config key: {}", key),
     }
@@ -312,6 +341,8 @@ is_estimated = true
         assert_eq!(loaded.server.api_token, "");
         assert!(!loaded.upload.auto_upload);
         assert_eq!(loaded.formatting.locale, "en");
+        assert!(!loaded.tui.reverse_sort_default);
+        assert!(!loaded.tui.hide_empty_periods);
     }
 
     #[test]
@@ -328,6 +359,8 @@ is_estimated = true
         set_config_value("number-human", "true").expect("set number-human");
         set_config_value("locale", "de").expect("set locale");
         set_config_value("decimal-places", "3").expect("set decimal-places");
+        set_config_value("reverse-sort-default", "true").expect("set reverse-sort-default");
+        set_config_value("hide-empty-periods", "true").expect("set hide-empty-periods");
 
         let cfg = Config::load()
             .expect("load config")
@@ -340,6 +373,8 @@ is_estimated = true
         assert!(cfg.formatting.number_human);
         assert_eq!(cfg.formatting.locale, "de");
         assert_eq!(cfg.formatting.decimal_places, 3);
+        assert!(cfg.tui.reverse_sort_default);
+        assert!(cfg.tui.hide_empty_periods);
 
         let err = set_config_value("unknown-key", "value").unwrap_err();
         let msg = format!("{err}");
@@ -353,5 +388,34 @@ is_estimated = true
             msg.contains("Invalid boolean value"),
             "unexpected error message: {msg}"
         );
+    }
+
+    #[test]
+    fn config_toml_parses_tui_section() {
+        let toml_str = r#"
+[server]
+url = "https://splitrail.dev"
+api_token = ""
+
+[upload]
+auto_upload = false
+upload_today_only = false
+retry_attempts = 3
+last_date_uploaded = 0
+
+[formatting]
+number_comma = false
+number_human = false
+locale = "en"
+decimal_places = 2
+
+[tui]
+reverse_sort_default = true
+hide_empty_periods = true
+"#;
+
+        let config: Config = toml::from_str(toml_str).expect("parse config");
+        assert!(config.tui.reverse_sort_default);
+        assert!(config.tui.hide_empty_periods);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ enum ConfigSubcommands {
     Show,
     /// Set configuration value
     Set {
-        /// Configuration key (api-token, auto-upload, number-comma, number-human, locale, decimal-places)
+        /// Configuration key (api-token, auto-upload, number-comma, number-human, locale, decimal-places, reverse-sort-default, hide-empty-periods)
         key: String,
         /// Configuration value
         value: String,
@@ -290,6 +290,7 @@ async fn run_default(format_options: utils::NumberFormatOptions) {
     if let Err(e) = tui::run_tui(
         stats_manager.get_stats_receiver(),
         &format_options,
+        config.tui.clone(),
         upload_status.clone(),
         update_status,
         file_watcher,

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2,6 +2,7 @@ pub mod logic;
 #[cfg(test)]
 mod tests;
 
+use crate::config::TuiConfig;
 use crate::models::is_model_estimated;
 use crate::types::{
     AnalyzerStatsView, CompactDate, DailyStats, MultiAnalyzerStatsView, SharedAnalyzerView,
@@ -20,7 +21,8 @@ use crossterm::terminal::{
 };
 use crossterm::{ExecutableCommand, execute};
 use logic::{
-    SessionAggregate, aggregate_daily_stats_by_month, date_matches_buffer, has_data_shared,
+    SessionAggregate, aggregate_daily_stats_by_month, date_matches_buffer, filtered_aggregate_keys,
+    has_data_shared, is_empty_period,
 };
 use parking_lot::Mutex;
 use ratatui::backend::CrosstermBackend;
@@ -63,36 +65,6 @@ enum StatsViewMode {
     Session,
 }
 
-/// A simple Either type for iterators to avoid allocation when reversing.
-enum EitherIter<L, R> {
-    Left(L),
-    Right(R),
-}
-
-impl<L, R, T> Iterator for EitherIter<L, R>
-where
-    L: Iterator<Item = T>,
-    R: Iterator<Item = T>,
-{
-    type Item = T;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            EitherIter::Left(l) => l.next(),
-            EitherIter::Right(r) => r.next(),
-        }
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match self {
-            EitherIter::Left(l) => l.size_hint(),
-            EitherIter::Right(r) => r.size_hint(),
-        }
-    }
-}
-
 enum AggregateStatsData<'a> {
     Borrowed(&'a BTreeMap<String, DailyStats>),
     Owned(BTreeMap<String, DailyStats>),
@@ -119,52 +91,46 @@ fn get_aggregate_stats<'a>(
     }
 }
 
-fn aggregate_total_rows(view: &AnalyzerStatsView, aggregate_view_mode: AggregateViewMode) -> usize {
-    get_aggregate_stats(view, aggregate_view_mode)
-        .as_map()
-        .len()
-        + 2
+fn aggregate_total_rows(
+    view: &AnalyzerStatsView,
+    aggregate_view_mode: AggregateViewMode,
+    hide_empty_periods: bool,
+) -> usize {
+    let visible_rows = filtered_aggregate_keys(
+        get_aggregate_stats(view, aggregate_view_mode).as_map(),
+        hide_empty_periods,
+        false,
+    )
+    .len();
+    visible_rows + 2
 }
 
 fn find_matching_aggregate_index(
     view: &AnalyzerStatsView,
     aggregate_view_mode: AggregateViewMode,
     buffer: &str,
+    hide_empty_periods: bool,
     sort_reversed: bool,
 ) -> Option<usize> {
     let aggregate_stats = get_aggregate_stats(view, aggregate_view_mode);
-    let stats = aggregate_stats.as_map();
-
-    if sort_reversed {
-        stats
-            .iter()
-            .rev()
-            .enumerate()
-            .find(|(_, (period, _))| date_matches_buffer(period, buffer))
-            .map(|(index, _)| index)
-    } else {
-        stats
-            .iter()
-            .enumerate()
-            .find(|(_, (period, _))| date_matches_buffer(period, buffer))
-            .map(|(index, _)| index)
-    }
+    filtered_aggregate_keys(aggregate_stats.as_map(), hide_empty_periods, sort_reversed)
+        .into_iter()
+        .enumerate()
+        .find(|(_, period)| date_matches_buffer(period, buffer))
+        .map(|(index, _)| index)
 }
 
 fn aggregate_key_at(
     view: &AnalyzerStatsView,
     aggregate_view_mode: AggregateViewMode,
     index: usize,
+    hide_empty_periods: bool,
     sort_reversed: bool,
 ) -> Option<String> {
     let aggregate_stats = get_aggregate_stats(view, aggregate_view_mode);
-    let stats = aggregate_stats.as_map();
-
-    if sort_reversed {
-        stats.iter().rev().nth(index).map(|(key, _)| key.clone())
-    } else {
-        stats.iter().nth(index).map(|(key, _)| key.clone())
-    }
+    filtered_aggregate_keys(aggregate_stats.as_map(), hide_empty_periods, sort_reversed)
+        .into_iter()
+        .nth(index)
 }
 
 fn clamp_table_selection(table_state: &mut TableState, total_rows: usize) {
@@ -225,6 +191,7 @@ struct UiState<'a> {
     date_jump_active: bool,
     date_jump_buffer: &'a str,
     sort_reversed: bool,
+    hide_empty_periods: bool,
     show_totals: bool,
 }
 
@@ -242,6 +209,7 @@ const TOKEN_COL_WIDTH: u16 = 12;
 pub fn run_tui(
     stats_receiver: watch::Receiver<MultiAnalyzerStatsView>,
     format_options: &NumberFormatOptions,
+    tui_config: TuiConfig,
     upload_status: Arc<Mutex<UploadStatus>>,
     update_status: Arc<Mutex<crate::version_check::UpdateStatus>>,
     file_watcher: FileWatcher,
@@ -274,6 +242,7 @@ pub fn run_tui(
             &mut terminal,
             stats_receiver,
             format_options,
+            tui_config,
             &mut selected_tab,
             &mut scroll_offset,
             &mut aggregate_view_mode,
@@ -295,6 +264,7 @@ async fn run_app(
     terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
     mut stats_receiver: watch::Receiver<MultiAnalyzerStatsView>,
     format_options: &NumberFormatOptions,
+    tui_config: TuiConfig,
     selected_tab: &mut usize,
     scroll_offset: &mut usize,
     aggregate_view_mode: &mut AggregateViewMode,
@@ -309,7 +279,8 @@ async fn run_app(
     let mut session_day_filters: Vec<Option<CompactDate>> = Vec::new();
     let mut date_jump_active = false;
     let mut date_jump_buffer = String::new();
-    let mut sort_reversed = false;
+    let mut sort_reversed = tui_config.reverse_sort_default;
+    let mut hide_empty_periods = tui_config.hide_empty_periods;
     let mut show_totals = true;
     let mut current_stats = stats_receiver.borrow().clone();
 
@@ -413,6 +384,7 @@ async fn run_app(
                     date_jump_active,
                     date_jump_buffer: &date_jump_buffer,
                     sort_reversed,
+                    hide_empty_periods,
                     show_totals,
                 };
                 draw_ui(
@@ -479,6 +451,7 @@ async fn run_app(
                                 &stats,
                                 *aggregate_view_mode,
                                 &date_jump_buffer,
+                                hide_empty_periods,
                                 sort_reversed,
                             ) {
                                 table_state.select(Some(index));
@@ -497,6 +470,7 @@ async fn run_app(
                                 &stats,
                                 *aggregate_view_mode,
                                 &date_jump_buffer,
+                                hide_empty_periods,
                                 sort_reversed,
                             ) {
                                 table_state.select(Some(index));
@@ -577,9 +551,12 @@ async fn run_app(
                             StatsViewMode::Aggregate => {
                                 if let Some(current_stats) = filtered_stats.get(*selected_tab) {
                                     let view = current_stats.read();
-                                    let data_rows =
-                                        aggregate_total_rows(&view, *aggregate_view_mode)
-                                            .saturating_sub(2);
+                                    let data_rows = aggregate_total_rows(
+                                        &view,
+                                        *aggregate_view_mode,
+                                        hide_empty_periods,
+                                    )
+                                    .saturating_sub(2);
                                     let last_row = if data_rows > 0 { data_rows + 1 } else { 1 };
 
                                     if selected < last_row {
@@ -638,9 +615,12 @@ async fn run_app(
                             StatsViewMode::Aggregate => {
                                 if let Some(current_stats) = filtered_stats.get(*selected_tab) {
                                     let view = current_stats.read();
-                                    let data_rows =
-                                        aggregate_total_rows(&view, *aggregate_view_mode)
-                                            .saturating_sub(2);
+                                    let data_rows = aggregate_total_rows(
+                                        &view,
+                                        *aggregate_view_mode,
+                                        hide_empty_periods,
+                                    )
+                                    .saturating_sub(2);
                                     table_state.select(Some(selected.saturating_sub(
                                         if data_rows > 0 && selected == data_rows + 1 {
                                             2
@@ -694,8 +674,11 @@ async fn run_app(
                             StatsViewMode::Aggregate => {
                                 if let Some(current_stats) = filtered_stats.get(*selected_tab) {
                                     let view = current_stats.read();
-                                    let total_rows =
-                                        aggregate_total_rows(&view, *aggregate_view_mode);
+                                    let total_rows = aggregate_total_rows(
+                                        &view,
+                                        *aggregate_view_mode,
+                                        hide_empty_periods,
+                                    );
                                     table_state.select(Some(total_rows.saturating_sub(1)));
                                     needs_redraw = true;
                                 }
@@ -735,8 +718,11 @@ async fn run_app(
                             StatsViewMode::Aggregate => {
                                 if let Some(current_stats) = filtered_stats.get(*selected_tab) {
                                     let view = current_stats.read();
-                                    let total_rows =
-                                        aggregate_total_rows(&view, *aggregate_view_mode);
+                                    let total_rows = aggregate_total_rows(
+                                        &view,
+                                        *aggregate_view_mode,
+                                        hide_empty_periods,
+                                    );
                                     let new_selected =
                                         (selected + 10).min(total_rows.saturating_sub(1));
                                     table_state.select(Some(new_selected));
@@ -807,7 +793,7 @@ async fn run_app(
                         let view = current_stats.read();
                         clamp_table_selection(
                             table_state,
-                            aggregate_total_rows(&view, *aggregate_view_mode),
+                            aggregate_total_rows(&view, *aggregate_view_mode, hide_empty_periods),
                         );
                     }
 
@@ -858,13 +844,18 @@ async fn run_app(
                     {
                         let view = current_stats.read();
                         if selected_idx
-                            < aggregate_total_rows(&view, AggregateViewMode::Daily)
-                                .saturating_sub(2)
+                            < aggregate_total_rows(
+                                &view,
+                                AggregateViewMode::Daily,
+                                hide_empty_periods,
+                            )
+                            .saturating_sub(2)
                         {
                             let day_key = aggregate_key_at(
                                 &view,
                                 AggregateViewMode::Daily,
                                 selected_idx,
+                                hide_empty_periods,
                                 sort_reversed,
                             )
                             .and_then(|key| CompactDate::from_str(&key));
@@ -881,6 +872,20 @@ async fn run_app(
                 }
                 KeyCode::Char('r') => {
                     sort_reversed = !sort_reversed;
+                    needs_redraw = true;
+                }
+                KeyCode::Char('e') => {
+                    hide_empty_periods = !hide_empty_periods;
+                    if matches!(*stats_view_mode, StatsViewMode::Aggregate)
+                        && let Some(current_stats) = filtered_stats.get(*selected_tab)
+                        && let Some(table_state) = table_states.get_mut(*selected_tab)
+                    {
+                        let view = current_stats.read();
+                        clamp_table_selection(
+                            table_state,
+                            aggregate_total_rows(&view, *aggregate_view_mode, hide_empty_periods),
+                        );
+                    }
                     needs_redraw = true;
                 }
                 KeyCode::Char('s') => {
@@ -1029,6 +1034,7 @@ fn draw_ui(
                             } else {
                                 ""
                             },
+                            ui_state.hide_empty_periods,
                             ui_state.sort_reversed,
                         );
                         has_estimated
@@ -1097,11 +1103,11 @@ fn draw_ui(
                     };
 
                     format!(
-                        "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • s to toggle summary • / for {jump_label} • m to toggle daily/monthly{drill_hint} • Ctrl+T for per-session view • q/Esc to quit"
+                        "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • e to toggle empty periods • s to toggle summary • / for {jump_label} • m to toggle daily/monthly{drill_hint} • Ctrl+T for per-session view • q/Esc to quit"
                     )
                 }
                 StatsViewMode::Session => {
-                    "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • s to toggle summary • m to toggle daily/monthly • Ctrl+T for per-period view • q/Esc to quit".to_string()
+                    "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • e to toggle empty periods • s to toggle summary • m to toggle daily/monthly • Ctrl+T for per-period view • q/Esc to quit".to_string()
                 }
             };
 
@@ -1195,6 +1201,7 @@ fn draw_aggregate_stats_table(
     table_state: &mut TableState,
     aggregate_view_mode: AggregateViewMode,
     date_filter: &str,
+    hide_empty_periods: bool,
     sort_reversed: bool,
 ) -> (usize, bool) {
     let period_header = match aggregate_view_mode {
@@ -1204,7 +1211,9 @@ fn draw_aggregate_stats_table(
 
     let aggregate_stats = get_aggregate_stats(stats, aggregate_view_mode);
     let aggregate_stats = aggregate_stats.as_map();
-    clamp_table_selection(table_state, aggregate_stats.len() + 2);
+    let visible_periods =
+        filtered_aggregate_keys(aggregate_stats, hide_empty_periods, sort_reversed);
+    clamp_table_selection(table_state, visible_periods.len() + 2);
 
     let header = Row::new(vec![
         Cell::new(""),
@@ -1280,14 +1289,10 @@ fn draw_aggregate_stats_table(
     let mut total_tool_calls: u64 = 0;
     let mut total_conversations: u64 = 0;
 
-    // Use EitherIter to avoid allocation when reversing
-    let items_to_render = if sort_reversed {
-        EitherIter::Right(aggregate_stats.iter().rev())
-    } else {
-        EitherIter::Left(aggregate_stats.iter())
-    };
-
-    for (i, (period, period_stats)) in items_to_render.enumerate() {
+    for (i, period) in visible_periods.iter().enumerate() {
+        let period_stats = aggregate_stats
+            .get(period)
+            .expect("visible period key must exist in aggregate stats");
         // Filter rows based on date search
         if !date_filter.is_empty() && !date_matches_buffer(period, date_filter) {
             continue;
@@ -1316,15 +1321,7 @@ fn draw_aggregate_stats_table(
         let models = models_vec.join(", ");
 
         // Check if this is an empty row
-        let is_empty_row = period_stats.stats.cost_cents == 0
-            && period_stats.stats.cached_tokens == 0
-            && period_stats.stats.input_tokens == 0
-            && period_stats.stats.output_tokens == 0
-            && period_stats.stats.reasoning_tokens == 0
-            && period_stats.conversations == 0
-            && period_stats.user_messages == 0
-            && period_stats.ai_messages == 0
-            && period_stats.stats.tool_calls == 0;
+        let is_empty_row = is_empty_period(period_stats);
 
         // Create styled cells with colors matching original implementation
         let period_text = format_aggregate_period_for_display(period, aggregate_view_mode);
@@ -1586,8 +1583,8 @@ fn draw_aggregate_stats_table(
         },
         Line::from(Span::styled(
             match aggregate_view_mode {
-                AggregateViewMode::Daily => format!("Total ({}d)", aggregate_stats.len()),
-                AggregateViewMode::Monthly => format!("Total ({}m)", aggregate_stats.len()),
+                AggregateViewMode::Daily => format!("Total ({}d)", visible_periods.len()),
+                AggregateViewMode::Monthly => format!("Total ({}m)", visible_periods.len()),
             },
             Style::default().add_modifier(Modifier::BOLD),
         )),

--- a/src/tui/logic.rs
+++ b/src/tui/logic.rs
@@ -175,6 +175,36 @@ pub fn aggregate_daily_stats_by_month(
     monthly_stats
 }
 
+pub fn is_empty_period(stats: &DailyStats) -> bool {
+    stats.stats.cost_cents == 0
+        && stats.stats.cached_tokens == 0
+        && stats.stats.input_tokens == 0
+        && stats.stats.output_tokens == 0
+        && stats.stats.reasoning_tokens == 0
+        && stats.conversations == 0
+        && stats.user_messages == 0
+        && stats.ai_messages == 0
+        && stats.stats.tool_calls == 0
+}
+
+pub fn filtered_aggregate_keys(
+    aggregate_stats: &BTreeMap<String, DailyStats>,
+    hide_empty_periods: bool,
+    sort_reversed: bool,
+) -> Vec<String> {
+    let mut keys: Vec<String> = aggregate_stats
+        .iter()
+        .filter(|(_, stats)| !hide_empty_periods || !is_empty_period(stats))
+        .map(|(key, _)| key.clone())
+        .collect();
+
+    if sort_reversed {
+        keys.reverse();
+    }
+
+    keys
+}
+
 /// Check if an AnalyzerStatsView has any data to display.
 pub fn has_data_view(stats: &crate::types::AnalyzerStatsView) -> bool {
     stats.num_conversations > 0

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,6 +1,7 @@
 /// Tests for TUI components: table state management, upload progress, date matching, and stats accumulation.
 use crate::tui::logic::{
     accumulate_tui_stats, aggregate_daily_stats_by_month, date_matches_buffer,
+    filtered_aggregate_keys,
 };
 use crate::tui::{
     create_upload_progress_callback, format_month_for_display, show_upload_error,
@@ -418,6 +419,49 @@ fn test_date_filter_with_january() {
     assert!(date_matches_buffer("2025-01-15", "1"));
     assert!(date_matches_buffer("2025-01-15", "jan"));
     assert!(date_matches_buffer("2025-01-15", "JAN"));
+}
+
+#[test]
+fn test_filtered_aggregate_keys_skips_empty_periods_when_enabled() {
+    let stats = BTreeMap::from([
+        (
+            "2025-01-01".to_string(),
+            make_daily_stats("2025-01-01", 10, 0, 1),
+        ),
+        (
+            "2025-01-02".to_string(),
+            make_daily_stats("2025-01-02", 0, 0, 0),
+        ),
+    ]);
+
+    let keys = filtered_aggregate_keys(&stats, true, false);
+
+    assert_eq!(keys, vec!["2025-01-01".to_string()]);
+}
+
+#[test]
+fn test_filtered_aggregate_keys_reverses_after_filtering() {
+    let stats = BTreeMap::from([
+        (
+            "2025-01-01".to_string(),
+            make_daily_stats("2025-01-01", 10, 0, 1),
+        ),
+        (
+            "2025-01-02".to_string(),
+            make_daily_stats("2025-01-02", 0, 0, 0),
+        ),
+        (
+            "2025-01-03".to_string(),
+            make_daily_stats("2025-01-03", 20, 0, 2),
+        ),
+    ]);
+
+    let keys = filtered_aggregate_keys(&stats, true, true);
+
+    assert_eq!(
+        keys,
+        vec!["2025-01-03".to_string(), "2025-01-01".to_string()]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add persistent TUI config for reverse sort and hiding empty periods
- initialize TUI state from config and add an interactive empty-period toggle
- keep aggregate rendering, jump, and selection logic consistent with filtered periods

## Test Plan
- [x] cargo test --quiet

<img width="1971" height="159" alt="image" src="https://github.com/user-attachments/assets/644a9eb6-2170-4734-8df5-284e1590124e" />

<img width="1314" height="672" alt="image" src="https://github.com/user-attachments/assets/c6b6dd5a-8901-4350-9375-7b8650d0dec8" />

