### PR TITLE
Add GPT-5.5 pricing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2477,9 +2477,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/src/models.rs
+++ b/src/models.rs
@@ -564,6 +564,28 @@ fn populate_defaults(
     );
 
     add_model!(
+        "gpt-5.5",
+        PricingStructure::Flat {
+            input_per_1m: 5.0,
+            output_per_1m: 30.0
+        },
+        CachingSupport::OpenAI {
+            cached_input_per_1m: 0.50
+        },
+        false
+    );
+
+    add_model!(
+        "gpt-5.5-pro",
+        PricingStructure::Flat {
+            input_per_1m: 30.0,
+            output_per_1m: 180.0
+        },
+        CachingSupport::None,
+        false
+    );
+
+    add_model!(
         "gpt-5.4-mini",
         PricingStructure::Flat {
             input_per_1m: 0.75,
@@ -1262,6 +1284,12 @@ fn populate_defaults(
     add_alias!("gpt-5.2-codex", "gpt-5.2-codex");
     add_alias!("gpt-5.3-codex", "gpt-5.3-codex");
     add_alias!("gpt-5-pro", "gpt-5-pro");
+    add_alias!("gpt-5.4", "gpt-5.4");
+    add_alias!("gpt-5.4-pro", "gpt-5.4-pro");
+    add_alias!("gpt-5.4-mini", "gpt-5.4-mini");
+    add_alias!("gpt-5.4-nano", "gpt-5.4-nano");
+    add_alias!("gpt-5.5", "gpt-5.5");
+    add_alias!("gpt-5.5-pro", "gpt-5.5-pro");
 
     // Anthropic aliases
     add_alias!("claude-opus-4.7", "claude-opus-4-7");


### PR DESCRIPTION
## Summary
- add GPT-5.5 and GPT-5.5 Pro pricing to the default model registry
- add direct aliases for GPT-5.4 and GPT-5.5 model IDs
- use flat GPT-5.5 pricing because OpenAI has not published a separate long-context surcharge for GPT-5.5

## Test
- cargo test models --all-targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new OpenAI models: `gpt-5.5` and `gpt-5.5-pro` with configured input and output pricing.
  * `gpt-5.5` includes cached-input pricing support, while `gpt-5.5-pro` has caching disabled.
  * Models are now directly accessible via their standard names and aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->