### PR TITLE
feat: move upload state to platform state directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,10 @@ pub struct UploadConfig {
     pub auto_upload: bool,
     pub upload_today_only: bool,
     pub retry_attempts: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
+pub struct UploadState {
     pub last_date_uploaded: i64,
 }
 
@@ -58,7 +62,6 @@ impl Default for Config {
                 auto_upload: false,
                 upload_today_only: false,
                 retry_attempts: 3,
-                last_date_uploaded: 0,
             },
             formatting: FormattingConfig {
                 number_comma: false,
@@ -75,11 +78,17 @@ impl Default for Config {
 
 thread_local! {
     static TEST_CONFIG_PATH: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
+    static TEST_STATE_PATH: RefCell<Option<PathBuf>> = const { RefCell::new(None) };
 }
 
 #[cfg(test)]
 pub fn set_test_config_path(path: PathBuf) {
     TEST_CONFIG_PATH.with(|p| *p.borrow_mut() = Some(path));
+}
+
+#[cfg(test)]
+pub fn set_test_state_path(path: PathBuf) {
+    TEST_STATE_PATH.with(|p| *p.borrow_mut() = Some(path));
 }
 
 impl Config {
@@ -146,9 +155,77 @@ impl Config {
     pub fn is_server_url_missing(&self) -> bool {
         self.server.url.is_empty()
     }
+}
 
-    pub fn set_last_date_uploaded(&mut self, date: i64) {
-        self.upload.last_date_uploaded = date;
+#[derive(Debug, Deserialize, Default)]
+struct LegacyConfigFile {
+    #[serde(default)]
+    upload: LegacyUploadConfig,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct LegacyUploadConfig {
+    last_date_uploaded: Option<i64>,
+}
+
+impl UploadState {
+    pub fn state_path() -> Result<PathBuf> {
+        #[cfg(test)]
+        {
+            if let Some(path) = TEST_STATE_PATH.with(|p| p.borrow().clone()) {
+                return Ok(path);
+            }
+        }
+
+        let state_root = dirs::state_dir()
+            .or_else(dirs::data_local_dir)
+            .context("Could not find platform state directory")?;
+
+        Ok(state_root.join("splitrail").join("state.toml"))
+    }
+
+    pub fn load() -> Result<Self> {
+        let state_path = Self::state_path()?;
+        if state_path.exists() {
+            let content = fs::read_to_string(&state_path).context("Failed to read state file")?;
+            return toml::from_str(&content).context("Failed to parse state file");
+        }
+
+        if let Some(state) = Self::load_legacy_from_config()? {
+            if state.last_date_uploaded > 0 {
+                state.save()?;
+            }
+            return Ok(state);
+        }
+
+        Ok(Self::default())
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let state_path = Self::state_path()?;
+        if let Some(parent) = state_path.parent() {
+            fs::create_dir_all(parent).context("Failed to create state directory")?;
+        }
+
+        let content = toml::to_string_pretty(self).context("Failed to serialize state")?;
+        fs::write(&state_path, content).context("Failed to write state file")?;
+        Ok(())
+    }
+
+    fn load_legacy_from_config() -> Result<Option<Self>> {
+        let config_path = Config::config_path()?;
+        if !config_path.exists() {
+            return Ok(None);
+        }
+
+        let content = fs::read_to_string(&config_path).context("Failed to read config file")?;
+        let legacy: LegacyConfigFile =
+            toml::from_str(&content).context("Failed to parse config file")?;
+
+        Ok(legacy
+            .upload
+            .last_date_uploaded
+            .map(|last_date_uploaded| Self { last_date_uploaded }))
     }
 }
 
@@ -272,11 +349,13 @@ mod tests {
     use crate::models::PricingStructure;
     use tempfile::TempDir;
 
-    fn setup_test_config() -> (TempDir, PathBuf) {
+    fn setup_test_config() -> (TempDir, PathBuf, PathBuf) {
         let dir = TempDir::new().expect("tempdir");
         let config_path = dir.path().join(".splitrail.toml");
+        let state_path = dir.path().join("state.toml");
         set_test_config_path(config_path.clone());
-        (dir, config_path)
+        set_test_state_path(state_path.clone());
+        (dir, config_path, state_path)
     }
 
     #[test]
@@ -290,7 +369,6 @@ api_token = "test-token"
 auto_upload = true
 upload_today_only = false
 retry_attempts = 5
-last_date_uploaded = 0
 
 [formatting]
 number_comma = true
@@ -329,7 +407,7 @@ is_estimated = true
 
     #[test]
     fn default_config_round_trip() {
-        let (_dir, _path) = setup_test_config();
+        let (_dir, config_path, _state_path) = setup_test_config();
         // Ensure there is a default config on disk using the CLI helper.
         create_default_config(true).expect("create_default_config");
 
@@ -343,11 +421,17 @@ is_estimated = true
         assert_eq!(loaded.formatting.locale, "en");
         assert!(!loaded.tui.reverse_sort_default);
         assert!(!loaded.tui.hide_empty_periods);
+
+        let saved = fs::read_to_string(config_path).expect("read saved config");
+        assert!(
+            !saved.contains("last_date_uploaded"),
+            "runtime upload state should not be persisted in config"
+        );
     }
 
     #[test]
     fn set_config_value_behaviour() {
-        let (_dir, _path) = setup_test_config();
+        let (_dir, _path, _state_path) = setup_test_config();
 
         // Ensure base config exists.
         create_default_config(true).expect("create_default_config");
@@ -391,6 +475,38 @@ is_estimated = true
     }
 
     #[test]
+    fn legacy_config_upload_checkpoint_migrates_to_state() {
+        let (_dir, config_path, state_path) = setup_test_config();
+        fs::write(
+            &config_path,
+            r#"
+[server]
+url = "https://splitrail.dev"
+api_token = ""
+
+[upload]
+auto_upload = false
+upload_today_only = false
+retry_attempts = 3
+last_date_uploaded = 1234
+
+[formatting]
+number_comma = false
+number_human = false
+locale = "en"
+decimal_places = 2
+"#,
+        )
+        .expect("write legacy config");
+
+        let state = UploadState::load().expect("load migrated state");
+        assert_eq!(state.last_date_uploaded, 1234);
+
+        let saved_state = fs::read_to_string(state_path).expect("read state file");
+        assert!(saved_state.contains("last_date_uploaded = 1234"));
+    }
+
+    #[test]
     fn config_toml_parses_tui_section() {
         let toml_str = r#"
 [server]
@@ -401,7 +517,6 @@ api_token = ""
 auto_upload = false
 upload_today_only = false
 retry_attempts = 3
-last_date_uploaded = 0
 
 [formatting]
 number_comma = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,8 +32,15 @@ pub struct UploadConfig {
     pub retry_attempts: u32,
 }
 
+/// Runtime upload progress state, persisted separately from user configuration.
+///
+/// Stored in the platform state directory (e.g. `~/.local/state/splitrail/state.toml`
+/// on Linux) so that incremental upload checkpoints do not pollute the
+/// user-editable config file.
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
 pub struct UploadState {
+    /// Timestamp (milliseconds since Unix epoch) of the last successfully uploaded message.
+    /// Used to filter out already-uploaded messages on the next run.
     pub last_date_uploaded: i64,
 }
 
@@ -169,6 +176,7 @@ struct LegacyUploadConfig {
 }
 
 impl UploadState {
+    /// Returns the path to the state file, using a test override when running under `cfg(test)`.
     pub fn state_path() -> Result<PathBuf> {
         #[cfg(test)]
         {
@@ -184,6 +192,11 @@ impl UploadState {
         Ok(state_root.join("splitrail").join("state.toml"))
     }
 
+    /// Load upload state from the state file.
+    ///
+    /// If the state file does not exist, attempts to migrate `last_date_uploaded`
+    /// from the legacy config location. Falls back to a zero-value default if
+    /// neither source is present.
     pub fn load() -> Result<Self> {
         let state_path = Self::state_path()?;
         if state_path.exists() {
@@ -201,6 +214,7 @@ impl UploadState {
         Ok(Self::default())
     }
 
+    /// Persist the current state to the state file, creating the directory if needed.
     pub fn save(&self) -> Result<()> {
         let state_path = Self::state_path()?;
         if let Some(parent) = state_path.parent() {
@@ -212,6 +226,8 @@ impl UploadState {
         Ok(())
     }
 
+    /// Read `last_date_uploaded` from the old `[upload]` section of the config file, if present.
+    /// Returns `None` when the config file does not exist or the field is absent.
     fn load_legacy_from_config() -> Result<Option<Self>> {
         let config_path = Config::config_path()?;
         if !config_path.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ mod utils;
 mod version_check;
 mod watcher;
 
+use crate::config::UploadState;
+
 #[cfg(feature = "mimalloc")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -325,7 +327,10 @@ async fn run_upload(args: UploadArgs) -> Result<()> {
     };
 
     match config::Config::load() {
-        Ok(Some(mut config)) if config.is_configured() => {
+        Ok(Some(config)) if config.is_configured() => {
+            let last_date_uploaded = UploadState::load()
+                .context("Failed to load upload state")?
+                .last_date_uploaded;
             let messages_to_upload = if args.full {
                 // --full flag: Flatten all messages from all analyzers
                 stats
@@ -347,7 +352,7 @@ async fn run_upload(args: UploadArgs) -> Result<()> {
                         // For all other analyzers, only add new messages
                         messages.extend(
                             utils::get_messages_later_than(
-                                config.upload.last_date_uploaded,
+                                last_date_uploaded,
                                 analyzer_stats.messages,
                             )
                             .await?,
@@ -362,7 +367,7 @@ async fn run_upload(args: UploadArgs) -> Result<()> {
                     .into_iter()
                     .flat_map(|s| s.messages)
                     .collect();
-                utils::get_messages_later_than(config.upload.last_date_uploaded, all_messages)
+                utils::get_messages_later_than(last_date_uploaded, all_messages)
                     .await
                     .context("Failed to get messages later than last saved date")?
             };
@@ -381,7 +386,7 @@ async fn run_upload(args: UploadArgs) -> Result<()> {
             }
 
             let progress_callback = tui::create_upload_progress_callback(&format_options);
-            upload::upload_message_stats(&messages_to_upload, &mut config, progress_callback)
+            upload::upload_message_stats(&messages_to_upload, &config, progress_callback)
                 .await
                 .context("Failed to upload messages")?;
             tui::show_upload_success(messages_to_upload.len(), &format_options);

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -515,7 +515,13 @@ pub async fn perform_background_upload(
             return None;
         }
 
-        let last_date_uploaded = UploadState::load().ok()?.last_date_uploaded;
+        let last_date_uploaded = match UploadState::load() {
+            Ok(state) => state.last_date_uploaded,
+            Err(e) => {
+                eprintln!("Failed to load upload state: {e:#}");
+                return None;
+            }
+        };
 
         let all_messages: Vec<_> = stats
             .analyzer_stats

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,4 +1,4 @@
-use crate::config::Config;
+use crate::config::{Config, UploadState};
 use crate::reqwest_simd_json::{ReqwestSimdJsonExt, ResponseSimdJsonExt};
 use crate::tui::UploadStatus;
 use crate::types::{ConversationMessage, ErrorResponse, MultiAnalyzerStats, UploadResponse};
@@ -91,7 +91,7 @@ mod tests;
 
 pub async fn upload_message_stats<F>(
     messages: &[ConversationMessage],
-    config: &mut Config,
+    config: &Config,
     mut progress_callback: F,
 ) -> Result<()>
 where
@@ -211,7 +211,7 @@ where
         if let Some(err) = last_err {
             // Save progress for any chunks that already succeeded
             if messages_processed > 0 {
-                save_chunk_progress(config, &sorted_messages, messages_processed, upload_debug);
+                save_chunk_progress(&sorted_messages, messages_processed, upload_debug);
             }
             return Err(err);
         }
@@ -221,7 +221,7 @@ where
         // Save incremental progress after each successful chunk so that a
         // later failure (or a manual re-run) only re-uploads the remaining
         // messages instead of re-sending everything from scratch.
-        save_chunk_progress(config, &sorted_messages, messages_processed, upload_debug);
+        save_chunk_progress(&sorted_messages, messages_processed, upload_debug);
     }
 
     // No additional save needed here — save_chunk_progress already persisted
@@ -236,7 +236,6 @@ where
 /// from the successfully uploaded portion.  On the next upload run, only
 /// messages newer than this timestamp will be re-sent.
 fn save_chunk_progress(
-    config: &mut Config,
     sorted_messages: &[&ConversationMessage],
     messages_processed: usize,
     upload_debug: bool,
@@ -249,8 +248,11 @@ fn save_chunk_progress(
     // uses >=) doesn't re-include this exact message.
     if let Some(last_msg) = sorted_messages.get(messages_processed - 1) {
         let checkpoint = last_msg.date.timestamp_millis() + 1;
-        config.set_last_date_uploaded(checkpoint);
-        if let Err(e) = config.save(true) {
+        if let Err(e) = (UploadState {
+            last_date_uploaded: checkpoint,
+        })
+        .save()
+        {
             if upload_debug {
                 upload_debug_log(format!(
                     "[splitrail upload] warning: failed to save chunk progress: {e:#}"
@@ -464,7 +466,7 @@ pub async fn perform_background_upload_messages<F>(
     }
 
     let upload_result = async {
-        let mut config = Config::load().ok().flatten()?;
+        let config = Config::load().ok().flatten()?;
         if !config.is_configured() {
             return None;
         }
@@ -475,7 +477,7 @@ pub async fn perform_background_upload_messages<F>(
 
         let result = upload_message_stats(
             &messages,
-            &mut config,
+            &config,
             make_progress_callback(upload_status.clone()),
         )
         .await;
@@ -513,13 +515,15 @@ pub async fn perform_background_upload(
             return None;
         }
 
+        let last_date_uploaded = UploadState::load().ok()?.last_date_uploaded;
+
         let all_messages: Vec<_> = stats
             .analyzer_stats
             .into_iter()
             .flat_map(|s| s.messages)
             .collect();
 
-        utils::get_messages_later_than(config.upload.last_date_uploaded, all_messages)
+        utils::get_messages_later_than(last_date_uploaded, all_messages)
             .await
             .ok()
     }

--- a/src/upload/tests.rs
+++ b/src/upload/tests.rs
@@ -15,13 +15,15 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
-use crate::config::set_test_config_path;
+use crate::config::{UploadState, set_test_config_path, set_test_state_path};
 
-fn setup_test_config() -> (TempDir, PathBuf) {
+fn setup_test_config() -> (TempDir, PathBuf, PathBuf) {
     let dir = TempDir::new().expect("tempdir");
     let config_path = dir.path().join(".splitrail.toml");
+    let state_path = dir.path().join("state.toml");
     set_test_config_path(config_path.clone());
-    (dir, config_path)
+    set_test_state_path(state_path.clone());
+    (dir, config_path, state_path)
 }
 
 fn make_test_message(conversation_hash: &str) -> ConversationMessage {
@@ -170,22 +172,26 @@ async fn start_test_server(
 
 #[tokio::test]
 async fn upload_message_stats_empty_messages_returns_ok_and_no_progress() {
-    let mut config = Config::default();
+    let (_dir, _config_path, _state_path) = setup_test_config();
+    let config = Config::default();
     let mut progress_calls = 0usize;
 
-    upload_message_stats(&[], &mut config, |_, _| {
+    upload_message_stats(&[], &config, |_, _| {
         progress_calls += 1;
     })
     .await
     .expect("upload should succeed");
 
     assert_eq!(progress_calls, 0);
-    assert_eq!(config.upload.last_date_uploaded, 0);
+    assert_eq!(
+        UploadState::load().expect("load state").last_date_uploaded,
+        0
+    );
 }
 
 #[tokio::test]
 async fn upload_message_stats_success_updates_progress_and_config() {
-    let (_dir, _path) = setup_test_config();
+    let (_dir, config_path, _state_path) = setup_test_config();
 
     let request_counter = Arc::new(AtomicUsize::new(0));
     let base_url = match start_test_server(
@@ -206,12 +212,13 @@ async fn upload_message_stats_success_updates_progress_and_config() {
     let mut config = Config::default();
     config.server.url = base_url;
     config.server.api_token = "TEST_TOKEN".to_string();
+    config.save(true).expect("save configured config");
 
     let messages = vec![make_test_message("c1")];
     let progress_values: Arc<Mutex<Vec<(usize, usize)>>> = Arc::new(Mutex::new(Vec::new()));
     let progress_values_clone = progress_values.clone();
 
-    upload_message_stats(&messages, &mut config, move |current, total| {
+    upload_message_stats(&messages, &config, move |current, total| {
         progress_values_clone.lock().push((current, total));
     })
     .await
@@ -225,23 +232,27 @@ async fn upload_message_stats_success_updates_progress_and_config() {
     assert_eq!(final_total, messages.len());
     assert_eq!(final_current, messages.len());
 
+    let state = UploadState::load().expect("load upload state");
     assert!(
-        config.upload.last_date_uploaded > 0,
+        state.last_date_uploaded > 0,
         "last_date_uploaded should be updated"
     );
 
     let saved = Config::load()
         .expect("load config")
         .expect("config should exist on disk");
-    assert_eq!(
-        saved.upload.last_date_uploaded,
-        config.upload.last_date_uploaded
+    assert_eq!(saved.upload.retry_attempts, config.upload.retry_attempts);
+
+    let config_contents = std::fs::read_to_string(config_path).expect("read saved config");
+    assert!(
+        !config_contents.contains("last_date_uploaded"),
+        "config should not persist upload runtime state"
     );
 }
 
 #[tokio::test]
 async fn upload_message_stats_server_error_plain_text_propagates_message() {
-    let (_dir, _path) = setup_test_config();
+    let (_dir, _path, _state_path) = setup_test_config();
 
     let request_counter = Arc::new(AtomicUsize::new(0));
     let base_url = match start_test_server(
@@ -267,7 +278,7 @@ async fn upload_message_stats_server_error_plain_text_propagates_message() {
 
     let messages = vec![make_test_message("c1")];
 
-    let err = upload_message_stats(&messages, &mut config, |_c, _t| {})
+    let err = upload_message_stats(&messages, &config, |_c, _t| {})
         .await
         .expect_err("upload should fail");
 
@@ -281,7 +292,7 @@ async fn upload_message_stats_server_error_plain_text_propagates_message() {
 
 #[tokio::test]
 async fn upload_message_stats_server_error_json_uses_error_field() {
-    let (_dir, _path) = setup_test_config();
+    let (_dir, _path, _state_path) = setup_test_config();
 
     let request_counter = Arc::new(AtomicUsize::new(0));
     let base_url = match start_test_server(
@@ -307,7 +318,7 @@ async fn upload_message_stats_server_error_json_uses_error_field() {
 
     let messages = vec![make_test_message("c1")];
 
-    let err = upload_message_stats(&messages, &mut config, |_c, _t| {})
+    let err = upload_message_stats(&messages, &config, |_c, _t| {})
         .await
         .expect_err("upload should fail");
 
@@ -321,7 +332,7 @@ async fn upload_message_stats_server_error_json_uses_error_field() {
 
 #[tokio::test]
 async fn upload_message_stats_large_batch_is_split_into_chunks() {
-    let (_dir, _path) = setup_test_config();
+    let (_dir, _path, _state_path) = setup_test_config();
 
     // Use more than 3000 messages to trigger multiple chunks.
     let message_count = 3005usize;
@@ -352,7 +363,7 @@ async fn upload_message_stats_large_batch_is_split_into_chunks() {
         messages.push(make_test_message(&format!("c{i}")));
     }
 
-    upload_message_stats(&messages, &mut config, |_c, _t| {})
+    upload_message_stats(&messages, &config, |_c, _t| {})
         .await
         .expect("upload should succeed");
 
@@ -365,7 +376,7 @@ async fn upload_message_stats_large_batch_is_split_into_chunks() {
 
 #[tokio::test]
 async fn perform_background_upload_no_config_keeps_status_unchanged() {
-    let (_dir, config_path) = setup_test_config();
+    let (_dir, config_path, _state_path) = setup_test_config();
 
     // Ensure there is no config file.
     if config_path.exists() {
@@ -390,7 +401,7 @@ async fn perform_background_upload_no_config_keeps_status_unchanged() {
 
 #[tokio::test]
 async fn perform_background_upload_unconfigured_config_keeps_status_unchanged() {
-    let (_dir, _path) = setup_test_config();
+    let (_dir, _path, _state_path) = setup_test_config();
 
     // Save a default config which is not configured (missing API token).
     let config = Config::default();
@@ -414,7 +425,7 @@ async fn perform_background_upload_unconfigured_config_keeps_status_unchanged() 
 
 #[tokio::test]
 async fn perform_background_upload_propagates_upload_errors_to_status() {
-    let (_dir, _path) = setup_test_config();
+    let (_dir, _path, _state_path) = setup_test_config();
 
     let request_counter = Arc::new(AtomicUsize::new(0));
     let base_url = match start_test_server(
@@ -465,7 +476,7 @@ async fn perform_background_upload_propagates_upload_errors_to_status() {
 
 #[tokio::test]
 async fn upload_message_stats_retries_on_failure_then_succeeds() {
-    let (_dir, _path) = setup_test_config();
+    let (_dir, _path, _state_path) = setup_test_config();
 
     // The server will fail on the first request and succeed on the second.
     // We use a shared counter so the server knows which response to give.
@@ -517,7 +528,7 @@ async fn upload_message_stats_retries_on_failure_then_succeeds() {
 
     let messages = vec![make_test_message("retry-c1")];
 
-    upload_message_stats(&messages, &mut config, |_c, _t| {})
+    upload_message_stats(&messages, &config, |_c, _t| {})
         .await
         .expect("upload should succeed after retry");
 
@@ -527,7 +538,10 @@ async fn upload_message_stats_retries_on_failure_then_succeeds() {
         "expected 2 requests: first fails, second succeeds"
     );
     assert!(
-        config.upload.last_date_uploaded > 0,
+        UploadState::load()
+            .expect("load upload state")
+            .last_date_uploaded
+            > 0,
         "last_date_uploaded should be updated after successful retry"
     );
 }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -273,7 +273,8 @@ impl RealtimeStatsManager {
 
         let last_date_uploaded = match UploadState::load() {
             Ok(state) => state.last_date_uploaded,
-            Err(_) => {
+            Err(e) => {
+                eprintln!("Failed to load upload state: {e:#}");
                 *self.upload_in_progress.lock() = false;
                 return;
             }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::watch;
 
 use crate::analyzer::AnalyzerRegistry;
-use crate::config::Config;
+use crate::config::{Config, UploadState};
 use crate::tui::UploadStatus;
 use crate::types::MultiAnalyzerStatsView;
 use crate::upload;
@@ -243,10 +243,10 @@ impl RealtimeStatsManager {
 
     async fn trigger_auto_upload_if_enabled(&mut self) {
         // Check if auto-upload is enabled
-        let config = match Config::load() {
-            Ok(Some(cfg)) if cfg.upload.auto_upload && cfg.is_configured() => cfg,
+        match Config::load() {
+            Ok(Some(cfg)) if cfg.upload.auto_upload && cfg.is_configured() => {}
             _ => return, // Auto-upload not enabled or config not available
-        };
+        }
 
         // Check if an upload is already in progress
         if *self.upload_in_progress.lock() {
@@ -271,12 +271,17 @@ impl RealtimeStatsManager {
         // Mark upload as in progress
         *self.upload_in_progress.lock() = true;
 
+        let last_date_uploaded = match UploadState::load() {
+            Ok(state) => state.last_date_uploaded,
+            Err(_) => {
+                *self.upload_in_progress.lock() = false;
+                return;
+            }
+        };
+
         // For incremental upload, load only changed/new messages
         // This avoids loading all historical data into memory
-        let messages = match self
-            .registry
-            .load_messages_for_upload(config.upload.last_date_uploaded)
-        {
+        let messages = match self.registry.load_messages_for_upload(last_date_uploaded) {
             Ok(msgs) => msgs,
             Err(_) => {
                 *self.upload_in_progress.lock() = false;


### PR DESCRIPTION
Fixes #175

## Summary

Extracts `last_date_uploaded` from `UploadConfig` into a dedicated `UploadState` struct persisted to the platform state directory (`~/.local/state/splitrail/state.toml` on Linux, `data_local_dir` fallback on macOS/Windows). This keeps runtime upload progress out of the user-editable config file.

## Changes

- **`src/config.rs`**: Add `UploadState` struct with `load()`/`save()` backed by the platform state directory. Remove `last_date_uploaded` from `UploadConfig` and `set_last_date_uploaded` from `Config`. Add legacy migration: on first load, if `last_date_uploaded` is present in the old config it is migrated to the new state file automatically.
- **`src/upload.rs`**: Update `upload_message_stats` and `save_chunk_progress` to write progress via `UploadState::save()` instead of mutating `Config`. Drop `&mut Config` requirement throughout.
- **`src/watcher.rs`**: Load `UploadState` separately to obtain `last_date_uploaded` for incremental uploads.
- **`src/main.rs`**: Load `UploadState` separately in the CLI upload path.
- **`src/upload/tests.rs`**: Update tests to use `UploadState` for assertions and configure a test state path to prevent cross-test pollution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Upload checkpoint state is now stored in a dedicated state file (not in the config), and runtime upload state is no longer persisted into configuration files.
  * Automatic migration moves existing checkpoint data from older config format into the new state file.

* **Tests**
  * Test harness updated to use and verify the new state file; tests assert migration and that config files no longer contain runtime upload state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->