### PR TITLE
Remove GPT-5.2 Codex pricing warning

### DIFF
--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -13,7 +13,7 @@ use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
 use crate::models::calculate_total_cost;
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
-use crate::utils::{deserialize_utc_timestamp, hash_text, warn_once, warn_once_yellow};
+use crate::utils::{deserialize_utc_timestamp, hash_text, warn_once};
 
 const DEFAULT_FALLBACK_MODEL: &str = "gpt-5";
 
@@ -188,15 +188,6 @@ struct SessionModel {
 
 impl SessionModel {
     fn explicit(name: String) -> Self {
-        // Warn users who may have uploaded gpt-5.2-codex data before pricing was added
-        if name == "gpt-5.2-codex" {
-            warn_once_yellow(
-                "gpt-5.2-codex pricing was added recently. Any data uploaded to \
-                Splitrail Cloud with this model will show costs as $0. To fix: go to \
-                Settings on splitrail.dev, delete your Codex CLI data, then re-upload."
-                    .to_string(),
-            );
-        }
         Self { name }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,17 +22,6 @@ pub fn warn_once(message: impl Into<String>) {
     }
 }
 
-/// Like warn_once, but prints in yellow with a warning emoji
-pub fn warn_once_yellow(message: impl Into<String>) {
-    let message = message.into();
-    let cache = WARNED_MESSAGES.get_or_init(|| Mutex::new(HashSet::new()));
-
-    if cache.lock().insert(message.clone()) {
-        // ANSI escape codes: \x1b[33m = yellow, \x1b[0m = reset
-        eprintln!("\x1b[33m⚠️  {message}\x1b[0m");
-    }
-}
-
 #[derive(Clone)]
 pub struct NumberFormatOptions {
     pub use_comma: bool,


### PR DESCRIPTION
## Summary
- Remove the special GPT-5.2 Codex pricing warning from Codex CLI parsing
- Remove the now-unused yellow warning helper

## Verification
- cargo fmt --all --quiet
- cargo build --quiet
- rg check for removed warning strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of token cost calculations by properly normalizing cached read tokens for models with caching support.

* **New Features**
  * Added support for semantic understanding of how different models handle input tokens, particularly for cached token scenarios.

* **Configuration Changes**
  * Updated caching support configuration schema for improved clarity and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Piebald-AI/splitrail/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->