### PR TITLE
feat: add all-tools period aggregation views

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -338,6 +338,8 @@ struct UiState<'a> {
     show_totals: bool,
 }
 
+/// Build the tab data shown in the TUI, prepending a synthetic "All Tools"
+/// view ahead of the individual analyzer tabs.
 pub(crate) fn build_display_stats(
     filtered_stats: &[SharedAnalyzerView],
 ) -> Vec<SharedAnalyzerView> {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -13,7 +13,7 @@ use crate::utils::{
 };
 use crate::watcher::{FileWatcher, RealtimeStatsManager, WatcherEvent};
 use anyhow::Result;
-use chrono::{Datelike, Local};
+use chrono::{Datelike, Local, NaiveDate};
 use crossterm::event::{self, Event, KeyCode, KeyModifiers};
 use crossterm::style::{Print, ResetColor, SetForegroundColor};
 use crossterm::terminal::{
@@ -21,8 +21,9 @@ use crossterm::terminal::{
 };
 use crossterm::{ExecutableCommand, execute};
 use logic::{
-    SessionAggregate, aggregate_daily_stats_by_month, date_matches_buffer, filtered_aggregate_keys,
-    has_data_shared, is_empty_period,
+    SessionAggregate, aggregate_daily_stats_by_month, aggregate_daily_stats_by_week,
+    aggregate_daily_stats_by_year, date_matches_buffer, filtered_aggregate_keys, has_data_shared,
+    is_empty_period,
 };
 use parking_lot::Mutex;
 use ratatui::backend::CrosstermBackend;
@@ -56,7 +57,85 @@ pub enum UploadStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AggregateViewMode {
     Daily,
+    Weekly,
     Monthly,
+    Yearly,
+}
+
+impl AggregateViewMode {
+    fn next(self) -> Self {
+        match self {
+            Self::Daily => Self::Weekly,
+            Self::Weekly => Self::Monthly,
+            Self::Monthly => Self::Yearly,
+            Self::Yearly => Self::Daily,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PeriodFilter {
+    Day(CompactDate),
+    Week { iso_year: i32, iso_week: u32 },
+    Month { year: u16, month: u8 },
+    Year { year: u16 },
+}
+
+impl PeriodFilter {
+    fn from_period_key(period: &str, aggregate_view_mode: AggregateViewMode) -> Option<Self> {
+        match aggregate_view_mode {
+            AggregateViewMode::Daily => CompactDate::from_str(period).map(Self::Day),
+            AggregateViewMode::Weekly => {
+                let (year, week) = period.split_once("-W")?;
+                Some(Self::Week {
+                    iso_year: year.parse().ok()?,
+                    iso_week: week.parse().ok()?,
+                })
+            }
+            AggregateViewMode::Monthly => {
+                let mut parts = period.split('-');
+                Some(Self::Month {
+                    year: parts.next()?.parse().ok()?,
+                    month: parts.next()?.parse().ok()?,
+                })
+            }
+            AggregateViewMode::Yearly => Some(Self::Year {
+                year: period.parse().ok()?,
+            }),
+        }
+    }
+
+    fn matches_compact_date(self, date: CompactDate) -> bool {
+        match self {
+            Self::Day(day) => day == date,
+            Self::Week { iso_year, iso_week } => compact_date_to_naive(date)
+                .map(|date| {
+                    let week = date.iso_week();
+                    week.year() == iso_year && week.week() == iso_week
+                })
+                .unwrap_or(false),
+            Self::Month { year, month } => date.year() == year && date.month() == month,
+            Self::Year { year } => date.year() == year,
+        }
+    }
+
+    fn display_key(self) -> String {
+        match self {
+            Self::Day(day) => day.to_string(),
+            Self::Week { iso_year, iso_week } => format!("{iso_year:04}-W{iso_week:02}"),
+            Self::Month { year, month } => format!("{year:04}-{month:02}"),
+            Self::Year { year } => format!("{year:04}"),
+        }
+    }
+
+    fn view_mode(self) -> AggregateViewMode {
+        match self {
+            Self::Day(_) => AggregateViewMode::Daily,
+            Self::Week { .. } => AggregateViewMode::Weekly,
+            Self::Month { .. } => AggregateViewMode::Monthly,
+            Self::Year { .. } => AggregateViewMode::Yearly,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -85,8 +164,14 @@ fn get_aggregate_stats<'a>(
 ) -> AggregateStatsData<'a> {
     match aggregate_view_mode {
         AggregateViewMode::Daily => AggregateStatsData::Borrowed(&view.daily_stats),
+        AggregateViewMode::Weekly => {
+            AggregateStatsData::Owned(aggregate_daily_stats_by_week(&view.daily_stats))
+        }
         AggregateViewMode::Monthly => {
             AggregateStatsData::Owned(aggregate_daily_stats_by_month(&view.daily_stats))
+        }
+        AggregateViewMode::Yearly => {
+            AggregateStatsData::Owned(aggregate_daily_stats_by_year(&view.daily_stats))
         }
     }
 }
@@ -133,6 +218,17 @@ fn aggregate_key_at(
         .nth(index)
 }
 
+fn filtered_session_count(view: &AnalyzerStatsView, period_filter: Option<PeriodFilter>) -> usize {
+    period_filter
+        .map(|filter| {
+            view.session_aggregates
+                .iter()
+                .filter(|session| filter.matches_compact_date(session.date))
+                .count()
+        })
+        .unwrap_or_else(|| view.session_aggregates.len())
+}
+
 fn clamp_table_selection(table_state: &mut TableState, total_rows: usize) {
     if total_rows == 0 {
         table_state.select(None);
@@ -141,6 +237,10 @@ fn clamp_table_selection(table_state: &mut TableState, total_rows: usize) {
 
     let selected = table_state.selected().unwrap_or(0);
     table_state.select(Some(selected.min(total_rows.saturating_sub(1))));
+}
+
+fn compact_date_to_naive(date: CompactDate) -> Option<NaiveDate> {
+    NaiveDate::from_ymd_opt(date.year() as i32, date.month() as u32, date.day() as u32)
 }
 
 fn format_month_for_display(month_key: &str) -> String {
@@ -170,13 +270,56 @@ fn format_month_for_display(month_key: &str) -> String {
     }
 }
 
+fn format_week_for_display(week_key: &str) -> String {
+    if week_key == "unknown" {
+        return "Unknown".to_string();
+    }
+
+    let Some((year, week)) = week_key.split_once("-W") else {
+        return week_key.to_string();
+    };
+    let Some(year) = year.parse::<i32>().ok() else {
+        return week_key.to_string();
+    };
+    let Some(week) = week.parse::<u32>().ok() else {
+        return week_key.to_string();
+    };
+
+    let formatted = format!("{year}-W{week:02}");
+    let current_week = Local::now().date_naive().iso_week();
+
+    if current_week.year() == year && current_week.week() == week {
+        format!("{formatted}*")
+    } else {
+        formatted
+    }
+}
+
+fn format_year_for_display(year_key: &str) -> String {
+    if year_key == "unknown" {
+        return "Unknown".to_string();
+    }
+
+    let Some(year) = year_key.parse::<i32>().ok() else {
+        return year_key.to_string();
+    };
+
+    if Local::now().year() == year {
+        format!("{year}*")
+    } else {
+        year.to_string()
+    }
+}
+
 fn format_aggregate_period_for_display(
     period: &str,
     aggregate_view_mode: AggregateViewMode,
 ) -> String {
     match aggregate_view_mode {
         AggregateViewMode::Daily => format_date_for_display(period),
+        AggregateViewMode::Weekly => format_week_for_display(period),
         AggregateViewMode::Monthly => format_month_for_display(period),
+        AggregateViewMode::Yearly => format_year_for_display(period),
     }
 }
 
@@ -187,12 +330,53 @@ struct UiState<'a> {
     aggregate_view_mode: AggregateViewMode,
     stats_view_mode: StatsViewMode,
     session_window_offsets: &'a mut [usize],
-    session_day_filters: &'a mut [Option<CompactDate>],
+    session_period_filters: &'a mut [Option<PeriodFilter>],
     date_jump_active: bool,
     date_jump_buffer: &'a str,
     sort_reversed: bool,
     hide_empty_periods: bool,
     show_totals: bool,
+}
+
+pub(crate) fn build_display_stats(
+    filtered_stats: &[SharedAnalyzerView],
+) -> Vec<SharedAnalyzerView> {
+    if filtered_stats.is_empty() {
+        return Vec::new();
+    }
+
+    let mut combined_daily_stats = BTreeMap::new();
+    let mut combined_sessions = Vec::new();
+    let mut combined_conversations = 0u64;
+
+    for stats in filtered_stats {
+        let view = stats.read();
+        combined_conversations += view.num_conversations;
+
+        for (key, day_stats) in &view.daily_stats {
+            let entry = combined_daily_stats
+                .entry(key.clone())
+                .or_insert_with(|| DailyStats {
+                    date: day_stats.date,
+                    ..DailyStats::default()
+                });
+            *entry += day_stats;
+        }
+
+        combined_sessions.extend(view.session_aggregates.iter().cloned());
+    }
+
+    combined_sessions.sort_by_key(|session| session.first_timestamp);
+
+    let mut display_stats = Vec::with_capacity(filtered_stats.len() + 1);
+    display_stats.push(Arc::new(parking_lot::RwLock::new(AnalyzerStatsView {
+        daily_stats: combined_daily_stats,
+        session_aggregates: combined_sessions,
+        num_conversations: combined_conversations,
+        analyzer_name: Arc::from("All Tools"),
+    })));
+    display_stats.extend(filtered_stats.iter().cloned());
+    display_stats
 }
 
 /// Column width for all token count columns (Cached, Input, Output, Reasoning).
@@ -276,7 +460,7 @@ async fn run_app(
 ) -> Result<()> {
     let mut table_states: Vec<TableState> = Vec::new();
     let mut session_window_offsets: Vec<usize> = Vec::new();
-    let mut session_day_filters: Vec<Option<CompactDate>> = Vec::new();
+    let mut session_period_filters: Vec<Option<PeriodFilter>> = Vec::new();
     let mut date_jump_active = false;
     let mut date_jump_buffer = String::new();
     let mut sort_reversed = tui_config.reverse_sort_default;
@@ -287,7 +471,7 @@ async fn run_app(
     // Initialize table states for current stats
     update_table_states(&mut table_states, &current_stats, selected_tab);
     update_window_offsets(&mut session_window_offsets, &table_states.len());
-    update_day_filters(&mut session_day_filters, &table_states.len());
+    update_period_filters(&mut session_period_filters, &table_states.len());
 
     let mut needs_redraw = true;
     let mut last_upload_status = {
@@ -308,6 +492,7 @@ async fn run_app(
         .filter(|stats| has_data_shared(stats))
         .cloned()
         .collect();
+    let mut display_stats = build_display_stats(&filtered_stats);
 
     loop {
         // Check for update status changes
@@ -330,9 +515,10 @@ async fn run_app(
                 .filter(|stats| has_data_shared(stats))
                 .cloned()
                 .collect();
+            display_stats = build_display_stats(&filtered_stats);
             update_table_states(&mut table_states, &current_stats, selected_tab);
             update_window_offsets(&mut session_window_offsets, &table_states.len());
-            update_day_filters(&mut session_day_filters, &table_states.len());
+            update_period_filters(&mut session_period_filters, &table_states.len());
 
             needs_redraw = true;
         }
@@ -380,7 +566,7 @@ async fn run_app(
                     aggregate_view_mode: *aggregate_view_mode,
                     stats_view_mode: *stats_view_mode,
                     session_window_offsets: &mut session_window_offsets,
-                    session_day_filters: &mut session_day_filters,
+                    session_period_filters: &mut session_period_filters,
                     date_jump_active,
                     date_jump_buffer: &date_jump_buffer,
                     sort_reversed,
@@ -389,7 +575,7 @@ async fn run_app(
                 };
                 draw_ui(
                     frame,
-                    &filtered_stats,
+                    &display_stats,
                     format_options,
                     &mut ui_state,
                     upload_status.clone(),
@@ -433,8 +619,8 @@ async fn run_app(
                 }
             }
 
-            // Only handle navigation keys if we have data (`filtered_stats` is non-empty).
-            if filtered_stats.is_empty() {
+            // Only handle navigation keys if we have data (`display_stats` is non-empty).
+            if display_stats.is_empty() {
                 continue;
             }
 
@@ -443,7 +629,7 @@ async fn run_app(
                     KeyCode::Char(c) if c.is_ascii_alphanumeric() || c == '-' || c == '/' => {
                         date_jump_buffer.push(c);
                         // Auto-jump to first matching date or month.
-                        if let Some(current_stats) = filtered_stats.get(*selected_tab)
+                        if let Some(current_stats) = display_stats.get(*selected_tab)
                             && let Some(table_state) = table_states.get_mut(*selected_tab)
                         {
                             let stats = current_stats.read();
@@ -462,7 +648,7 @@ async fn run_app(
                     KeyCode::Backspace => {
                         date_jump_buffer.pop();
                         // Re-evaluate match after backspace
-                        if let Some(current_stats) = filtered_stats.get(*selected_tab)
+                        if let Some(current_stats) = display_stats.get(*selected_tab)
                             && let Some(table_state) = table_states.get_mut(*selected_tab)
                         {
                             let stats = current_stats.read();
@@ -494,20 +680,13 @@ async fn run_app(
 
                     if let StatsViewMode::Session = *stats_view_mode
                         && let Some(table_state) = table_states.get_mut(*selected_tab)
-                        && let Some(view) = filtered_stats.get(*selected_tab)
+                        && let Some(view) = display_stats.get(*selected_tab)
                     {
                         let view = view.read();
-                        let target_len = match session_day_filters
-                            .get(*selected_tab)
-                            .and_then(|f| f.as_ref())
-                        {
-                            Some(day) => view
-                                .session_aggregates
-                                .iter()
-                                .filter(|s| &s.date == day)
-                                .count(),
-                            None => view.session_aggregates.len(),
-                        };
+                        let target_len = filtered_session_count(
+                            &view,
+                            session_period_filters.get(*selected_tab).copied().flatten(),
+                        );
                         if target_len > 0 {
                             table_state.select(Some(target_len.saturating_sub(1)));
                         }
@@ -516,26 +695,19 @@ async fn run_app(
                     needs_redraw = true;
                 }
                 KeyCode::Right | KeyCode::Char('l')
-                    if *selected_tab < filtered_stats.len().saturating_sub(1) =>
+                    if *selected_tab < display_stats.len().saturating_sub(1) =>
                 {
                     *selected_tab += 1;
 
                     if let StatsViewMode::Session = *stats_view_mode
                         && let Some(table_state) = table_states.get_mut(*selected_tab)
-                        && let Some(view) = filtered_stats.get(*selected_tab)
+                        && let Some(view) = display_stats.get(*selected_tab)
                     {
                         let view = view.read();
-                        let target_len = match session_day_filters
-                            .get(*selected_tab)
-                            .and_then(|f| f.as_ref())
-                        {
-                            Some(day) => view
-                                .session_aggregates
-                                .iter()
-                                .filter(|s| &s.date == day)
-                                .count(),
-                            None => view.session_aggregates.len(),
-                        };
+                        let target_len = filtered_session_count(
+                            &view,
+                            session_period_filters.get(*selected_tab).copied().flatten(),
+                        );
                         if target_len > 0 {
                             table_state.select(Some(target_len.saturating_sub(1)));
                         }
@@ -549,7 +721,7 @@ async fn run_app(
                     {
                         match *stats_view_mode {
                             StatsViewMode::Aggregate => {
-                                if let Some(current_stats) = filtered_stats.get(*selected_tab) {
+                                if let Some(current_stats) = display_stats.get(*selected_tab) {
                                     let view = current_stats.read();
                                     let data_rows = aggregate_total_rows(
                                         &view,
@@ -574,20 +746,17 @@ async fn run_app(
                                 }
                             }
                             StatsViewMode::Session => {
-                                let filtered_len = filtered_stats
+                                let filtered_len = display_stats
                                     .get(*selected_tab)
                                     .map(|view| {
                                         let v = view.read();
-                                        session_day_filters
-                                            .get(*selected_tab)
-                                            .and_then(|f| f.as_ref())
-                                            .map(|day| {
-                                                v.session_aggregates
-                                                    .iter()
-                                                    .filter(|s| &s.date == day)
-                                                    .count()
-                                            })
-                                            .unwrap_or_else(|| v.session_aggregates.len())
+                                        filtered_session_count(
+                                            &v,
+                                            session_period_filters
+                                                .get(*selected_tab)
+                                                .copied()
+                                                .flatten(),
+                                        )
                                     })
                                     .unwrap_or(0);
 
@@ -613,7 +782,7 @@ async fn run_app(
                     {
                         match *stats_view_mode {
                             StatsViewMode::Aggregate => {
-                                if let Some(current_stats) = filtered_stats.get(*selected_tab) {
+                                if let Some(current_stats) = display_stats.get(*selected_tab) {
                                     let view = current_stats.read();
                                     let data_rows = aggregate_total_rows(
                                         &view,
@@ -632,20 +801,17 @@ async fn run_app(
                                 }
                             }
                             StatsViewMode::Session => {
-                                let filtered_len = filtered_stats
+                                let filtered_len = display_stats
                                     .get(*selected_tab)
                                     .map(|view| {
                                         let v = view.read();
-                                        session_day_filters
-                                            .get(*selected_tab)
-                                            .and_then(|f| f.as_ref())
-                                            .map(|day| {
-                                                v.session_aggregates
-                                                    .iter()
-                                                    .filter(|s| &s.date == day)
-                                                    .count()
-                                            })
-                                            .unwrap_or_else(|| v.session_aggregates.len())
+                                        filtered_session_count(
+                                            &v,
+                                            session_period_filters
+                                                .get(*selected_tab)
+                                                .copied()
+                                                .flatten(),
+                                        )
                                     })
                                     .unwrap_or(0);
 
@@ -672,7 +838,7 @@ async fn run_app(
                     if let Some(table_state) = table_states.get_mut(*selected_tab) {
                         match *stats_view_mode {
                             StatsViewMode::Aggregate => {
-                                if let Some(current_stats) = filtered_stats.get(*selected_tab) {
+                                if let Some(current_stats) = display_stats.get(*selected_tab) {
                                     let view = current_stats.read();
                                     let total_rows = aggregate_total_rows(
                                         &view,
@@ -684,20 +850,17 @@ async fn run_app(
                                 }
                             }
                             StatsViewMode::Session => {
-                                let filtered_len = filtered_stats
+                                let filtered_len = display_stats
                                     .get(*selected_tab)
                                     .map(|view| {
                                         let v = view.read();
-                                        session_day_filters
-                                            .get(*selected_tab)
-                                            .and_then(|f| f.as_ref())
-                                            .map(|day| {
-                                                v.session_aggregates
-                                                    .iter()
-                                                    .filter(|s| &s.date == day)
-                                                    .count()
-                                            })
-                                            .unwrap_or_else(|| v.session_aggregates.len())
+                                        filtered_session_count(
+                                            &v,
+                                            session_period_filters
+                                                .get(*selected_tab)
+                                                .copied()
+                                                .flatten(),
+                                        )
                                     })
                                     .unwrap_or(0);
 
@@ -716,7 +879,7 @@ async fn run_app(
                     {
                         match *stats_view_mode {
                             StatsViewMode::Aggregate => {
-                                if let Some(current_stats) = filtered_stats.get(*selected_tab) {
+                                if let Some(current_stats) = display_stats.get(*selected_tab) {
                                     let view = current_stats.read();
                                     let total_rows = aggregate_total_rows(
                                         &view,
@@ -730,20 +893,17 @@ async fn run_app(
                                 }
                             }
                             StatsViewMode::Session => {
-                                let filtered_len = filtered_stats
+                                let filtered_len = display_stats
                                     .get(*selected_tab)
                                     .map(|view| {
                                         let v = view.read();
-                                        session_day_filters
-                                            .get(*selected_tab)
-                                            .and_then(|f| f.as_ref())
-                                            .map(|day| {
-                                                v.session_aggregates
-                                                    .iter()
-                                                    .filter(|s| &s.date == day)
-                                                    .count()
-                                            })
-                                            .unwrap_or_else(|| v.session_aggregates.len())
+                                        filtered_session_count(
+                                            &v,
+                                            session_period_filters
+                                                .get(*selected_tab)
+                                                .copied()
+                                                .flatten(),
+                                        )
                                     })
                                     .unwrap_or(0);
 
@@ -775,10 +935,7 @@ async fn run_app(
                     }
                 }
                 KeyCode::Char('m') => {
-                    *aggregate_view_mode = match *aggregate_view_mode {
-                        AggregateViewMode::Daily => AggregateViewMode::Monthly,
-                        AggregateViewMode::Monthly => AggregateViewMode::Daily,
-                    };
+                    *aggregate_view_mode = aggregate_view_mode.next();
 
                     if matches!(*stats_view_mode, StatsViewMode::Session) {
                         *stats_view_mode = StatsViewMode::Aggregate;
@@ -787,7 +944,7 @@ async fn run_app(
                     date_jump_active = false;
                     date_jump_buffer.clear();
 
-                    if let Some(current_stats) = filtered_stats.get(*selected_tab)
+                    if let Some(current_stats) = display_stats.get(*selected_tab)
                         && let Some(table_state) = table_states.get_mut(*selected_tab)
                     {
                         let view = current_stats.read();
@@ -802,7 +959,7 @@ async fn run_app(
                 KeyCode::Char('t') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                     *stats_view_mode = match *stats_view_mode {
                         StatsViewMode::Aggregate => {
-                            session_day_filters[*selected_tab] = None;
+                            session_period_filters[*selected_tab] = None;
                             StatsViewMode::Session
                         }
                         StatsViewMode::Session => StatsViewMode::Aggregate,
@@ -813,20 +970,14 @@ async fn run_app(
 
                     if let StatsViewMode::Session = *stats_view_mode
                         && let Some(table_state) = table_states.get_mut(*selected_tab)
-                        && let Some(view) = filtered_stats.get(*selected_tab)
+                        && let Some(view) = display_stats.get(*selected_tab)
                     {
                         let v = view.read();
                         if !v.session_aggregates.is_empty() {
-                            let target_len = session_day_filters
-                                .get(*selected_tab)
-                                .and_then(|f| f.as_ref())
-                                .map(|day| {
-                                    v.session_aggregates
-                                        .iter()
-                                        .filter(|s| &s.date == day)
-                                        .count()
-                                })
-                                .unwrap_or_else(|| v.session_aggregates.len());
+                            let target_len = filtered_session_count(
+                                &v,
+                                session_period_filters.get(*selected_tab).copied().flatten(),
+                            );
                             if target_len > 0 {
                                 table_state.select(Some(target_len.saturating_sub(1)));
                             }
@@ -837,31 +988,28 @@ async fn run_app(
                 }
                 KeyCode::Enter => {
                     if let StatsViewMode::Aggregate = *stats_view_mode
-                        && matches!(*aggregate_view_mode, AggregateViewMode::Daily)
-                        && let Some(current_stats) = filtered_stats.get(*selected_tab)
+                        && let Some(current_stats) = display_stats.get(*selected_tab)
                         && let Some(table_state) = table_states.get_mut(*selected_tab)
                         && let Some(selected_idx) = table_state.selected()
                     {
                         let view = current_stats.read();
                         if selected_idx
-                            < aggregate_total_rows(
-                                &view,
-                                AggregateViewMode::Daily,
-                                hide_empty_periods,
-                            )
-                            .saturating_sub(2)
+                            < aggregate_total_rows(&view, *aggregate_view_mode, hide_empty_periods)
+                                .saturating_sub(2)
                         {
-                            let day_key = aggregate_key_at(
+                            let period_filter = aggregate_key_at(
                                 &view,
-                                AggregateViewMode::Daily,
+                                *aggregate_view_mode,
                                 selected_idx,
                                 hide_empty_periods,
                                 sort_reversed,
                             )
-                            .and_then(|key| CompactDate::from_str(&key));
+                            .and_then(|key| {
+                                PeriodFilter::from_period_key(&key, *aggregate_view_mode)
+                            });
 
-                            if let Some(day_key) = day_key {
-                                session_day_filters[*selected_tab] = Some(day_key);
+                            if let Some(period_filter) = period_filter {
+                                session_period_filters[*selected_tab] = Some(period_filter);
                                 *stats_view_mode = StatsViewMode::Session;
                                 session_window_offsets[*selected_tab] = 0;
                                 table_state.select(Some(0));
@@ -877,7 +1025,7 @@ async fn run_app(
                 KeyCode::Char('e') => {
                     hide_empty_periods = !hide_empty_periods;
                     if matches!(*stats_view_mode, StatsViewMode::Aggregate)
-                        && let Some(current_stats) = filtered_stats.get(*selected_tab)
+                        && let Some(current_stats) = display_stats.get(*selected_tab)
                         && let Some(table_state) = table_states.get_mut(*selected_tab)
                     {
                         let view = current_stats.read();
@@ -902,14 +1050,14 @@ async fn run_app(
 
 fn draw_ui(
     frame: &mut Frame,
-    filtered_stats: &[SharedAnalyzerView],
+    display_stats: &[SharedAnalyzerView],
     format_options: &NumberFormatOptions,
     ui_state: &mut UiState,
     upload_status: Arc<Mutex<UploadStatus>>,
     update_status: Arc<Mutex<crate::version_check::UpdateStatus>>,
 ) {
-    // Since we're already working with filtered stats, has_data is simply whether we have any stats
-    let has_data = !filtered_stats.is_empty();
+    let has_data = !display_stats.is_empty();
+    let tool_stats = if has_data { &display_stats[1..] } else { &[] };
 
     // Check if we have an error to determine help area height
     let has_error = matches!(*upload_status.lock(), UploadStatus::Failed(_));
@@ -996,7 +1144,7 @@ fn draw_ui(
 
     if has_data {
         // Tabs
-        let tab_titles: Vec<Line> = filtered_stats
+        let tab_titles: Vec<Line> = display_stats
             .iter()
             .map(|stats| {
                 let s = stats.read();
@@ -1014,7 +1162,7 @@ fn draw_ui(
         frame.render_widget(tabs, chunks[1 + chunk_offset]);
 
         // Get current analyzer stats
-        if let Some(current_stats) = filtered_stats.get(ui_state.selected_tab)
+        if let Some(current_stats) = display_stats.get(ui_state.selected_tab)
             && let Some(current_table_state) = ui_state.table_states.get_mut(ui_state.selected_tab)
         {
             // Draw main table - hold read lock only for this scope
@@ -1047,7 +1195,7 @@ fn draw_ui(
                             format_options,
                             current_table_state,
                             &mut ui_state.session_window_offsets[ui_state.selected_tab],
-                            ui_state.session_day_filters[ui_state.selected_tab],
+                            ui_state.session_period_filters[ui_state.selected_tab],
                             ui_state.sort_reversed,
                         );
                         false // Session view doesn't track estimated models yet
@@ -1059,9 +1207,9 @@ fn draw_ui(
             // When in Session mode with a day filter, only show totals for that day
             // NOTE: This acquires its own read locks, so we must not hold any above
             let help_chunk_offset = if ui_state.show_totals {
-                let day_filter = match ui_state.stats_view_mode {
+                let period_filter = match ui_state.stats_view_mode {
                     StatsViewMode::Session => ui_state
-                        .session_day_filters
+                        .session_period_filters
                         .get(ui_state.selected_tab)
                         .copied()
                         .flatten(),
@@ -1070,9 +1218,9 @@ fn draw_ui(
                 draw_summary_stats(
                     frame,
                     chunks[3 + chunk_offset],
-                    filtered_stats,
+                    tool_stats,
                     format_options,
-                    day_filter,
+                    period_filter,
                 );
                 4 + chunk_offset
             } else {
@@ -1093,21 +1241,17 @@ fn draw_ui(
                 StatsViewMode::Aggregate => {
                     let jump_label = match ui_state.aggregate_view_mode {
                         AggregateViewMode::Daily => "date jump",
+                        AggregateViewMode::Weekly => "week jump",
                         AggregateViewMode::Monthly => "month jump",
-                    };
-                    let drill_hint = if matches!(ui_state.aggregate_view_mode, AggregateViewMode::Daily)
-                    {
-                        " • Enter to drill into day"
-                    } else {
-                        ""
+                        AggregateViewMode::Yearly => "year jump",
                     };
 
                     format!(
-                        "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • e to toggle empty periods • s to toggle summary • / for {jump_label} • m to toggle daily/monthly{drill_hint} • Ctrl+T for per-session view • q/Esc to quit"
+                        "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • e to toggle empty periods • s to toggle summary • / for {jump_label} • m to cycle day/week/month/year • Enter to drill into period • Ctrl+T for all sessions • q/Esc to quit"
                     )
                 }
                 StatsViewMode::Session => {
-                    "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • e to toggle empty periods • s to toggle summary • m to toggle daily/monthly • Ctrl+T for per-period view • q/Esc to quit".to_string()
+                    "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • e to toggle empty periods • s to toggle summary • m to cycle day/week/month/year • Ctrl+T for aggregate view • q/Esc to quit".to_string()
                 }
             };
 
@@ -1206,7 +1350,9 @@ fn draw_aggregate_stats_table(
 ) -> (usize, bool) {
     let period_header = match aggregate_view_mode {
         AggregateViewMode::Daily => "Date",
+        AggregateViewMode::Weekly => "Week",
         AggregateViewMode::Monthly => "Month",
+        AggregateViewMode::Yearly => "Year",
     };
 
     let aggregate_stats = get_aggregate_stats(stats, aggregate_view_mode);
@@ -1584,7 +1730,9 @@ fn draw_aggregate_stats_table(
         Line::from(Span::styled(
             match aggregate_view_mode {
                 AggregateViewMode::Daily => format!("Total ({}d)", visible_periods.len()),
+                AggregateViewMode::Weekly => format!("Total ({}w)", visible_periods.len()),
                 AggregateViewMode::Monthly => format!("Total ({}m)", visible_periods.len()),
+                AggregateViewMode::Yearly => format!("Total ({}y)", visible_periods.len()),
             },
             Style::default().add_modifier(Modifier::BOLD),
         )),
@@ -1672,7 +1820,7 @@ fn draw_session_stats_table(
     format_options: &NumberFormatOptions,
     table_state: &mut TableState,
     window_offset: &mut usize,
-    day_filter: Option<CompactDate>,
+    period_filter: Option<PeriodFilter>,
     sort_reversed: bool,
 ) {
     let header = Row::new(vec![
@@ -1691,8 +1839,11 @@ fn draw_session_stats_table(
     .height(1);
 
     let filtered_sessions: Vec<&SessionAggregate> = {
-        let mut sessions: Vec<_> = match day_filter {
-            Some(day) => sessions.iter().filter(|s| s.date == day).collect(),
+        let mut sessions: Vec<_> = match period_filter {
+            Some(filter) => sessions
+                .iter()
+                .filter(|session| filter.matches_compact_date(session.date))
+                .collect(),
             None => sessions.iter().collect(),
         };
         if sort_reversed {
@@ -2098,9 +2249,9 @@ fn draw_summary_stats(
     area: Rect,
     filtered_stats: &[SharedAnalyzerView],
     format_options: &NumberFormatOptions,
-    day_filter: Option<CompactDate>,
+    period_filter: Option<PeriodFilter>,
 ) {
-    // Aggregate stats from all tools, optionally filtered to a single day
+    // Aggregate stats from all tools, optionally filtered to a single period
     let mut total_cost_cents: u64 = 0;
     let mut total_cached: u64 = 0;
     let mut total_input: u64 = 0;
@@ -2111,11 +2262,10 @@ fn draw_summary_stats(
 
     for stats_arc in filtered_stats {
         let stats = stats_arc.read();
-        // Iterate directly - filter inline if day_filter is set
-        for (day, day_stats) in stats.daily_stats.iter() {
-            // Skip if day doesn't match filter
-            if let Some(filter_day) = day_filter
-                && CompactDate::from_str(day) != Some(filter_day)
+        // Iterate directly - filter inline if a period filter is set
+        for day_stats in stats.daily_stats.values() {
+            if let Some(filter) = period_filter
+                && !filter.matches_compact_date(day_stats.date)
             {
                 continue;
             }
@@ -2137,7 +2287,7 @@ fn draw_summary_stats(
                 || day_stats.ai_messages > 0
                 || day_stats.conversations > 0
             {
-                all_days.insert(day.clone());
+                all_days.insert(day_stats.date);
             }
         }
     }
@@ -2195,11 +2345,11 @@ fn draw_summary_stats(
         )]),
     );
 
-    // Show "Totals" or "Totals for <date>" depending on filter
-    let title = if let Some(day) = day_filter {
+    // Show "Totals" or "Totals for <period>" depending on filter
+    let title = if let Some(filter) = period_filter {
         format!(
             "Totals for {}",
-            crate::utils::format_date_for_display(&day.to_string())
+            format_aggregate_period_for_display(&filter.display_key(), filter.view_mode())
         )
     } else {
         "Totals".to_string()
@@ -2228,12 +2378,17 @@ fn update_table_states(
         .iter()
         .filter(|stats| has_data_shared(stats))
         .count();
+    let display_count = if filtered_count > 0 {
+        filtered_count + 1
+    } else {
+        0
+    };
 
     // Preserve existing table states when resizing
     let old_states = table_states.clone();
     table_states.clear();
 
-    for i in 0..filtered_count {
+    for i in 0..display_count {
         let state = if i < old_states.len() {
             // Preserve existing state if available
             old_states[i]
@@ -2247,8 +2402,8 @@ fn update_table_states(
     }
 
     // Ensure selected tab is within bounds
-    if *selected_tab >= filtered_count && filtered_count > 0 {
-        *selected_tab = filtered_count - 1;
+    if *selected_tab >= display_count && display_count > 0 {
+        *selected_tab = display_count - 1;
     }
 }
 
@@ -2268,10 +2423,10 @@ fn update_window_offsets(window_offsets: &mut Vec<usize>, filtered_count: &usize
     }
 }
 
-/// Resize the day filter vector to match the filtered analyzer count.
+/// Resize the period filter vector to match the filtered analyzer count.
 ///
 /// Preserves existing filter values when growing; new entries default to `None`.
-fn update_day_filters(filters: &mut Vec<Option<CompactDate>>, filtered_count: &usize) {
+fn update_period_filters(filters: &mut Vec<Option<PeriodFilter>>, filtered_count: &usize) {
     let old_len = filters.len();
     filters.resize(*filtered_count, None);
     if *filtered_count < old_len {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -365,7 +365,14 @@ pub(crate) fn build_display_stats(
             *entry += day_stats;
         }
 
-        combined_sessions.extend(view.session_aggregates.iter().cloned());
+        combined_sessions.extend(view.session_aggregates.iter().cloned().map(|mut session| {
+            let base_name = session
+                .session_name
+                .clone()
+                .unwrap_or_else(|| session.session_id.clone());
+            session.session_name = Some(format!("[{}] {}", session.analyzer_name, base_name));
+            session
+        }));
     }
 
     combined_sessions.sort_by_key(|session| session.first_timestamp);
@@ -2429,11 +2436,7 @@ fn update_window_offsets(window_offsets: &mut Vec<usize>, filtered_count: &usize
 ///
 /// Preserves existing filter values when growing; new entries default to `None`.
 fn update_period_filters(filters: &mut Vec<Option<PeriodFilter>>, filtered_count: &usize) {
-    let old_len = filters.len();
     filters.resize(*filtered_count, None);
-    if *filtered_count < old_len {
-        filters.truncate(*filtered_count);
-    }
 }
 
 /// Build a callback that prints upload progress to stdout with animated dots.

--- a/src/tui/logic.rs
+++ b/src/tui/logic.rs
@@ -283,6 +283,10 @@ where
     aggregate_stats
 }
 
+/// Roll up daily statistics into monthly totals.
+///
+/// Groups days by `YYYY-MM`, using the first day of the month as the
+/// representative `CompactDate` stored in the aggregated row.
 pub fn aggregate_daily_stats_by_month(
     daily_stats: &BTreeMap<String, DailyStats>,
 ) -> BTreeMap<String, DailyStats> {
@@ -326,6 +330,9 @@ pub fn aggregate_daily_stats_by_week(
 }
 
 /// Roll up daily statistics into yearly totals.
+///
+/// Yearly rows are keyed as `YYYY` and use January 1st as the representative
+/// `CompactDate`.
 pub fn aggregate_daily_stats_by_year(
     daily_stats: &BTreeMap<String, DailyStats>,
 ) -> BTreeMap<String, DailyStats> {
@@ -335,6 +342,7 @@ pub fn aggregate_daily_stats_by_year(
     })
 }
 
+/// Return whether a period contains no visible activity for the aggregate table.
 pub fn is_empty_period(stats: &DailyStats) -> bool {
     stats.stats.cost_cents == 0
         && stats.stats.cached_tokens == 0
@@ -347,6 +355,7 @@ pub fn is_empty_period(stats: &DailyStats) -> bool {
         && stats.stats.tool_calls == 0
 }
 
+/// Collect aggregate keys after applying empty-period filtering and sort order.
 pub fn filtered_aggregate_keys(
     aggregate_stats: &BTreeMap<String, DailyStats>,
     hide_empty_periods: bool,

--- a/src/tui/logic.rs
+++ b/src/tui/logic.rs
@@ -253,11 +253,11 @@ pub fn date_matches_buffer(day: &str, buffer: &str) -> bool {
     false
 }
 
-/// Roll up daily statistics into monthly totals.
+/// Roll up daily statistics into periods derived by `period_key_fn`.
 ///
-/// Groups daily stats by year-month (YYYY-MM) and sums all metrics. Each month
-/// entry uses day 1 of that month as its representative date. Returns a new
-/// map with monthly aggregated data.
+/// `period_key_fn` returns a `(period_key, representative_date)` pair for each
+/// daily row. All rows with the same key are then merged via
+/// `DailyStats += &DailyStats`.
 fn aggregate_daily_stats_by_period<F>(
     daily_stats: &BTreeMap<String, DailyStats>,
     mut period_key_fn: F,

--- a/src/tui/logic.rs
+++ b/src/tui/logic.rs
@@ -5,6 +5,7 @@ use crate::types::{
     CompactDate, ConversationMessage, DailyStats, MessageRole, ModelCounts, Stats, TuiStats,
     intern_model,
 };
+use chrono::{Datelike, NaiveDate, Weekday};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -36,6 +37,95 @@ fn parse_period_parts(day: &str) -> Option<(u32, u32, Option<u32>)> {
     }
 }
 
+fn parse_input_date(buffer: &str) -> Option<NaiveDate> {
+    let normalized = buffer.trim().replace('/', "-");
+    let trimmed = normalized.trim_end_matches('-');
+    let parts: Vec<&str> = trimmed.split('-').filter(|s| !s.is_empty()).collect();
+
+    let [p0, p1, p2] = parts.as_slice() else {
+        return None;
+    };
+
+    let (a, b, c) = (
+        p0.parse::<u32>().ok()?,
+        p1.parse::<u32>().ok()?,
+        p2.parse::<u32>().ok()?,
+    );
+
+    let (year, month, day) = if a > 31 {
+        (a as i32, b, c)
+    } else if c > 31 {
+        (c as i32, a, b)
+    } else {
+        return None;
+    };
+
+    NaiveDate::from_ymd_opt(year, month, day)
+}
+
+fn parse_week_key(period: &str) -> Option<(i32, u32)> {
+    let (year, week) = period.split_once("-W")?;
+    Some((year.parse().ok()?, week.parse().ok()?))
+}
+
+fn week_matches_buffer(week_year: i32, iso_week: u32, buffer: &str) -> bool {
+    if let Some(date) = parse_input_date(buffer) {
+        let input_week = date.iso_week();
+        return input_week.year() == week_year && input_week.week() == iso_week;
+    }
+
+    let normalized = buffer
+        .trim()
+        .to_uppercase()
+        .replace('/', "-")
+        .replace(' ', "");
+    let canonical = format!("{week_year:04}-W{iso_week:02}");
+
+    if normalized == canonical
+        || normalized == format!("{week_year:04}-W{iso_week}")
+        || normalized == format!("W{iso_week:02}")
+        || normalized == format!("W{iso_week}")
+        || normalized == format!("WEEK{iso_week:02}")
+        || normalized == format!("WEEK{iso_week}")
+    {
+        return true;
+    }
+
+    let parts: Vec<&str> = normalized.split('-').filter(|s| !s.is_empty()).collect();
+
+    match parts.as_slice() {
+        [single] => single
+            .parse::<u32>()
+            .map(|value| value == iso_week || value == week_year as u32)
+            .unwrap_or(false),
+        [year, week] => {
+            if let (Ok(year), Ok(week)) = (year.parse::<i32>(), week.parse::<u32>()) {
+                year == week_year && week == iso_week
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }
+}
+
+fn year_matches_buffer(year: u32, buffer: &str) -> bool {
+    if let Some(date) = parse_input_date(buffer) {
+        return date.year() as u32 == year;
+    }
+
+    let normalized = buffer.trim().replace('/', "-");
+    if normalized == year.to_string() {
+        return true;
+    }
+
+    normalized
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .filter_map(|part| part.parse::<u32>().ok())
+        .any(|value| value == year)
+}
+
 fn month_name_to_number(lower: &str) -> Option<u32> {
     match lower {
         s if "january".starts_with(s) && s.len() >= 3 => Some(1),
@@ -60,9 +150,25 @@ pub fn date_matches_buffer(day: &str, buffer: &str) -> bool {
         return true;
     }
 
+    if let Some((week_year, iso_week)) = parse_week_key(day) {
+        return week_matches_buffer(week_year, iso_week, buffer);
+    }
+
+    if let Ok(year) = day.parse::<u32>() {
+        return year_matches_buffer(year, buffer);
+    }
+
     let Some((day_year, day_month, day_number)) = parse_period_parts(day) else {
         return day == buffer;
     };
+
+    if let Some(date) = parse_input_date(buffer) {
+        return day_year == date.year() as u32
+            && day_month == date.month()
+            && day_number
+                .map(|actual_day| actual_day == date.day())
+                .unwrap_or(true);
+    }
 
     // Check for month name match first
     let lower = buffer.to_lowercase();
@@ -152,27 +258,81 @@ pub fn date_matches_buffer(day: &str, buffer: &str) -> bool {
 /// Groups daily stats by year-month (YYYY-MM) and sums all metrics. Each month
 /// entry uses day 1 of that month as its representative date. Returns a new
 /// map with monthly aggregated data.
-pub fn aggregate_daily_stats_by_month(
+fn aggregate_daily_stats_by_period<F>(
     daily_stats: &BTreeMap<String, DailyStats>,
-) -> BTreeMap<String, DailyStats> {
-    let mut monthly_stats = BTreeMap::new();
+    mut period_key_fn: F,
+) -> BTreeMap<String, DailyStats>
+where
+    F: FnMut(&DailyStats) -> (String, CompactDate),
+{
+    let mut aggregate_stats = BTreeMap::new();
 
     for day_stats in daily_stats.values() {
-        let year = day_stats.date.year();
-        let month = day_stats.date.month();
-        let month_key = format!("{year:04}-{month:02}");
+        let (period_key, period_date) = period_key_fn(day_stats);
 
-        let monthly_entry = monthly_stats
-            .entry(month_key)
+        let aggregate_entry = aggregate_stats
+            .entry(period_key)
             .or_insert_with(|| DailyStats {
-                date: CompactDate::from_parts(year, month, 1),
+                date: period_date,
                 ..DailyStats::default()
             });
 
-        *monthly_entry += day_stats;
+        *aggregate_entry += day_stats;
     }
 
-    monthly_stats
+    aggregate_stats
+}
+
+pub fn aggregate_daily_stats_by_month(
+    daily_stats: &BTreeMap<String, DailyStats>,
+) -> BTreeMap<String, DailyStats> {
+    aggregate_daily_stats_by_period(daily_stats, |day_stats| {
+        let year = day_stats.date.year();
+        let month = day_stats.date.month();
+        (
+            format!("{year:04}-{month:02}"),
+            CompactDate::from_parts(year, month, 1),
+        )
+    })
+}
+
+/// Roll up daily statistics into ISO weekly totals.
+///
+/// Weeks use ISO-8601 semantics, so they start on Monday and are keyed as
+/// `YYYY-Www`, where `YYYY` is the ISO week year.
+pub fn aggregate_daily_stats_by_week(
+    daily_stats: &BTreeMap<String, DailyStats>,
+) -> BTreeMap<String, DailyStats> {
+    aggregate_daily_stats_by_period(daily_stats, |day_stats| {
+        let date = NaiveDate::from_ymd_opt(
+            day_stats.date.year() as i32,
+            day_stats.date.month() as u32,
+            day_stats.date.day() as u32,
+        )
+        .expect("CompactDate should always contain a valid calendar date");
+        let iso_week = date.iso_week();
+        let week_start = NaiveDate::from_isoywd_opt(iso_week.year(), iso_week.week(), Weekday::Mon)
+            .expect("ISO week from a valid date should map back to a valid Monday");
+
+        (
+            format!("{:04}-W{:02}", iso_week.year(), iso_week.week()),
+            CompactDate::from_parts(
+                week_start.year() as u16,
+                week_start.month() as u8,
+                week_start.day() as u8,
+            ),
+        )
+    })
+}
+
+/// Roll up daily statistics into yearly totals.
+pub fn aggregate_daily_stats_by_year(
+    daily_stats: &BTreeMap<String, DailyStats>,
+) -> BTreeMap<String, DailyStats> {
+    aggregate_daily_stats_by_period(daily_stats, |day_stats| {
+        let year = day_stats.date.year();
+        (format!("{year:04}"), CompactDate::from_parts(year, 1, 1))
+    })
 }
 
 pub fn is_empty_period(stats: &DailyStats) -> bool {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,11 +1,12 @@
 /// Tests for TUI components: table state management, upload progress, date matching, and stats accumulation.
 use crate::tui::logic::{
-    accumulate_tui_stats, aggregate_daily_stats_by_month, date_matches_buffer,
-    filtered_aggregate_keys,
+    accumulate_tui_stats, aggregate_daily_stats_by_month, aggregate_daily_stats_by_week,
+    aggregate_daily_stats_by_year, date_matches_buffer, filtered_aggregate_keys,
 };
 use crate::tui::{
-    create_upload_progress_callback, format_month_for_display, show_upload_error,
-    show_upload_success, update_day_filters, update_table_states, update_window_offsets,
+    PeriodFilter, build_display_stats, create_upload_progress_callback, format_month_for_display,
+    format_week_for_display, format_year_for_display, show_upload_error, show_upload_success,
+    update_period_filters, update_table_states, update_window_offsets,
 };
 use crate::types::{
     AgenticCodingToolStats, CompactDate, DailyStats, MultiAnalyzerStats, Stats, TuiStats,
@@ -82,13 +83,13 @@ fn test_update_table_states_filters_and_preserves_selection() {
 
     update_table_states(&mut table_states, &multi_view, &mut selected_tab);
 
-    // Only analyzers with data should be represented.
-    assert_eq!(table_states.len(), 1);
+    // Data tabs include the synthetic All Tools tab plus each analyzer with data.
+    assert_eq!(table_states.len(), 2);
     assert_eq!(selected_tab, 0);
     assert_eq!(table_states[0].selected(), Some(0));
 
     // If selected_tab is out of range, it should be clamped.
-    let mut table_states = vec![TableState::default(); 1];
+    let mut table_states = vec![TableState::default(); 2];
     let mut selected_tab = 10usize;
     let multi2 = MultiAnalyzerStats {
         analyzer_stats: vec![
@@ -98,28 +99,56 @@ fn test_update_table_states_filters_and_preserves_selection() {
     };
     let multi_view2 = multi2.into_view();
     update_table_states(&mut table_states, &multi_view2, &mut selected_tab);
-    assert_eq!(selected_tab, 0);
+    assert_eq!(selected_tab, 1);
 }
 
 #[test]
 fn test_update_window_offsets_and_day_filters_resize() {
     let mut offsets = vec![5usize];
     let day = CompactDate::from_str("2025-01-01").unwrap();
-    let mut filters: Vec<Option<CompactDate>> = vec![Some(day)];
+    let mut filters: Vec<Option<PeriodFilter>> = vec![Some(PeriodFilter::Day(day))];
 
     let count_two = 2usize;
     update_window_offsets(&mut offsets, &count_two);
-    update_day_filters(&mut filters, &count_two);
+    update_period_filters(&mut filters, &count_two);
 
     assert_eq!(offsets, vec![5, 0]);
-    assert_eq!(filters, vec![Some(day), None]);
+    assert_eq!(filters, vec![Some(PeriodFilter::Day(day)), None]);
 
     let count_one = 1usize;
     update_window_offsets(&mut offsets, &count_one);
-    update_day_filters(&mut filters, &count_one);
+    update_period_filters(&mut filters, &count_one);
 
     assert_eq!(offsets, vec![5]);
-    assert_eq!(filters, vec![Some(day)]);
+    assert_eq!(filters, vec![Some(PeriodFilter::Day(day))]);
+}
+
+#[test]
+fn test_build_display_stats_prepends_all_tools_view() {
+    let multi = MultiAnalyzerStats {
+        analyzer_stats: vec![
+            make_tool_stats("tool-a", true),
+            make_tool_stats("tool-b", true),
+        ],
+    };
+    let multi_view = multi.into_view();
+    let filtered_stats: Vec<_> = multi_view.analyzer_stats.clone();
+
+    let display_stats = build_display_stats(&filtered_stats);
+
+    assert_eq!(display_stats.len(), 3);
+
+    let all_tools = display_stats[0].read();
+    assert_eq!(&*all_tools.analyzer_name, "All Tools");
+    assert_eq!(all_tools.num_conversations, 2);
+    assert_eq!(
+        all_tools
+            .daily_stats
+            .get("2025-01-01")
+            .unwrap()
+            .conversations,
+        2
+    );
 }
 
 // ============================================================================
@@ -484,7 +513,25 @@ fn test_date_filter_monthly_keys() {
     assert!(date_matches_buffer("2025-06", "jun"));
     assert!(date_matches_buffer("2025-06", "6/2025"));
     assert!(date_matches_buffer("2025-06", "2025"));
+    assert!(date_matches_buffer("2025-06", "2025-06-15"));
     assert!(!date_matches_buffer("2025-06", "6-15"));
+}
+
+#[test]
+fn test_date_filter_weekly_keys() {
+    assert!(date_matches_buffer("2025-W20", "2025-W20"));
+    assert!(date_matches_buffer("2025-W20", "W20"));
+    assert!(date_matches_buffer("2025-W20", "20"));
+    assert!(date_matches_buffer("2025-W20", "2025-05-14"));
+    assert!(!date_matches_buffer("2025-W20", "2025-W21"));
+}
+
+#[test]
+fn test_date_filter_yearly_keys() {
+    assert!(date_matches_buffer("2025", "2025"));
+    assert!(date_matches_buffer("2025", "2025-06"));
+    assert!(date_matches_buffer("2025", "2025-06-15"));
+    assert!(!date_matches_buffer("2025", "2024"));
 }
 
 #[test]
@@ -521,10 +568,78 @@ fn test_aggregate_daily_stats_by_month_rolls_up_days() {
 }
 
 #[test]
+fn test_aggregate_daily_stats_by_week_rolls_up_iso_weeks() {
+    let mut daily_stats = BTreeMap::new();
+    daily_stats.insert(
+        "2024-12-30".to_string(),
+        make_daily_stats("2024-12-30", 100, 100, 1),
+    );
+    daily_stats.insert(
+        "2025-01-05".to_string(),
+        make_daily_stats("2025-01-05", 200, 200, 2),
+    );
+    daily_stats.insert(
+        "2025-01-06".to_string(),
+        make_daily_stats("2025-01-06", 50, 50, 1),
+    );
+
+    let weekly = aggregate_daily_stats_by_week(&daily_stats);
+
+    assert_eq!(weekly.len(), 2);
+
+    let first_week = weekly.get("2025-W01").unwrap();
+    assert_eq!(first_week.date, CompactDate::from_parts(2024, 12, 30));
+    assert_eq!(first_week.stats.input_tokens, 300);
+    assert_eq!(first_week.stats.cost_cents, 300);
+    assert_eq!(first_week.conversations, 3);
+
+    let second_week = weekly.get("2025-W02").unwrap();
+    assert_eq!(second_week.date, CompactDate::from_parts(2025, 1, 6));
+    assert_eq!(second_week.stats.input_tokens, 50);
+    assert_eq!(second_week.conversations, 1);
+}
+
+#[test]
+fn test_aggregate_daily_stats_by_year_rolls_up_years() {
+    let mut daily_stats = BTreeMap::new();
+    daily_stats.insert(
+        "2024-12-31".to_string(),
+        make_daily_stats("2024-12-31", 25, 25, 1),
+    );
+    daily_stats.insert(
+        "2025-01-01".to_string(),
+        make_daily_stats("2025-01-01", 75, 75, 2),
+    );
+    daily_stats.insert(
+        "2025-12-31".to_string(),
+        make_daily_stats("2025-12-31", 125, 125, 3),
+    );
+
+    let yearly = aggregate_daily_stats_by_year(&daily_stats);
+
+    assert_eq!(yearly.len(), 2);
+    assert_eq!(yearly.get("2024").unwrap().stats.input_tokens, 25);
+
+    let year_2025 = yearly.get("2025").unwrap();
+    assert_eq!(year_2025.date, CompactDate::from_parts(2025, 1, 1));
+    assert_eq!(year_2025.stats.input_tokens, 200);
+    assert_eq!(year_2025.stats.cost_cents, 200);
+    assert_eq!(year_2025.conversations, 5);
+}
+
+#[test]
 fn test_format_month_for_display_formats_month_and_year() {
     assert_eq!(format_month_for_display("unknown"), "Unknown");
     assert_eq!(format_month_for_display("invalid"), "invalid");
     assert_eq!(format_month_for_display("2025-02"), "2/2025");
+}
+
+#[test]
+fn test_format_week_and_year_for_display() {
+    assert_eq!(format_week_for_display("unknown"), "Unknown");
+    assert_eq!(format_week_for_display("1999-W02"), "1999-W02");
+    assert_eq!(format_year_for_display("unknown"), "Unknown");
+    assert_eq!(format_year_for_display("1999"), "1999");
 }
 
 #[test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -103,7 +103,7 @@ fn test_update_table_states_filters_and_preserves_selection() {
 }
 
 #[test]
-fn test_update_window_offsets_and_day_filters_resize() {
+fn test_update_window_offsets_and_period_filters_resize() {
     let mut offsets = vec![5usize];
     let day = CompactDate::from_str("2025-01-01").unwrap();
     let mut filters: Vec<Option<PeriodFilter>> = vec![Some(PeriodFilter::Day(day))];


### PR DESCRIPTION
## Summary

This PR adds broader period-based aggregation support to the TUI and introduces a combined **All Tools** view so reviewers can inspect total usage across all tracked tools in one place.

## Key Changes

- add daily, weekly, monthly, and yearly aggregation modes in the TUI
- use ISO week grouping for weekly views, with weeks starting on Monday
- add an **All Tools** tab that combines usage from every analyzer and supports the same period switching, search, and drilldown behavior as individual tool tabs
- generalize period filtering so session drilldown and totals work consistently across day/week/month/year views
- extend TUI tests to cover weekly/yearly aggregation, period matching, and the combined tab behavior

## Testing

- cargo fmt --all --quiet
- cargo build --quiet
- cargo test --quiet
- cargo clippy --quiet -- -D warnings
- cargo doc --quiet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly and yearly aggregation modes, enabling broader time-period views beyond daily and monthly.
  * Introduced "All Tools" combined view for cross-tool data aggregation.
  * Enhanced navigation with period-based jumping (week/month/year drilling).

* **Improvements**
  * Improved session filtering to respect selected time periods.
  * Refined UI state management for time-period filtering.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Piebald-AI/splitrail/pull/158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->