### PR TITLE
fix: support newer Gemini CLI and Copilot session formats

### DIFF
--- a/src/analyzers/copilot.rs
+++ b/src/analyzers/copilot.rs
@@ -54,9 +54,13 @@ impl CopilotAnalyzer {
 #[serde(rename_all = "camelCase")]
 struct CopilotChatSession {
     version: u32,
-    requester_username: String,
-    responder_username: String,
-    initial_location: String,
+    #[serde(default)]
+    requester_username: Option<String>,
+    #[serde(default)]
+    responder_username: Option<String>,
+    #[serde(default)]
+    initial_location: Option<String>,
+    #[serde(default)]
     requests: Vec<CopilotRequest>,
     #[serde(default)]
     session_id: Option<String>,

--- a/src/analyzers/gemini_cli.rs
+++ b/src/analyzers/gemini_cli.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -73,6 +74,13 @@ enum GeminiCliMessage {
         content: Option<GeminiCliContent>,
     },
     Info {
+        id: String,
+        #[serde(deserialize_with = "deserialize_utc_timestamp")]
+        timestamp: DateTime<Utc>,
+        #[serde(default)]
+        content: Option<GeminiCliContent>,
+    },
+    Warning {
         id: String,
         #[serde(deserialize_with = "deserialize_utc_timestamp")]
         timestamp: DateTime<Utc>,
@@ -245,19 +253,29 @@ fn calculate_gemini_cost(tokens: &GeminiCliTokens, model_name: &str) -> f64 {
     input_cost + output_cost + cache_cost
 }
 
-// JSON session parsing (not JSONL)
-fn parse_json_session_file(file_path: &Path) -> Result<Vec<ConversationMessage>> {
+fn is_gemini_cli_chat_path(path: &Path) -> bool {
+    path.is_file()
+        && path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .is_some_and(|ext| ext == "json" || ext == "jsonl")
+        && path
+            .ancestors()
+            .skip(1)
+            .any(|ancestor| ancestor.file_name().is_some_and(|name| name == "chats"))
+}
+
+fn messages_from_session(
+    file_path: &Path,
+    messages: Vec<GeminiCliMessage>,
+) -> Vec<ConversationMessage> {
     let project_hash = extract_and_hash_project_id_gemini_cli(file_path);
     let file_path_str = file_path.to_string_lossy();
+    let conversation_hash = hash_text(&file_path.to_string_lossy());
     let mut entries = Vec::new();
     let mut fallback_session_name: Option<String> = None;
 
-    // Parse the complete session JSON
-    let session: GeminiCliSession =
-        simd_json::from_slice(&mut std::fs::read_to_string(file_path)?.into_bytes())?;
-
-    // Process each message in the session
-    for message in session.messages {
+    for message in messages {
         match message {
             GeminiCliMessage::User {
                 id: _,
@@ -290,7 +308,7 @@ fn parse_json_session_file(file_path: &Path) -> Result<Vec<ConversationMessage>>
                         file_path_str,
                         timestamp.to_rfc3339()
                     )),
-                    conversation_hash: hash_text(&file_path.to_string_lossy()),
+                    conversation_hash: conversation_hash.clone(),
                     model: None,
                     stats: Stats::default(),
                     role: MessageRole::User,
@@ -309,7 +327,6 @@ fn parse_json_session_file(file_path: &Path) -> Result<Vec<ConversationMessage>>
             } => {
                 let mut stats = extract_tool_stats(&tool_calls);
 
-                // Update stats with token information
                 stats.input_tokens = tokens.input;
                 stats.output_tokens = tokens.output;
                 stats.reasoning_tokens = tokens.thoughts;
@@ -330,7 +347,7 @@ fn parse_json_session_file(file_path: &Path) -> Result<Vec<ConversationMessage>>
                     )),
                     date: timestamp,
                     project_hash: project_hash.clone(),
-                    conversation_hash: hash_text(&file_path.to_string_lossy()),
+                    conversation_hash: conversation_hash.clone(),
                     stats,
                     role: MessageRole::Assistant,
                     uuid: None,
@@ -341,7 +358,53 @@ fn parse_json_session_file(file_path: &Path) -> Result<Vec<ConversationMessage>>
         }
     }
 
-    Ok(entries)
+    entries
+}
+
+// JSON session parsing (not JSONL)
+fn parse_json_session_file(file_path: &Path) -> Result<Vec<ConversationMessage>> {
+    let session: GeminiCliSession =
+        simd_json::from_slice(&mut std::fs::read_to_string(file_path)?.into_bytes())?;
+    Ok(messages_from_session(file_path, session.messages))
+}
+
+fn parse_jsonl_session_file(file_path: &Path) -> Result<Vec<ConversationMessage>> {
+    let content = std::fs::read_to_string(file_path)?;
+    let mut message_order = Vec::new();
+    let mut latest_messages = HashMap::new();
+
+    for line in content.lines().filter(|line| !line.trim().is_empty()) {
+        let mut line_bytes = line.as_bytes().to_vec();
+        let value: simd_json::OwnedValue = simd_json::from_slice(&mut line_bytes)?;
+
+        if value.get("$set").is_some() {
+            continue;
+        }
+
+        if value.get("type").is_none() || value.get("id").is_none() {
+            continue;
+        }
+
+        let id = match value.get("id").and_then(|v| v.as_str()) {
+            Some(id) => id.to_string(),
+            None => continue,
+        };
+
+        let mut message_bytes = line.as_bytes().to_vec();
+        let message: GeminiCliMessage = simd_json::from_slice(&mut message_bytes)?;
+
+        if !latest_messages.contains_key(&id) {
+            message_order.push(id.clone());
+        }
+        latest_messages.insert(id, message);
+    }
+
+    let messages = message_order
+        .into_iter()
+        .filter_map(|id| latest_messages.remove(&id))
+        .collect();
+
+    Ok(messages_from_session(file_path, messages))
 }
 
 #[async_trait]
@@ -365,16 +428,9 @@ impl Analyzer for GeminiCliAnalyzer {
         let sources = Self::data_dir()
             .filter(|d| d.is_dir())
             .into_iter()
-            .flat_map(|tmp_dir| WalkDir::new(tmp_dir).min_depth(3).max_depth(3).into_iter())
+            .flat_map(|tmp_dir| WalkDir::new(tmp_dir).into_iter())
             .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_type().is_file()
-                    && e.path().extension().is_some_and(|ext| ext == "json")
-                    && e.path()
-                        .parent()
-                        .and_then(|p| p.file_name())
-                        .is_some_and(|name| name == "chats")
-            })
+            .filter(|e| is_gemini_cli_chat_path(e.path()))
             .map(|e| DataSource {
                 path: e.into_path(),
             })
@@ -387,20 +443,16 @@ impl Analyzer for GeminiCliAnalyzer {
         Self::data_dir()
             .filter(|d| d.is_dir())
             .into_iter()
-            .flat_map(|tmp_dir| WalkDir::new(tmp_dir).min_depth(3).max_depth(3).into_iter())
+            .flat_map(|tmp_dir| WalkDir::new(tmp_dir).into_iter())
             .filter_map(|e| e.ok())
-            .any(|e| {
-                e.file_type().is_file()
-                    && e.path().extension().is_some_and(|ext| ext == "json")
-                    && e.path()
-                        .parent()
-                        .and_then(|p| p.file_name())
-                        .is_some_and(|name| name == "chats")
-            })
+            .any(|e| is_gemini_cli_chat_path(e.path()))
     }
 
     fn parse_source(&self, source: &DataSource) -> Result<Vec<ConversationMessage>> {
-        parse_json_session_file(&source.path)
+        match source.path.extension().and_then(|ext| ext.to_str()) {
+            Some("jsonl") => parse_jsonl_session_file(&source.path),
+            _ => parse_json_session_file(&source.path),
+        }
     }
 
     fn parse_sources_parallel(&self, sources: &[DataSource]) -> Vec<ConversationMessage> {
@@ -419,13 +471,7 @@ impl Analyzer for GeminiCliAnalyzer {
     }
 
     fn is_valid_data_path(&self, path: &Path) -> bool {
-        // Must be a .json file in a "chats" directory
-        path.is_file()
-            && path.extension().is_some_and(|ext| ext == "json")
-            && path
-                .parent()
-                .and_then(|p| p.file_name())
-                .is_some_and(|name| name == "chats")
+        is_gemini_cli_chat_path(path)
     }
 
     fn contribution_strategy(&self) -> ContributionStrategy {

--- a/src/analyzers/tests/copilot.rs
+++ b/src/analyzers/tests/copilot.rs
@@ -199,3 +199,34 @@ fn test_copilot_glob_patterns() {
         "VS Code Copilot patterns should not include Copilot CLI event files"
     );
 }
+
+#[test]
+fn test_parse_empty_copilot_session_without_requester_username() {
+    let dir = tempfile::tempdir().unwrap();
+    let session_path = dir.path().join("empty-session.json");
+    std::fs::write(
+        &session_path,
+        r#"{
+            "version": 3,
+            "responderUsername": "",
+            "initialLocation": "panel",
+            "requests": [],
+            "sessionId": "b4c76ee0-d6af-4c61-a85b-2b092ebd86fd",
+            "creationDate": 1768224201981,
+            "lastMessageDate": 1768224201981,
+            "hasPendingEdits": false,
+            "inputState": {
+                "mode": {
+                    "id": "agent",
+                    "kind": "agent"
+                },
+                "inputText": ""
+            }
+        }"#,
+    )
+    .unwrap();
+
+    let messages =
+        parse_copilot_session_file(&session_path).expect("empty sessions should parse cleanly");
+    assert!(messages.is_empty());
+}

--- a/src/analyzers/tests/copilot.rs
+++ b/src/analyzers/tests/copilot.rs
@@ -201,27 +201,18 @@ fn test_copilot_glob_patterns() {
 }
 
 #[test]
-fn test_parse_empty_copilot_session_without_requester_username() {
+fn test_parse_empty_copilot_session_without_optional_metadata_fields() {
     let dir = tempfile::tempdir().unwrap();
     let session_path = dir.path().join("empty-session.json");
     std::fs::write(
         &session_path,
         r#"{
             "version": 3,
-            "responderUsername": "",
-            "initialLocation": "panel",
             "requests": [],
             "sessionId": "b4c76ee0-d6af-4c61-a85b-2b092ebd86fd",
             "creationDate": 1768224201981,
             "lastMessageDate": 1768224201981,
-            "hasPendingEdits": false,
-            "inputState": {
-                "mode": {
-                    "id": "agent",
-                    "kind": "agent"
-                },
-                "inputText": ""
-            }
+            "hasPendingEdits": false
         }"#,
     )
     .unwrap();

--- a/src/analyzers/tests/gemini_cli.rs
+++ b/src/analyzers/tests/gemini_cli.rs
@@ -345,3 +345,103 @@ async fn test_gemini_cli_issue_137_regression() {
         .expect("issue #137 regression: parse_source must accept array-of-parts content");
     assert_eq!(parsed.len(), 2);
 }
+
+#[tokio::test]
+async fn test_gemini_cli_warning_messages_are_ignored() {
+    let dir = tempdir().unwrap();
+    let project_dir = dir.path().join("tmp").join("project-warning").join("chats");
+    let json_content = r#"{
+        "sessionId": "sess-warning",
+        "projectHash": "proj-hash",
+        "startTime": "2026-03-20T08:00:00Z",
+        "lastUpdated": "2026-03-20T08:05:00Z",
+        "messages": [
+            {
+                "type": "user",
+                "id": "u-1",
+                "timestamp": "2026-03-20T08:00:00Z",
+                "content": [{"text": "run the tests"}]
+            },
+            {
+                "type": "warning",
+                "id": "w-1",
+                "timestamp": "2026-03-20T08:00:01Z",
+                "content": [{"text": "tool output warning"}]
+            },
+            {
+                "type": "gemini",
+                "id": "g-1",
+                "timestamp": "2026-03-20T08:00:05Z",
+                "content": "done",
+                "model": "gemini-3-flash-preview",
+                "tokens": {
+                    "input": 10,
+                    "output": 20,
+                    "thoughts": 5,
+                    "cached": 0,
+                    "tool": 0,
+                    "total": 35
+                }
+            }
+        ]
+    }"#;
+    let session_path = write_session(&project_dir, json_content);
+
+    let analyzer = GeminiCliAnalyzer::new();
+    let source = crate::analyzer::DataSource { path: session_path };
+    let messages = analyzer
+        .parse_source(&source)
+        .expect("warning message types should not break parsing");
+
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].role, crate::types::MessageRole::User);
+    assert_eq!(messages[1].role, crate::types::MessageRole::Assistant);
+}
+
+#[tokio::test]
+async fn test_gemini_cli_jsonl_latest_message_version_wins() {
+    let dir = tempdir().unwrap();
+    let session_dir = dir
+        .path()
+        .join("tmp")
+        .join("project-jsonl")
+        .join("chats")
+        .join("9e43d548-335e-4ad0-b797-4f8bce36e08c");
+    std::fs::create_dir_all(&session_dir).unwrap();
+    let session_path = session_dir.join("06fhku.jsonl");
+    let jsonl_content = r#"{"sessionId":"sess-jsonl","projectHash":"proj-hash","startTime":"2026-04-28T16:10:11.637Z","lastUpdated":"2026-04-28T16:10:11.637Z","kind":"main"}
+{"id":"u-1","timestamp":"2026-04-28T16:11:14.988Z","type":"user","content":[{"text":"inspect this cache design"}]}
+{"$set":{"lastUpdated":"2026-04-28T16:11:14.989Z"}}
+{"id":"g-1","timestamp":"2026-04-28T16:11:38.569Z","type":"gemini","content":"first draft","thoughts":[],"tokens":{"input":20,"output":30,"cached":0,"thoughts":4,"tool":0,"total":54},"model":"gemini-3-flash-preview"}
+{"$set":{"lastUpdated":"2026-04-28T16:11:38.569Z"}}
+{"id":"g-1","timestamp":"2026-04-28T16:11:38.569Z","type":"gemini","content":"final draft","thoughts":[],"tokens":{"input":20,"output":30,"cached":0,"thoughts":4,"tool":0,"total":54},"model":"gemini-3-flash-preview","toolCalls":[{"id":"call-1","name":"run_shell_command","args":{"command":"rg cache"},"result":[]}]}
+"#;
+    let mut file = File::create(&session_path).unwrap();
+    file.write_all(jsonl_content.as_bytes()).unwrap();
+
+    let analyzer = GeminiCliAnalyzer::new();
+    let source = crate::analyzer::DataSource {
+        path: session_path.clone(),
+    };
+    let messages = analyzer
+        .parse_source(&source)
+        .expect("jsonl sessions should parse successfully");
+
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].role, crate::types::MessageRole::User);
+    assert_eq!(
+        messages[0].session_name.as_deref(),
+        Some("inspect this cache design")
+    );
+
+    let assistant = messages
+        .iter()
+        .find(|m| m.role == crate::types::MessageRole::Assistant)
+        .unwrap();
+    assert_eq!(assistant.stats.input_tokens, 20);
+    assert_eq!(assistant.stats.output_tokens, 30);
+    assert_eq!(assistant.stats.reasoning_tokens, 4);
+    assert_eq!(assistant.stats.tool_calls, 1);
+    assert_eq!(assistant.stats.terminal_commands, 1);
+    assert!(analyzer.is_valid_data_path(&session_path));
+}


### PR DESCRIPTION
## Summary
- support Gemini CLI `.jsonl` session logs and nested `chats/` subdirectories
- ignore Gemini `warning` messages and `$set` metadata updates while keeping the latest message version per id
- tolerate empty newer GitHub Copilot chat session files and add regression coverage for both parsers

## Root Cause
Recent Gemini CLI releases changed chat persistence from a single `.json` object to incremental `.jsonl` logs and introduced nested subagent session paths. Newer Copilot session files can also omit fields that the parser previously required even when the session has no requests.

## Validation
- cargo fmt --all --quiet
- cargo build --quiet
- cargo test --quiet
- cargo clippy --quiet -- -D warnings
- cargo doc --quiet

Fixes #154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for parsing Gemini CLI JSONL chat logs with per-message-id deduplication (latest wins)
  * Recognition and exclusion of Warning message type from conversation streams

* **Bug Fixes**
  * Copilot session parser no longer fails when optional metadata fields are absent

* **Tests**
  * Added tests covering Gemini JSONL handling, warning-message behavior, and Copilot parsing of empty-request sessions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->