### PR TITLE
Add TUI config options, Apps column, and analyzer fixes

### DIFF
--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -76,8 +76,18 @@ impl Analyzer for ClaudeCodeAnalyzer {
         let project_hash = extract_and_hash_project_id(&source.path);
         let conversation_hash = crate::utils::hash_text(&source.path.to_string_lossy());
         let file = File::open(&source.path)?;
-        let (messages, _, _, _) =
+        let (mut messages, summaries, _uuids, fallback) =
             parse_jsonl_file(&source.path, file, &project_hash, &conversation_hash)?;
+        // Apply the within-file session name (summary, else first-message fallback)
+        // so the live TUI session view shows real titles, not just the upload path.
+        let name = summaries.into_iter().next().map(|(_, n)| n).or(fallback);
+        if let Some(name) = name {
+            for m in &mut messages {
+                if m.session_name.is_none() {
+                    m.session_name = Some(name.clone());
+                }
+            }
+        }
         Ok(messages)
     }
 

--- a/src/analyzers/copilot.rs
+++ b/src/analyzers/copilot.rs
@@ -81,6 +81,10 @@ struct CopilotRequest {
     timestamp: i64,
     #[serde(default)]
     model_id: Option<String>,
+    /// Optional provider-reported cost in USD. Copilot IDE sessions don't normally
+    /// carry this; when present it is honored verbatim (mirrors Kilo/OpenCode).
+    #[serde(default)]
+    cost: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -400,6 +404,21 @@ pub(crate) fn parse_copilot_session_file(session_file: &Path) -> Result<Vec<Conv
             stats.file_searches += file_ops.file_searches;
             stats.file_content_searches += file_ops.file_content_searches;
             stats.terminal_commands += file_ops.terminal_commands;
+        }
+
+        // Cost: Copilot IDE sessions don't natively record a dollar cost. Honor an
+        // explicit provider-reported cost when present; otherwise price the counted
+        // tokens with the shared pricing table, consistent with the other analyzers.
+        if let Some(cost) = request.cost.filter(|c| *c > 0.0) {
+            stats.cost = cost;
+        } else if let Some(model_name) = &model {
+            stats.cost = crate::models::calculate_total_cost(
+                model_name,
+                stats.input_tokens,
+                stats.output_tokens,
+                stats.cache_creation_tokens,
+                stats.cache_read_tokens,
+            );
         }
 
         entries.push(ConversationMessage {

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,18 +44,87 @@ pub struct UploadState {
     pub last_date_uploaded: i64,
 }
 
+fn default_currency_symbol() -> String {
+    "$".to_string()
+}
+
+fn default_view() -> String {
+    "daily".to_string()
+}
+
+fn default_cost_decimal_places() -> usize {
+    2
+}
+
+fn default_accent_color() -> String {
+    "cyan".to_string()
+}
+
+fn default_true() -> bool {
+    true
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FormattingConfig {
     pub number_comma: bool,
     pub number_human: bool,
     pub locale: String,
     pub decimal_places: usize,
+    /// Symbol shown before cost amounts (e.g. "$", "€", "£"). Default "$".
+    #[serde(default = "default_currency_symbol")]
+    pub currency_symbol: String,
+    /// Decimal places used for cost amounts (e.g. 2 -> $1.23, 0 -> $1). Default 2.
+    #[serde(default = "default_cost_decimal_places")]
+    pub cost_decimal_places: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct TuiConfig {
+    #[serde(default)]
     pub reverse_sort_default: bool,
+    #[serde(default)]
     pub hide_empty_periods: bool,
+    /// Aggregation the TUI opens in: "daily" | "weekly" | "monthly" | "yearly".
+    #[serde(default = "default_view")]
+    pub default_view: String,
+    /// Tab the TUI opens on, by tool name (e.g. "Claude Code"). Empty / "All
+    /// Tools" opens the combined first tab.
+    #[serde(default)]
+    pub default_tab: String,
+    /// Require a second 'q' to confirm before quitting the TUI.
+    #[serde(default)]
+    pub confirm_quit: bool,
+    /// Columns to hide from the aggregate table, e.g. ["models", "cached",
+    /// "reason"]. Recognized: cached, input, output, reason, convs, tools,
+    /// apps, models.
+    #[serde(default)]
+    pub hidden_columns: Vec<String>,
+    /// Accent color for the title, tab bar and selected row: "cyan" | "green"
+    /// | "magenta" | "blue" | "red" | "yellow" | "white".
+    #[serde(default = "default_accent_color")]
+    pub accent_color: String,
+    /// Tint each Cost cell by magnitude (dim -> green -> yellow -> red).
+    #[serde(default)]
+    pub color_costs: bool,
+    /// Show the "AGENTIC DEVELOPMENT TOOL ACTIVITY ANALYSIS" header banner.
+    #[serde(default = "default_true")]
+    pub show_header: bool,
+}
+
+impl Default for TuiConfig {
+    fn default() -> Self {
+        Self {
+            reverse_sort_default: false,
+            hide_empty_periods: false,
+            default_view: default_view(),
+            default_tab: String::new(),
+            confirm_quit: false,
+            hidden_columns: Vec::new(),
+            accent_color: default_accent_color(),
+            color_costs: false,
+            show_header: true,
+        }
+    }
 }
 
 impl Default for Config {
@@ -75,6 +144,8 @@ impl Default for Config {
                 number_human: false,
                 locale: "en".to_string(),
                 decimal_places: 2,
+                currency_symbol: default_currency_symbol(),
+                cost_decimal_places: default_cost_decimal_places(),
             },
             tui: TuiConfig::default(),
             models: HashMap::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -352,6 +352,11 @@ pub fn show_config() -> Result<()> {
             println!("   Number Human: {}", config.formatting.number_human);
             println!("   Locale: {}", config.formatting.locale);
             println!("   Decimal Places: {}", config.formatting.decimal_places);
+            println!("   Currency Symbol: {}", config.formatting.currency_symbol);
+            println!(
+                "   Cost Decimal Places: {}",
+                config.formatting.cost_decimal_places
+            );
             println!(
                 "   TUI Reverse Sort Default: {}",
                 config.tui.reverse_sort_default
@@ -360,6 +365,27 @@ pub fn show_config() -> Result<()> {
                 "   TUI Hide Empty Periods: {}",
                 config.tui.hide_empty_periods
             );
+            println!("   TUI Default View: {}", config.tui.default_view);
+            println!(
+                "   TUI Default Tab: {}",
+                if config.tui.default_tab.is_empty() {
+                    "All Tools"
+                } else {
+                    &config.tui.default_tab
+                }
+            );
+            println!("   TUI Confirm Quit: {}", config.tui.confirm_quit);
+            println!(
+                "   TUI Hidden Columns: {}",
+                if config.tui.hidden_columns.is_empty() {
+                    "None".to_string()
+                } else {
+                    config.tui.hidden_columns.join(", ")
+                }
+            );
+            println!("   TUI Accent Color: {}", config.tui.accent_color);
+            println!("   TUI Color Costs: {}", config.tui.color_costs);
+            println!("   TUI Show Header: {}", config.tui.show_header);
             if !config.models.is_empty() {
                 println!("   Custom Models: {}", config.models.len());
             }
@@ -411,6 +437,13 @@ pub fn set_config_value(key: &str, value: &str) -> Result<()> {
             let places = value.parse::<usize>().context("Invalid number value")?;
             config.formatting.decimal_places = places;
         }
+        "currency-symbol" => {
+            config.formatting.currency_symbol = value.to_string();
+        }
+        "cost-decimal-places" => {
+            let places = value.parse::<usize>().context("Invalid number value")?;
+            config.formatting.cost_decimal_places = places;
+        }
         "reverse-sort-default" => {
             let enabled = value
                 .parse::<bool>()
@@ -422,6 +455,38 @@ pub fn set_config_value(key: &str, value: &str) -> Result<()> {
                 .parse::<bool>()
                 .context("Invalid boolean value. Use 'true' or 'false'")?;
             config.tui.hide_empty_periods = enabled;
+        }
+        "default-view" => {
+            config.tui.default_view = value.to_string();
+        }
+        "default-tab" => {
+            config.tui.default_tab = value.to_string();
+        }
+        "confirm-quit" => {
+            config.tui.confirm_quit = value
+                .parse::<bool>()
+                .context("Invalid boolean value. Use 'true' or 'false'")?;
+        }
+        "hidden-columns" => {
+            config.tui.hidden_columns = value
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToString::to_string)
+                .collect();
+        }
+        "accent-color" => {
+            config.tui.accent_color = value.to_string();
+        }
+        "color-costs" => {
+            config.tui.color_costs = value
+                .parse::<bool>()
+                .context("Invalid boolean value. Use 'true' or 'false'")?;
+        }
+        "show-header" => {
+            config.tui.show_header = value
+                .parse::<bool>()
+                .context("Invalid boolean value. Use 'true' or 'false'")?;
         }
         _ => anyhow::bail!("Unknown config key: {}", key),
     }
@@ -532,6 +597,15 @@ is_estimated = true
         set_config_value("decimal-places", "3").expect("set decimal-places");
         set_config_value("reverse-sort-default", "true").expect("set reverse-sort-default");
         set_config_value("hide-empty-periods", "true").expect("set hide-empty-periods");
+        set_config_value("currency-symbol", "€").expect("set currency-symbol");
+        set_config_value("cost-decimal-places", "0").expect("set cost-decimal-places");
+        set_config_value("default-view", "monthly").expect("set default-view");
+        set_config_value("default-tab", "Cline").expect("set default-tab");
+        set_config_value("confirm-quit", "true").expect("set confirm-quit");
+        set_config_value("hidden-columns", "reason, models").expect("set hidden-columns");
+        set_config_value("accent-color", "magenta").expect("set accent-color");
+        set_config_value("color-costs", "true").expect("set color-costs");
+        set_config_value("show-header", "false").expect("set show-header");
 
         let cfg = Config::load()
             .expect("load config")
@@ -546,6 +620,15 @@ is_estimated = true
         assert_eq!(cfg.formatting.decimal_places, 3);
         assert!(cfg.tui.reverse_sort_default);
         assert!(cfg.tui.hide_empty_periods);
+        assert_eq!(cfg.formatting.currency_symbol, "€");
+        assert_eq!(cfg.formatting.cost_decimal_places, 0);
+        assert_eq!(cfg.tui.default_view, "monthly");
+        assert_eq!(cfg.tui.default_tab, "Cline");
+        assert!(cfg.tui.confirm_quit);
+        assert_eq!(cfg.tui.hidden_columns, vec!["reason", "models"]);
+        assert_eq!(cfg.tui.accent_color, "magenta");
+        assert!(cfg.tui.color_costs);
+        assert!(!cfg.tui.show_header);
 
         let err = set_config_value("unknown-key", "value").unwrap_err();
         let msg = format!("{err}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,7 +119,7 @@ enum ConfigSubcommands {
     Show,
     /// Set configuration value
     Set {
-        /// Configuration key (api-token, auto-upload, number-comma, number-human, locale, decimal-places, reverse-sort-default, hide-empty-periods)
+        /// Configuration key (api-token, auto-upload, upload-today-only, number-comma, number-human, locale, decimal-places, currency-symbol, cost-decimal-places, reverse-sort-default, hide-empty-periods, default-view, default-tab, confirm-quit, hidden-columns, accent-color, color-costs, show-header)
         key: String,
         /// Configuration value
         value: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,8 @@ async fn main() {
         decimal_places: cli
             .decimal_places
             .unwrap_or(config.formatting.decimal_places),
+        currency_symbol: config.formatting.currency_symbol,
+        cost_decimal_places: config.formatting.cost_decimal_places,
     };
 
     match cli.command {
@@ -325,6 +327,8 @@ async fn run_upload(args: UploadArgs) -> Result<()> {
         use_human: config_file.formatting.number_human,
         locale: config_file.formatting.locale,
         decimal_places: config_file.formatting.decimal_places,
+        currency_symbol: config_file.formatting.currency_symbol,
+        cost_decimal_places: config_file.formatting.cost_decimal_places,
     };
 
     match config::Config::load() {

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -63,6 +63,16 @@ enum AggregateViewMode {
 }
 
 impl AggregateViewMode {
+    /// Parse the configured startup view (tui.default_view).
+    fn from_config(s: &str) -> Self {
+        match s.trim().to_lowercase().as_str() {
+            "weekly" | "week" => Self::Weekly,
+            "monthly" | "month" => Self::Monthly,
+            "yearly" | "year" => Self::Yearly,
+            _ => Self::Daily,
+        }
+    }
+
     fn next(self) -> Self {
         match self {
             Self::Daily => Self::Weekly,
@@ -336,6 +346,11 @@ struct UiState<'a> {
     sort_reversed: bool,
     hide_empty_periods: bool,
     show_totals: bool,
+    quit_pending: bool,
+    accent: Color,
+    hidden_cols: &'a std::collections::HashSet<String>,
+    color_costs: bool,
+    show_header: bool,
 }
 
 /// Build the tab data shown in the TUI, prepending a synthetic "All Tools"
@@ -354,6 +369,7 @@ pub(crate) fn build_display_stats(
     for stats in filtered_stats {
         let view = stats.read();
         combined_conversations += view.num_conversations;
+        let app_name = view.analyzer_name.to_string();
 
         for (key, day_stats) in &view.daily_stats {
             let entry = combined_daily_stats
@@ -363,6 +379,8 @@ pub(crate) fn build_display_stats(
                     ..DailyStats::default()
                 });
             *entry += day_stats;
+            // Record which app contributed this period (for the Apps column).
+            *entry.apps.entry(app_name.clone()).or_insert(0) += 1;
         }
 
         combined_sessions.extend(view.session_aggregates.iter().cloned().map(|mut session| {
@@ -415,7 +433,7 @@ pub fn run_tui(
 
     let mut selected_tab = 0;
     let mut scroll_offset = 0;
-    let mut aggregate_view_mode = AggregateViewMode::Daily;
+    let mut aggregate_view_mode = AggregateViewMode::from_config(&tui_config.default_view);
     let mut stats_view_mode = StatsViewMode::Aggregate;
 
     let (watcher_tx, mut watcher_rx) = mpsc::unbounded_channel::<WatcherEvent>();
@@ -475,6 +493,22 @@ async fn run_app(
     let mut sort_reversed = tui_config.reverse_sort_default;
     let mut hide_empty_periods = tui_config.hide_empty_periods;
     let mut show_totals = true;
+    let mut quit_pending = false;
+    // Appearance settings (constant for the session).
+    let accent = parse_accent(&tui_config.accent_color);
+    let color_costs = tui_config.color_costs;
+    let show_header = tui_config.show_header;
+    let hidden_cols: std::collections::HashSet<String> = tui_config
+        .hidden_columns
+        .iter()
+        .map(|s| match s.trim().to_lowercase().as_str() {
+            "inp" => "input".to_string(),
+            "outp" => "output".to_string(),
+            "reasoning" => "reason".to_string(),
+            "conversations" | "conv" => "convs".to_string(),
+            other => other.to_string(),
+        })
+        .collect();
     let mut current_stats = stats_receiver.borrow().clone();
 
     // Initialize table states for current stats
@@ -502,6 +536,19 @@ async fn run_app(
         .cloned()
         .collect();
     let mut display_stats = build_display_stats(&filtered_stats);
+
+    // Open on the configured default tab (matched by tool name; empty or
+    // "All Tools" keeps the combined first tab).
+    if !tui_config.default_tab.trim().is_empty()
+        && let Some(idx) = display_stats.iter().position(|v| {
+            v.read()
+                .analyzer_name
+                .as_ref()
+                .eq_ignore_ascii_case(tui_config.default_tab.trim())
+        })
+    {
+        *selected_tab = idx;
+    }
 
     loop {
         // Check for update status changes
@@ -581,6 +628,11 @@ async fn run_app(
                     sort_reversed,
                     hide_empty_periods,
                     show_totals,
+                    quit_pending,
+                    accent,
+                    hidden_cols: &hidden_cols,
+                    color_costs,
+                    show_header,
                 };
                 draw_ui(
                     frame,
@@ -614,7 +666,17 @@ async fn run_app(
             // Handle quitting. Esc is intentionally *not* a quit key; it acts as
             // a context-aware "go back"/cancel below.
             if matches!(key.code, KeyCode::Char('q')) {
+                if tui_config.confirm_quit && !quit_pending {
+                    quit_pending = true;
+                    needs_redraw = true;
+                    continue;
+                }
                 break;
+            }
+            // Any other key cancels a pending quit confirmation.
+            if quit_pending {
+                quit_pending = false;
+                needs_redraw = true;
             }
 
             // Handle update notification dismissal
@@ -1094,10 +1156,10 @@ fn draw_ui(
     let (chunks, chunk_offset) = if has_data {
         if show_update_banner {
             let mut constraints = vec![
-                Constraint::Length(3), // Header
-                Constraint::Length(1), // Update banner
-                Constraint::Length(1), // Tabs
-                Constraint::Min(3),    // Main table
+                Constraint::Length(if ui_state.show_header { 3 } else { 0 }), // Header
+                Constraint::Length(1),                                        // Update banner
+                Constraint::Length(1),                                        // Tabs
+                Constraint::Min(3),                                           // Main table
             ];
             if ui_state.show_totals {
                 constraints.push(Constraint::Length(9)); // Summary stats
@@ -1109,9 +1171,9 @@ fn draw_ui(
             )
         } else {
             let mut constraints = vec![
-                Constraint::Length(3), // Header
-                Constraint::Length(1), // Tabs
-                Constraint::Min(3),    // Main table
+                Constraint::Length(if ui_state.show_header { 3 } else { 0 }), // Header
+                Constraint::Length(1),                                        // Tabs
+                Constraint::Min(3),                                           // Main table
             ];
             if ui_state.show_totals {
                 constraints.push(Constraint::Length(9)); // Summary stats
@@ -1125,9 +1187,9 @@ fn draw_ui(
     } else {
         (
             Layout::vertical([
-                Constraint::Length(3), // Header
-                Constraint::Min(3),    // No-data message
-                Constraint::Length(1), // Help text
+                Constraint::Length(if ui_state.show_header { 3 } else { 0 }), // Header
+                Constraint::Min(3),                                           // No-data message
+                Constraint::Length(1),                                        // Help text
             ])
             .split(frame.area()),
             0, // No offset (no banner in no-data view)
@@ -1138,11 +1200,15 @@ fn draw_ui(
     let header = Paragraph::new(Text::from(vec![
         Line::styled(
             "AGENTIC DEVELOPMENT TOOL ACTIVITY ANALYSIS",
-            Style::new().cyan().bold(),
+            Style::default()
+                .fg(ui_state.accent)
+                .add_modifier(Modifier::BOLD),
         ),
         Line::styled(
             "==========================================",
-            Style::new().cyan().bold(),
+            Style::default()
+                .fg(ui_state.accent)
+                .add_modifier(Modifier::BOLD),
         ),
     ]));
     frame.render_widget(header, chunks[0]);
@@ -1177,7 +1243,7 @@ fn draw_ui(
         let tabs = Tabs::new(tab_titles)
             .select(ui_state.selected_tab)
             // .style(Style::default().add_modifier(Modifier::DIM))
-            .highlight_style(Style::new().black().on_light_green())
+            .highlight_style(Style::default().fg(Color::Black).bg(ui_state.accent))
             .padding("", "")
             .divider(" | ");
 
@@ -1206,6 +1272,9 @@ fn draw_ui(
                             },
                             ui_state.hide_empty_periods,
                             ui_state.sort_reversed,
+                            ui_state.accent,
+                            ui_state.hidden_cols,
+                            ui_state.color_costs,
                         );
                         has_estimated
                     }
@@ -1277,14 +1346,23 @@ fn draw_ui(
                 }
             };
 
-            let help_text = if has_estimated_models {
+            let help_text = if ui_state.quit_pending {
+                "Quit splitrail?  Press q again to confirm  •  any other key to cancel".to_string()
+            } else if has_estimated_models {
                 format!("{} • * = estimated pricing", base_help_text)
             } else {
                 base_help_text
             };
 
+            let help_style = if ui_state.quit_pending {
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().add_modifier(Modifier::DIM)
+            };
             let help = Paragraph::new(help_text)
-                .style(Style::default().add_modifier(Modifier::DIM))
+                .style(help_style)
                 .wrap(ratatui::widgets::Wrap { trim: true });
             frame.render_widget(help, help_chunks[0]);
 
@@ -1359,6 +1437,34 @@ fn draw_ui(
 }
 
 #[allow(clippy::too_many_arguments)]
+/// Parse the configured accent color name into a ratatui Color.
+fn parse_accent(s: &str) -> Color {
+    match s.trim().to_lowercase().as_str() {
+        "green" => Color::Green,
+        "magenta" | "purple" => Color::Magenta,
+        "blue" => Color::Blue,
+        "red" => Color::Red,
+        "yellow" => Color::Yellow,
+        "white" => Color::White,
+        "light_cyan" | "lightcyan" => Color::LightCyan,
+        "light_green" | "lightgreen" => Color::LightGreen,
+        _ => Color::Cyan,
+    }
+}
+
+/// Heatmap color for a cost cell: low -> green, mid -> yellow, high -> red.
+fn cost_heat(cents: u32, max: u32) -> Color {
+    if max == 0 {
+        return Color::Green;
+    }
+    let t = (cents as f64 / max as f64).clamp(0.0, 1.0);
+    let r = (90.0 + t * (235.0 - 90.0)) as u8;
+    let g = (200.0 - t * (200.0 - 80.0)) as u8;
+    let b = (110.0 - t * (110.0 - 70.0)) as u8;
+    Color::Rgb(r, g, b)
+}
+
+#[allow(clippy::too_many_arguments)]
 fn draw_aggregate_stats_table(
     frame: &mut Frame,
     area: Rect,
@@ -1369,6 +1475,9 @@ fn draw_aggregate_stats_table(
     date_filter: &str,
     hide_empty_periods: bool,
     sort_reversed: bool,
+    accent: Color,
+    hidden: &std::collections::HashSet<String>,
+    color_costs: bool,
 ) -> (usize, bool) {
     let period_header = match aggregate_view_mode {
         AggregateViewMode::Daily => "Date",
@@ -1383,21 +1492,49 @@ fn draw_aggregate_stats_table(
         filtered_aggregate_keys(aggregate_stats, hide_empty_periods, sort_reversed);
     clamp_table_selection(table_state, visible_periods.len() + 2);
 
-    let header = Row::new(vec![
+    // The Apps column is only meaningful in the combined "All Tools" view, where
+    // each period records which tools contributed. On single-tool tabs it is
+    // always empty, so collapse it entirely instead of reserving a blank gap.
+    let has_apps = aggregate_stats.values().any(|s| !s.apps.is_empty());
+    let show = |c: &str| {
+        if c == "apps" && !has_apps {
+            return false;
+        }
+        !hidden.contains(c)
+    };
+
+    let mut header_cells = vec![
         Cell::new(""),
         Cell::new(period_header),
         Cell::new(Text::from("Cost").right_aligned()),
-        Cell::new(Text::from("Cached Tks").right_aligned()),
-        Cell::new(Text::from("Inp Tks").right_aligned()),
-        Cell::new(Text::from("Outp Tks").right_aligned()),
-        Cell::new(Text::from("Reason Tks").right_aligned()),
-        Cell::new(Text::from("Convs").right_aligned()),
-        Cell::new(Text::from("Tools").right_aligned()),
-        // Cell::new(Text::from("Lines").right_aligned()),
-        Cell::new("Models"),
-    ])
-    .style(Style::default().add_modifier(Modifier::BOLD))
-    .height(1);
+    ];
+    if show("cached") {
+        header_cells.push(Cell::new(Text::from("Cached Tks").right_aligned()));
+    }
+    if show("input") {
+        header_cells.push(Cell::new(Text::from("Inp Tks").right_aligned()));
+    }
+    if show("output") {
+        header_cells.push(Cell::new(Text::from("Outp Tks").right_aligned()));
+    }
+    if show("reason") {
+        header_cells.push(Cell::new(Text::from("Reason Tks").right_aligned()));
+    }
+    if show("convs") {
+        header_cells.push(Cell::new(Text::from("Convs").right_aligned()));
+    }
+    if show("tools") {
+        header_cells.push(Cell::new(Text::from("Tools").right_aligned()));
+    }
+    if show("apps") {
+        header_cells.push(Cell::new("Apps"));
+    }
+    if show("models") {
+        header_cells.push(Cell::new("Models"));
+    }
+    let header = Row::new(header_cells)
+        .style(Style::default().add_modifier(Modifier::BOLD))
+        .height(1);
 
     // Find best values for highlighting
     // TODO: Let's refactor this.
@@ -1488,6 +1625,10 @@ fn draw_aggregate_stats_table(
         models_vec.sort();
         let models = models_vec.join(", ");
 
+        let mut apps_vec: Vec<String> = period_stats.apps.keys().cloned().collect();
+        apps_vec.sort();
+        let apps = apps_vec.join(", ");
+
         // Check if this is an empty row
         let is_empty_row = is_empty_period(period_stats);
 
@@ -1502,23 +1643,22 @@ fn draw_aggregate_stats_table(
             Line::from(Span::raw(period_text))
         };
 
-        let cost_cell = if is_empty_row {
-            Line::from(Span::styled(
-                format!("${:.2}", period_stats.stats.cost()),
-                Style::default().add_modifier(Modifier::DIM),
-            ))
+        let cost_str = format!(
+            "{}{:.prec$}",
+            format_options.currency_symbol,
+            period_stats.stats.cost(),
+            prec = format_options.cost_decimal_places
+        );
+        let cost_style = if is_empty_row {
+            Style::default().add_modifier(Modifier::DIM)
+        } else if color_costs {
+            Style::default().fg(cost_heat(period_stats.stats.cost_cents, best_cost_cents))
         } else if i == best_cost_i {
-            Line::from(Span::styled(
-                format!("${:.2}", period_stats.stats.cost()),
-                Style::default().fg(Color::Red),
-            ))
+            Style::default().fg(Color::Red)
         } else {
-            Line::from(Span::styled(
-                format!("${:.2}", period_stats.stats.cost()),
-                Style::default().fg(Color::Yellow),
-            ))
-        }
-        .right_aligned();
+            Style::default().fg(Color::Yellow)
+        };
+        let cost_cell = Line::from(Span::styled(cost_str, cost_style)).right_aligned();
 
         let tw = TOKEN_COL_WIDTH as usize;
 
@@ -1638,35 +1778,53 @@ fn draw_aggregate_stats_table(
             Style::default().add_modifier(Modifier::DIM),
         ));
 
+        let apps_cell = Line::from(Span::styled(
+            apps,
+            Style::default().add_modifier(Modifier::DIM),
+        ));
+
         // Create arrow indicator for currently selected row
         let arrow_cell = if table_state.selected() == Some(i) {
             Line::from(Span::styled(
                 "→",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(accent).add_modifier(Modifier::BOLD),
             ))
         } else {
             Line::from(Span::raw(""))
         };
 
-        rows.push(Row::new(vec![
-            arrow_cell,
-            period_cell,
-            cost_cell,
-            cached_cell,
-            input_cell,
-            output_cell,
-            reasoning_cell,
-            conv_cell,
-            tool_cell,
-            models_cell,
-        ]));
+        let mut row_cells = vec![arrow_cell, period_cell, cost_cell];
+        if show("cached") {
+            row_cells.push(cached_cell);
+        }
+        if show("input") {
+            row_cells.push(input_cell);
+        }
+        if show("output") {
+            row_cells.push(output_cell);
+        }
+        if show("reason") {
+            row_cells.push(reasoning_cell);
+        }
+        if show("convs") {
+            row_cells.push(conv_cell);
+        }
+        if show("tools") {
+            row_cells.push(tool_cell);
+        }
+        if show("apps") {
+            row_cells.push(apps_cell);
+        }
+        if show("models") {
+            row_cells.push(models_cell);
+        }
+        rows.push(Row::new(row_cells));
     }
 
-    // Collect all unique models for the totals row
+    // Collect all unique models (and apps) for the totals row
     let mut all_models = HashSet::new();
     let mut has_estimated_models = false;
+    let mut all_apps = std::collections::BTreeSet::new();
     for period_stats in aggregate_stats.values() {
         for model in period_stats.models.keys() {
             all_models.insert(model);
@@ -1674,7 +1832,11 @@ fn draw_aggregate_stats_table(
                 has_estimated_models = true;
             }
         }
+        for app in period_stats.apps.keys() {
+            all_apps.insert(app.clone());
+        }
     }
+    let all_apps_text = all_apps.into_iter().collect::<Vec<_>>().join(", ");
 
     let mut all_models_vec: Vec<String> = all_models
         .iter()
@@ -1691,60 +1853,52 @@ fn draw_aggregate_stats_table(
 
     // Add separator row before totals
     let token_sep = "─".repeat(TOKEN_COL_WIDTH as usize);
-    rows.push(Row::new(vec![
+    let dim = |s: String| {
         Line::from(Span::styled(
-            "",
+            s,
             Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            "───────────",
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            "──────────",
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            token_sep.clone(),
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            token_sep.clone(),
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            token_sep.clone(),
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            token_sep,
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            "──────",
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            "──────",
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-        Line::from(Span::styled(
-            "─".repeat(all_models_text.len().max(18)),
-            Style::default().add_modifier(Modifier::DIM),
-        )),
-    ]));
+        ))
+    };
+    let mut sep_cells = vec![
+        dim(String::new()),
+        dim("───────────".into()),
+        dim("──────────".into()),
+    ];
+    if show("cached") {
+        sep_cells.push(dim(token_sep.clone()));
+    }
+    if show("input") {
+        sep_cells.push(dim(token_sep.clone()));
+    }
+    if show("output") {
+        sep_cells.push(dim(token_sep.clone()));
+    }
+    if show("reason") {
+        sep_cells.push(dim(token_sep.clone()));
+    }
+    if show("convs") {
+        sep_cells.push(dim("──────".into()));
+    }
+    if show("tools") {
+        sep_cells.push(dim("──────".into()));
+    }
+    if show("apps") {
+        sep_cells.push(dim("─".repeat(all_apps_text.len().max(16))));
+    }
+    if show("models") {
+        sep_cells.push(dim("─".repeat(all_models_text.len().max(18))));
+    }
+    rows.push(Row::new(sep_cells));
 
     // Add totals row
     let total_cost = total_cost_cents as f64 / 100.0;
     let tw = TOKEN_COL_WIDTH as usize;
-    rows.push(Row::new(vec![
+    let mut totals_cells = vec![
         // Arrow indicator for totals row when selected
         if table_state.selected() == Some(rows.len()) {
             Line::from(Span::styled(
                 "→",
-                Style::default()
-                    .fg(Color::Cyan)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(accent).add_modifier(Modifier::BOLD),
             ))
         } else {
             Line::from(Span::raw(""))
@@ -1759,74 +1913,126 @@ fn draw_aggregate_stats_table(
             Style::default().add_modifier(Modifier::BOLD),
         )),
         Line::from(Span::styled(
-            format!("${total_cost:.2}"),
+            format!(
+                "{}{total_cost:.prec$}",
+                format_options.currency_symbol,
+                prec = format_options.cost_decimal_places
+            ),
             Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
         ))
         .right_aligned(),
-        Line::from(Span::styled(
-            format_number_fit(total_cached, format_options, tw),
-            Style::default()
-                .add_modifier(Modifier::DIM)
-                .add_modifier(Modifier::BOLD),
-        ))
-        .right_aligned(),
-        Line::from(Span::styled(
-            format_number_fit(total_input, format_options, tw),
-            Style::default().add_modifier(Modifier::BOLD),
-        ))
-        .right_aligned(),
-        Line::from(Span::styled(
-            format_number_fit(total_output, format_options, tw),
-            Style::default().add_modifier(Modifier::BOLD),
-        ))
-        .right_aligned(),
-        Line::from(Span::styled(
-            format_number_fit(total_reasoning, format_options, tw),
-            Style::default().add_modifier(Modifier::BOLD),
-        ))
-        .right_aligned(),
-        Line::from(Span::styled(
-            format_number(total_conversations, format_options),
-            Style::default().add_modifier(Modifier::BOLD),
-        ))
-        .right_aligned(),
-        Line::from(Span::styled(
-            format_number(total_tool_calls, format_options),
-            Style::default()
-                .fg(Color::Green)
-                .add_modifier(Modifier::BOLD),
-        ))
-        .right_aligned(),
-        Line::from(Span::styled(
+    ];
+    if show("cached") {
+        totals_cells.push(
+            Line::from(Span::styled(
+                format_number_fit(total_cached, format_options, tw),
+                Style::default()
+                    .add_modifier(Modifier::DIM)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .right_aligned(),
+        );
+    }
+    if show("input") {
+        totals_cells.push(
+            Line::from(Span::styled(
+                format_number_fit(total_input, format_options, tw),
+                Style::default().add_modifier(Modifier::BOLD),
+            ))
+            .right_aligned(),
+        );
+    }
+    if show("output") {
+        totals_cells.push(
+            Line::from(Span::styled(
+                format_number_fit(total_output, format_options, tw),
+                Style::default().add_modifier(Modifier::BOLD),
+            ))
+            .right_aligned(),
+        );
+    }
+    if show("reason") {
+        totals_cells.push(
+            Line::from(Span::styled(
+                format_number_fit(total_reasoning, format_options, tw),
+                Style::default().add_modifier(Modifier::BOLD),
+            ))
+            .right_aligned(),
+        );
+    }
+    if show("convs") {
+        totals_cells.push(
+            Line::from(Span::styled(
+                format_number(total_conversations, format_options),
+                Style::default().add_modifier(Modifier::BOLD),
+            ))
+            .right_aligned(),
+        );
+    }
+    if show("tools") {
+        totals_cells.push(
+            Line::from(Span::styled(
+                format_number(total_tool_calls, format_options),
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .right_aligned(),
+        );
+    }
+    if show("apps") {
+        totals_cells.push(Line::from(Span::styled(
+            all_apps_text,
+            Style::default().add_modifier(Modifier::DIM),
+        )));
+    }
+    if show("models") {
+        totals_cells.push(Line::from(Span::styled(
             all_models_text,
             Style::default().add_modifier(Modifier::DIM),
-        )),
-    ]));
+        )));
+    }
+    rows.push(Row::new(totals_cells));
 
     // Save the row count before moving rows into the table
     let total_rows = rows.len();
 
-    let table = Table::new(
-        rows,
-        [
-            Constraint::Length(1),               // Arrow
-            Constraint::Length(11),              // Date/Month
-            Constraint::Length(10),              // Cost
-            Constraint::Length(TOKEN_COL_WIDTH), // Cached
-            Constraint::Length(TOKEN_COL_WIDTH), // Input
-            Constraint::Length(TOKEN_COL_WIDTH), // Output
-            Constraint::Length(TOKEN_COL_WIDTH), // Reasoning
-            Constraint::Length(6),               // Convs
-            Constraint::Length(6),               // Tools
-            Constraint::Min(10),                 // Models
-        ],
-    )
-    .header(header)
-    .block(Block::default().title(""))
-    .row_highlight_style(Style::new().blue())
-    .column_spacing(2);
+    let mut widths = vec![
+        Constraint::Length(1),  // Arrow
+        Constraint::Length(11), // Date/Month
+        Constraint::Length(10), // Cost
+    ];
+    if show("cached") {
+        widths.push(Constraint::Length(TOKEN_COL_WIDTH));
+    }
+    if show("input") {
+        widths.push(Constraint::Length(TOKEN_COL_WIDTH));
+    }
+    if show("output") {
+        widths.push(Constraint::Length(TOKEN_COL_WIDTH));
+    }
+    if show("reason") {
+        widths.push(Constraint::Length(TOKEN_COL_WIDTH));
+    }
+    if show("convs") {
+        widths.push(Constraint::Length(6));
+    }
+    if show("tools") {
+        widths.push(Constraint::Length(6));
+    }
+    if show("apps") {
+        widths.push(Constraint::Min(16));
+    }
+    if show("models") {
+        widths.push(Constraint::Min(10));
+    }
+    let table = Table::new(rows, widths)
+        .header(header)
+        .block(Block::default().title(""))
+        .row_highlight_style(Style::default().fg(accent))
+        .column_spacing(2);
 
     frame.render_stateful_widget(table, area, table_state);
 
@@ -2027,12 +2233,22 @@ fn draw_session_stats_table(
 
             let cost_cell = if best_cost_i == Some(i) {
                 Line::from(Span::styled(
-                    format!("${:.2}", session.stats.cost()),
+                    format!(
+                        "{}{:.prec$}",
+                        format_options.currency_symbol,
+                        session.stats.cost(),
+                        prec = format_options.cost_decimal_places
+                    ),
                     Style::default().fg(Color::Red),
                 ))
             } else {
                 Line::from(Span::styled(
-                    format!("${:.2}", session.stats.cost()),
+                    format!(
+                        "{}{:.prec$}",
+                        format_options.currency_symbol,
+                        session.stats.cost(),
+                        prec = format_options.cost_decimal_places
+                    ),
                     Style::default().fg(Color::Yellow),
                 ))
             }
@@ -2195,7 +2411,11 @@ fn draw_session_stats_table(
                 )),
                 Line::from(Span::raw("")),
                 Line::from(Span::styled(
-                    format!("${total_cost:.2}"),
+                    format!(
+                        "{}{total_cost:.prec$}",
+                        format_options.currency_symbol,
+                        prec = format_options.cost_decimal_places
+                    ),
                     Style::default()
                         .fg(Color::Yellow)
                         .add_modifier(Modifier::BOLD),
@@ -2336,7 +2556,15 @@ fn draw_summary_stats(
             format_number(total_tool_calls, format_options),
             Color::LightGreen,
         ),
-        ("Cost:", format!("${total_cost:.2}"), Color::LightYellow),
+        (
+            "Cost:",
+            format!(
+                "{}{total_cost:.prec$}",
+                format_options.currency_symbol,
+                prec = format_options.cost_decimal_places
+            ),
+            Color::LightYellow,
+        ),
         ("Days tracked:", all_days.len().to_string(), Color::White),
     ];
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -4,15 +4,69 @@ use crate::tui::logic::{
     aggregate_daily_stats_by_year, date_matches_buffer, filtered_aggregate_keys,
 };
 use crate::tui::{
-    PeriodFilter, build_display_stats, create_upload_progress_callback, format_month_for_display,
-    format_week_for_display, format_year_for_display, show_upload_error, show_upload_success,
+    AggregateViewMode, PeriodFilter, build_display_stats, cost_heat,
+    create_upload_progress_callback, format_month_for_display, format_week_for_display,
+    format_year_for_display, parse_accent, show_upload_error, show_upload_success,
     update_period_filters, update_table_states, update_window_offsets,
 };
 use crate::types::{
     AgenticCodingToolStats, CompactDate, DailyStats, MultiAnalyzerStats, Stats, TuiStats,
 };
+use ratatui::style::Color;
 use ratatui::widgets::TableState;
 use std::collections::BTreeMap;
+
+// ============================================================================
+// CONFIG-DRIVEN APPEARANCE TESTS
+// ============================================================================
+
+#[test]
+fn aggregate_view_from_config() {
+    assert!(matches!(
+        AggregateViewMode::from_config("daily"),
+        AggregateViewMode::Daily
+    ));
+    assert!(matches!(
+        AggregateViewMode::from_config("WEEK"),
+        AggregateViewMode::Weekly
+    ));
+    assert!(matches!(
+        AggregateViewMode::from_config(" Monthly "),
+        AggregateViewMode::Monthly
+    ));
+    assert!(matches!(
+        AggregateViewMode::from_config("year"),
+        AggregateViewMode::Yearly
+    ));
+    assert!(matches!(
+        AggregateViewMode::from_config("nonsense"),
+        AggregateViewMode::Daily
+    ));
+}
+
+#[test]
+fn accent_color_parsing() {
+    assert_eq!(parse_accent("green"), Color::Green);
+    assert_eq!(parse_accent("MAGENTA"), Color::Magenta);
+    assert_eq!(parse_accent("purple"), Color::Magenta);
+    assert_eq!(parse_accent("blue"), Color::Blue);
+    assert_eq!(parse_accent("not-a-color"), Color::Cyan); // default
+}
+
+#[test]
+fn cost_heatmap_scales_with_magnitude() {
+    // max == 0 -> green floor
+    assert_eq!(cost_heat(50, 0), Color::Green);
+    // higher cost -> more red, less green
+    if let (Color::Rgb(lr, lg, _), Color::Rgb(hr, hg, _)) =
+        (cost_heat(10, 100), cost_heat(100, 100))
+    {
+        assert!(hr > lr, "redder at higher cost");
+        assert!(hg < lg, "less green at higher cost");
+    } else {
+        panic!("expected Rgb colors");
+    }
+}
 
 // ============================================================================
 // TABLE STATE MANAGEMENT TESTS (tui.rs helpers)
@@ -34,6 +88,7 @@ fn make_tool_stats(name: &str, has_data: bool) -> AgenticCodingToolStats {
                     ..TuiStats::default()
                 },
                 model_stats: BTreeMap::new(),
+                apps: BTreeMap::new(),
             },
         );
     }
@@ -65,6 +120,7 @@ fn make_daily_stats(
             ..TuiStats::default()
         },
         model_stats: BTreeMap::new(),
+        apps: BTreeMap::new(),
     }
 }
 
@@ -161,6 +217,8 @@ fn test_upload_progress_callback_runs_without_panicking() {
         use_comma: false,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 2,
     };
 
@@ -177,6 +235,8 @@ fn test_show_upload_success_and_error_do_not_panic() {
         use_comma: true,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 2,
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -273,6 +273,10 @@ pub struct DailyStats {
     /// Per-model aggregated statistics (tokens, cost, etc.) for this day.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub model_stats: BTreeMap<String, ModelStats>,
+    /// Apps/tools that contributed this period (populated for the combined
+    /// "All Tools" view so the table can list which apps were used).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub apps: BTreeMap<String, u32>,
 }
 
 impl std::ops::AddAssign<&DailyStats> for DailyStats {
@@ -289,6 +293,9 @@ impl std::ops::AddAssign<&DailyStats> for DailyStats {
                 .entry(model.clone())
                 .or_insert_with(|| ModelStats::new(model.clone()))
                 .add_model_stats(model_stat);
+        }
+        for (app, count) in &rhs.apps {
+            *self.apps.entry(app.clone()).or_insert(0) += count;
         }
     }
 }
@@ -312,6 +319,14 @@ impl std::ops::SubAssign<&DailyStats> for DailyStats {
                 existing.sub_model_stats(model_stat);
                 if existing.message_count == 0 {
                     self.model_stats.remove(model);
+                }
+            }
+        }
+        for (app, count) in &rhs.apps {
+            if let Some(existing) = self.apps.get_mut(app) {
+                *existing = existing.saturating_sub(*count);
+                if *existing == 0 {
+                    self.apps.remove(app);
                 }
             }
         }
@@ -833,6 +848,28 @@ mod tests {
         stats -= &day2;
         assert_eq!(stats.models.get("gpt-4"), None); // removed at 0
         assert_eq!(stats.models.get("claude"), None);
+    }
+
+    #[test]
+    fn daily_stats_apps_ref_counting() {
+        let mut stats = DailyStats::default();
+        let day1 = DailyStats {
+            apps: [("Claude Code".to_string(), 1)].into_iter().collect(),
+            ..Default::default()
+        };
+        let day2 = DailyStats {
+            apps: [("Codex CLI".to_string(), 1)].into_iter().collect(),
+            ..Default::default()
+        };
+
+        stats += &day1;
+        stats += &day2;
+        assert_eq!(stats.apps.get("Claude Code"), Some(&1));
+        assert_eq!(stats.apps.get("Codex CLI"), Some(&1));
+
+        stats -= &day1;
+        assert_eq!(stats.apps.get("Claude Code"), None); // removed at 0
+        assert_eq!(stats.apps.get("Codex CLI"), Some(&1));
     }
 
     fn make_session_contrib(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,6 +28,8 @@ pub struct NumberFormatOptions {
     pub use_human: bool,
     pub locale: String,
     pub decimal_places: usize,
+    pub currency_symbol: String,
+    pub cost_decimal_places: usize,
 }
 
 /// Format a number for display. Accepts both u32 and u64.
@@ -108,6 +110,8 @@ pub fn format_number_fit(
         use_human: true,
         use_comma: false,
         locale: options.locale.clone(),
+        currency_symbol: options.currency_symbol.clone(),
+        cost_decimal_places: options.cost_decimal_places,
         decimal_places: options.decimal_places,
     };
     let human = format_number(n, &human_options);
@@ -121,6 +125,8 @@ pub fn format_number_fit(
             use_human: true,
             use_comma: false,
             locale: options.locale.clone(),
+            currency_symbol: options.currency_symbol.clone(),
+            cost_decimal_places: options.cost_decimal_places,
             decimal_places: dp,
         };
         let compact = format_number(n, &compact_options);
@@ -140,6 +146,8 @@ pub fn format_number_fit(
         use_human: true,
         use_comma: false,
         locale: options.locale.clone(),
+        currency_symbol: options.currency_symbol.clone(),
+        cost_decimal_places: options.cost_decimal_places,
         decimal_places: 0,
     };
     format_number(n, &minimal)

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -9,6 +9,8 @@ fn test_format_number_comma() {
         use_comma: true,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 2,
     };
 
@@ -23,6 +25,8 @@ fn test_format_number_human() {
         use_comma: false,
         use_human: true,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 1,
     };
 
@@ -44,6 +48,8 @@ fn test_format_number_fit_preferred_format_fits() {
         use_comma: true,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 1,
     };
 
@@ -62,6 +68,8 @@ fn test_format_number_fit_comma_overflow_falls_back_to_human() {
         use_comma: true,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 1,
     };
 
@@ -85,6 +93,8 @@ fn test_format_number_fit_narrow_column_forces_compact() {
         use_comma: true,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 2,
     };
 
@@ -105,6 +115,8 @@ fn test_format_number_fit_plain_digits_fallback() {
         use_comma: true,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 2,
     };
 
@@ -122,6 +134,8 @@ fn test_format_number_fit_u64_totals() {
         use_comma: true,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 1,
     };
 
@@ -145,6 +159,8 @@ fn test_format_number_fit_human_mode_passthrough() {
         use_comma: false,
         use_human: true,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 1,
     };
 
@@ -159,6 +175,8 @@ fn test_format_number_fit_plain_mode_overflow() {
         use_comma: false,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 1,
     };
 
@@ -178,6 +196,8 @@ fn test_format_number_fit_zero() {
         use_comma: true,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 1,
     };
     assert_eq!(format_number_fit(0_u64, &options, 12), "0");
@@ -191,6 +211,8 @@ fn test_format_number_fit_exact_boundary() {
         use_comma: false,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 1,
     };
 
@@ -207,6 +229,8 @@ fn test_format_number_plain() {
         use_comma: false,
         use_human: false,
         locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
         decimal_places: 2,
     };
 


### PR DESCRIPTION
Formatting config:
- currency_symbol: configurable cost prefix (default "$")
- cost_decimal_places: configurable cost precision (default 2)

TUI config (all backward-compatible via serde defaults):
- default_view: open in daily/weekly/monthly/yearly
- default_tab: open on a named tool tab
- confirm_quit: require a second 'q' to quit
- hidden_columns: hide individual aggregate-table columns
- accent_color: recolor title, tabs, and selected row
- color_costs: tint Cost cells by magnitude (relative to view max)
- show_header: toggle the title banner

Apps column:
- Add apps map to DailyStats with ref-counted merge logic
- Render contributing tools per period in the All Tools view
- Auto-collapse the column on single-tool tabs where it is empty

Analyzers:
- claude_code: populate session_name from in-file summary so the live session view shows real titles instead of the upload path
- copilot: honor a provider-reported cost when present, otherwise price counted tokens via the shared pricing table (matches the other analyzers)

Tests: apps ref-counting, parse_accent, cost_heat, AggregateViewMode::from_config, and Copilot cost coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable TUI appearance: accent color, optional header, hidden columns, cost-cell coloring, currency symbol, and cost decimal precision.
  * Introduced config-driven default startup view/tab selection and optional quit confirmation.
* **Improvements**
  * Cost reporting now uses provider-reported cost when available, with accurate fallback calculation; cost/currency display is fully config-driven.
  * Session titles now reflect real per-session names (not upload paths).
  * Aggregate “Apps” information is conditionally shown when relevant.
* **Tests**
  * Updated and expanded TUI/config and cost-formatting coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->