### PR TITLE
feat(codex): support loading fallback model from config file

### DIFF
--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -31,7 +31,11 @@ pub(crate) fn get_fallback_model_with_home(home_dir: Option<PathBuf>) -> String 
             struct CodexConfig {
                 model: Option<String>,
             }
-            toml::from_str::<CodexConfig>(&content).ok()?.model
+            toml::from_str::<CodexConfig>(&content)
+                .ok()?
+                .model
+                .map(|m| m.trim().to_string())
+                .filter(|m| !m.is_empty())
         })
         .unwrap_or_else(|| DEFAULT_FALLBACK_MODEL.to_string())
 }

--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -15,7 +15,36 @@ use crate::models::calculate_total_cost;
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::{deserialize_utc_timestamp, hash_text, warn_once};
 
+use std::sync::OnceLock;
+
 const DEFAULT_FALLBACK_MODEL: &str = "gpt-5";
+
+static FALLBACK_MODEL: OnceLock<String> = OnceLock::new();
+
+pub(crate) fn get_fallback_model_with_home(home_dir: Option<PathBuf>) -> String {
+    home_dir
+        .map(|h| h.join(".codex").join("config.toml"))
+        .filter(|p| p.is_file())
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|content| {
+            #[derive(Deserialize)]
+            struct CodexConfig {
+                model: Option<String>,
+            }
+            toml::from_str::<CodexConfig>(&content).ok()?.model
+        })
+        .unwrap_or_else(|| DEFAULT_FALLBACK_MODEL.to_string())
+}
+
+fn get_fallback_model() -> &'static str {
+    FALLBACK_MODEL.get_or_init(|| {
+        if cfg!(test) {
+            DEFAULT_FALLBACK_MODEL.to_string()
+        } else {
+            get_fallback_model_with_home(dirs::home_dir())
+        }
+    })
+}
 
 pub struct CodexCliAnalyzer;
 
@@ -390,7 +419,7 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                         "assistant" if !saw_token_usage => {
                             let model_state = session_model.clone().unwrap_or_else(|| {
                                 let fallback = SessionModel::inferred(
-                                    DEFAULT_FALLBACK_MODEL.to_string(),
+                                    get_fallback_model().to_string(),
                                 );
                                 warn_once(format!(
                                     "WARNING: session {file_path_str} missing model metadata; using fallback model {} for cost estimation.",
@@ -450,7 +479,7 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                         if let Some(token_usage) = usage {
                             let model_state = session_model.clone().unwrap_or_else(|| {
                                 let fallback = SessionModel::inferred(
-                                    DEFAULT_FALLBACK_MODEL.to_string(),
+                                    get_fallback_model().to_string(),
                                 );
                                 warn_once(format!(
                                     "WARNING: session {file_path_str} missing model metadata; using fallback model {} for cost estimation.",

--- a/src/analyzers/tests/codex_cli.rs
+++ b/src/analyzers/tests/codex_cli.rs
@@ -351,4 +351,36 @@ fn test_get_fallback_model_with_home() {
     drop(file);
     let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
     assert_eq!(model, "gpt-5.5");
+
+    // Test case 4: empty string in config
+    let mut file = std::fs::File::create(&config_path).unwrap();
+    file.write_all(b"model = \"\"\n").unwrap();
+    drop(file);
+    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    assert_eq!(model, "gpt-5");
+
+    // Test case 5: None home directory
+    let model = get_fallback_model_with_home(None);
+    assert_eq!(model, "gpt-5");
+
+    // Test case 6: whitespace-only model
+    let mut file = std::fs::File::create(&config_path).unwrap();
+    file.write_all(b"model = \"   \"\n").unwrap();
+    drop(file);
+    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    assert_eq!(model, "gpt-5");
+
+    // Test case 7: invalid TOML syntax
+    let mut file = std::fs::File::create(&config_path).unwrap();
+    file.write_all(b"model = \n").unwrap();
+    drop(file);
+    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    assert_eq!(model, "gpt-5");
+
+    // Test case 8: config file exists but model key is omitted
+    let mut file = std::fs::File::create(&config_path).unwrap();
+    file.write_all(b"other_key = \"value\"\n").unwrap();
+    drop(file);
+    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    assert_eq!(model, "gpt-5");
 }

--- a/src/analyzers/tests/codex_cli.rs
+++ b/src/analyzers/tests/codex_cli.rs
@@ -326,3 +326,29 @@ fn test_codex_availability() {
 
     // Don't assert - just print for debugging
 }
+
+#[test]
+fn test_get_fallback_model_with_home() {
+    let dir = tempfile::tempdir().unwrap();
+    let codex_dir = dir.path().join(".codex");
+    std::fs::create_dir(&codex_dir).unwrap();
+    let config_path = codex_dir.join("config.toml");
+
+    // Test case 1: no config file
+    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    assert_eq!(model, "gpt-5");
+
+    // Test case 2: empty config file
+    let mut file = std::fs::File::create(&config_path).unwrap();
+    file.write_all(b"").unwrap();
+    drop(file);
+    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    assert_eq!(model, "gpt-5");
+
+    // Test case 3: model configured in config file
+    let mut file = std::fs::File::create(&config_path).unwrap();
+    file.write_all(b"model = \"gpt-5.5\"\n").unwrap();
+    drop(file);
+    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    assert_eq!(model, "gpt-5.5");
+}


### PR DESCRIPTION
## Summary

This pull request adds support for reading a fallback model from the Codex CLI configuration file located at `~/.codex/config.toml` before immediately falling back to `gpt-5`.

## Key Changes

- Implemented reading and parsing of the `model` key from `~/.codex/config.toml`.
- Cached the resolved fallback model using `std::sync::OnceLock` to avoid repeated filesystem access.
- Added a unit test to verify reading the model name from a mocked TOML config file.

## Testing

- Added `test_get_fallback_model_with_home` verifying different configuration scenarios (missing config, empty config, configured model).
- Ran all quality checks and verification steps (`cargo build`, `cargo test`, `cargo clippy`, `cargo doc`, `cargo fmt`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fallback model can be customized via a local configuration file in the user's home directory; the CLI now consistently uses this fallback for cost estimation when session metadata is absent, preserving the previous default when no valid config is present.

* **Tests**
  * Added tests covering missing, empty, invalid, whitespace, and explicitly set configurations to ensure reliable fallback resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->