### PR TITLE
Claude Sonnet 5

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -26,4 +26,26 @@ ignore = [
     # Re-evaluate once phf_generator adopts rand >= 0.10 or quinn-proto
     # releases a version using rand >= 0.10.
     "RUSTSEC-2026-0097",
+
+    # RUSTSEC-2026-0189: DNS rebinding vulnerability in rmcp's Streamable
+    # HTTP server transport (CVE-2026-42559), fixed in rmcp >= 1.4.0.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0189
+    #
+    # Not applicable to splitrail:
+    #   * The vulnerable code lives entirely in
+    #     `rmcp::transport::streamable_http_server`, which is only compiled
+    #     in when the `transport-streamable-http-server` feature (or its
+    #     `server-side-http` dependency) is enabled.
+    #   * We depend on rmcp with `features = ["server", "macros",
+    #     "transport-io"]`. `transport-io` is the stdio transport; it does
+    #     not pull in `server-side-http` or any HTTP transport, so the
+    #     advisory's affected module is never compiled into our binary.
+    #   * Per the advisory, non-HTTP transports (stdio, child-process) are
+    #     explicitly unaffected.
+    #
+    # Re-evaluate if splitrail ever enables an HTTP-based MCP transport, or
+    # when upgrading rmcp past its current 0.x line (a >=1.4.0 upgrade is a
+    # separate, larger change due to upstream API churn between rmcp 0.12
+    # and 1.x).
+    "RUSTSEC-2026-0189",
 ]

--- a/.claude/skills/pricing/SKILL.md
+++ b/.claude/skills/pricing/SKILL.md
@@ -15,6 +15,7 @@ Token pricing is defined in `src/models.rs`. Built-in models are populated by `p
    - `service_tiers`: Leave empty unless the provider has distinct priority/flex/batch rates.
    - `dated_pricing`: Leave empty unless pricing changes by usage date.
    - `is_estimated`: Set to `true` only when pricing is not confirmed by a provider/tool source.
+   - `input_token_semantics`: Auto-derived for built-in models (defaults to `ExcludesCache`); only GPT/o-series models typically need `IncludesCacheRead`. External model configs should set this explicitly if it affects cache-read counting.
 2. If the model has aliases (date suffixes, provider-prefixed names, regional names, etc.), add entries to the alias section mapping each observed name to the canonical model name.
 3. Add or update tests in `src/models.rs` for canonical pricing, aliases, caching, and estimated/non-estimated status.
 

--- a/.claude/skills/pricing/SKILL.md
+++ b/.claude/skills/pricing/SKILL.md
@@ -5,21 +5,37 @@ description: Guide for updating model pricing in Splitrail. Use when adding new 
 
 # Pricing Model Updates
 
-Token pricing is defined in `src/models.rs` using compile-time `phf` (perfect hash function) maps for fast lookups.
+Token pricing is defined in `src/models.rs`. Built-in models are populated by `populate_defaults()` into the runtime model registry, and user/config models can be merged with `init_external_models()`.
 
 ## Adding a New Model
 
-1. Add a `ModelInfo` entry to `MODEL_INDEX` (line 65 in `src/models.rs`) with:
-   - `pricing`: Use `PricingStructure::Flat { input_per_1m, output_per_1m }` for flat-rate models, or `PricingStructure::Tiered` for tiered pricing
-   - `caching`: Use the appropriate `CachingSupport` variant (`None`, `OpenAI`, `Anthropic`, or `Google`)
-   - `is_estimated`: Set to `true` if pricing is not officially published
-2. If the model has aliases (date suffixes, etc.), add entries to `MODEL_ALIASES` mapping to the canonical model name
+1. Add a `ModelInfo` entry in `populate_defaults()` with:
+   - `pricing`: Use `PricingStructure::Flat { input_per_1m, output_per_1m }` for flat-rate models, or `PricingStructure::Tiered` for threshold-based pricing.
+   - `caching`: Use the appropriate `CachingSupport` variant (`None`, `OpenAI`, `Anthropic`, `OpenAIWithWrites`, or `Tiered`).
+   - `service_tiers`: Leave empty unless the provider has distinct priority/flex/batch rates.
+   - `dated_pricing`: Leave empty unless pricing changes by usage date.
+   - `is_estimated`: Set to `true` only when pricing is not confirmed by a provider/tool source.
+2. If the model has aliases (date suffixes, provider-prefixed names, regional names, etc.), add entries to the alias section mapping each observed name to the canonical model name.
+3. Add or update tests in `src/models.rs` for canonical pricing, aliases, caching, and estimated/non-estimated status.
 
-See existing entries in `src/models.rs` for the pattern.
+## Dated Pricing Overrides
+
+Use `dated_pricing` when a model has temporary promotional pricing, launch pricing, or another time-bounded rate that should apply based on the original usage timestamp.
+
+The default `pricing` and `caching` fields should represent the durable/current sticker price. Each `DatedPricing` override has a `valid_until: NaiveDate` exclusive end date and applies when `usage_date < valid_until`. For example, an introductory rate that applies through `2026-08-31` should use `valid_until = NaiveDate::from_ymd_opt(2026, 9, 1).expect("valid date")`.
+
+When adding a dated override:
+
+- Keep the model's default `pricing`/`caching` at the post-promo or durable rate.
+- Add the temporary rate with `add_dated_pricing!()` after `add_model!()`.
+- Add boundary tests for the final day of the temporary rate and the first day after it ends.
+- Prefer dated calculator functions in analyzers that know the usage timestamp.
 
 ## Price Calculation
 
-Use `models::calculate_total_cost()` when an analyzer doesn't provide cost data.
+Use `models::calculate_total_cost_for_service_tier_at()` when an analyzer has a message or event timestamp. This preserves historical costs across dated pricing windows.
+
+Use the undated compatibility helpers, such as `models::calculate_total_cost()`, only for tests, config-like calculations, or call sites that truly do not know the usage date. Undated helpers use the model's default `pricing`/`caching`, not temporary dated overrides.
 
 ## Common Pricing Sources
 

--- a/src/analyzers/antigravity.rs
+++ b/src/analyzers/antigravity.rs
@@ -590,12 +590,14 @@ impl Analyzer for AntigravityCliAnalyzer {
                         .model_id
                         .clone()
                         .unwrap_or_else(|| "gemini-3-flash-preview".to_string());
-                    let cost = crate::models::calculate_total_cost(
+                    let cost = crate::models::calculate_total_cost_for_service_tier_at(
                         &model_name_str,
+                        crate::models::ServiceTier::Standard,
                         gen_meta.input_tokens,
                         gen_meta.output_tokens,
                         0,
                         0,
+                        Some(ts),
                     );
                     stats.input_tokens = gen_meta.input_tokens;
                     stats.output_tokens = gen_meta.output_tokens;
@@ -609,12 +611,14 @@ impl Analyzer for AntigravityCliAnalyzer {
                         .clone()
                         .unwrap_or_else(|| "gemini-2.5-flash".to_string());
                     let estimated_output_tokens = crate::analyzers::copilot::count_tokens(&content);
-                    let cost = crate::models::calculate_total_cost(
+                    let cost = crate::models::calculate_total_cost_for_service_tier_at(
                         &model_name_str,
+                        crate::models::ServiceTier::Standard,
                         0,
                         estimated_output_tokens,
                         0,
                         0,
+                        Some(ts),
                     );
                     stats.output_tokens = estimated_output_tokens;
                     stats.cost = cost;

--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -797,17 +797,10 @@ pub fn merge_message_into(
         dst.stats.todos_completed += src.stats.todos_completed;
         dst.stats.todos_in_progress += src.stats.todos_in_progress;
 
-        // Recalculate cost
-        if let Some(model) = &dst.model {
-            dst.stats.cost = calculate_total_cost_for_service_tier_at(
-                model,
-                crate::models::ServiceTier::Standard,
-                dst.stats.input_tokens,
-                dst.stats.output_tokens,
-                dst.stats.cache_creation_tokens,
-                dst.stats.cache_read_tokens,
-                Some(dst.date),
-            );
-        }
+        // Preserve each message's timestamp-aware price: `dst.stats.cost` was
+        // already priced at `dst.date`, and `src.stats.cost` was already
+        // priced at `src.date`, so just accumulate rather than recomputing
+        // the whole total at `dst.date` (which would reprice `src`'s tokens).
+        dst.stats.cost += src.stats.cost;
     }
 }

--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
-use crate::models::calculate_total_cost;
+use crate::models::calculate_total_cost_for_service_tier_at;
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::{fast_hash, hash_text};
 use walkdir::WalkDir;
@@ -545,13 +545,32 @@ pub fn extract_tool_stats(
     stats
 }
 
+#[cfg(test)]
 pub fn calculate_cost_from_tokens(usage: &Usage, model_name: &str) -> f64 {
-    calculate_total_cost(
+    calculate_total_cost_for_service_tier_at(
         model_name,
+        crate::models::ServiceTier::Standard,
         usage.input_tokens,
         usage.output_tokens,
         usage.cache_creation_input_tokens,
         usage.cache_read_input_tokens,
+        None,
+    )
+}
+
+pub fn calculate_cost_from_tokens_at(
+    usage: &Usage,
+    model_name: &str,
+    effective_at: DateTime<Utc>,
+) -> f64 {
+    calculate_total_cost_for_service_tier_at(
+        model_name,
+        crate::models::ServiceTier::Standard,
+        usage.input_tokens,
+        usage.output_tokens,
+        usage.cache_creation_input_tokens,
+        usage.cache_read_input_tokens,
+        Some(effective_at),
     )
 }
 
@@ -654,7 +673,8 @@ pub fn parse_jsonl_file<R: Read>(
                         msg.stats.cache_read_tokens = usage_val.cache_read_input_tokens;
                         msg.stats.cached_tokens = usage_val.cache_creation_input_tokens
                             + usage_val.cache_read_input_tokens;
-                        msg.stats.cost = calculate_cost_from_tokens(&usage_val, &model_name);
+                        msg.stats.cost =
+                            calculate_cost_from_tokens_at(&usage_val, &model_name, timestamp);
 
                         if let Some(request_id) = request_id
                             && let Some(message_id) = message_id
@@ -779,12 +799,14 @@ pub fn merge_message_into(
 
         // Recalculate cost
         if let Some(model) = &dst.model {
-            dst.stats.cost = calculate_total_cost(
+            dst.stats.cost = calculate_total_cost_for_service_tier_at(
                 model,
+                crate::models::ServiceTier::Standard,
                 dst.stats.input_tokens,
                 dst.stats.output_tokens,
                 dst.stats.cache_creation_tokens,
                 dst.stats.cache_read_tokens,
+                Some(dst.date),
             );
         }
     }

--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -11,7 +11,7 @@ use walkdir::WalkDir;
 
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
-use crate::models::calculate_total_cost;
+use crate::models::{ServiceTier, calculate_total_cost_for_service_tier_at};
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::{deserialize_utc_timestamp, hash_text, warn_once};
 
@@ -493,7 +493,11 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                                 fallback
                             });
 
-                            let mut stats = stats_from_usage(&token_usage, &model_state.name);
+                            let mut stats = stats_from_usage(
+                                &token_usage,
+                                &model_state.name,
+                                wrapper.timestamp,
+                            );
                             stats.tool_calls = current_tool_call_ids.len() as u32;
                             current_tool_call_ids.clear();
 
@@ -534,7 +538,11 @@ pub(crate) fn parse_codex_cli_jsonl_file(
     Ok((entries, detected_model))
 }
 
-fn calculate_cost_from_tokens(usage: &CodexCliTokenUsage, model_name: &str) -> f64 {
+fn calculate_cost_from_tokens(
+    usage: &CodexCliTokenUsage,
+    model_name: &str,
+    effective_at: DateTime<Utc>,
+) -> f64 {
     // Codex's output_tokens already include any reasoning tokens. Treat them as-is
     // so we don't double-charge for structured reasoning output.
     let total_output_tokens = usage.output_tokens;
@@ -543,21 +551,27 @@ fn calculate_cost_from_tokens(usage: &CodexCliTokenUsage, model_name: &str) -> f
     // since Codex input_tokens is a superset that includes cached tokens
     let actual_input_tokens = usage.input_tokens.saturating_sub(usage.cached_input_tokens);
 
-    calculate_total_cost(
+    calculate_total_cost_for_service_tier_at(
         model_name,
+        ServiceTier::Standard,
         actual_input_tokens,
         total_output_tokens,
         0, // Codex CLI doesn't have separate cache creation tokens
         usage.cached_input_tokens,
+        Some(effective_at),
     )
 }
 
-fn stats_from_usage(usage: &CodexCliTokenUsage, model_name: &str) -> Stats {
+fn stats_from_usage(
+    usage: &CodexCliTokenUsage,
+    model_name: &str,
+    effective_at: DateTime<Utc>,
+) -> Stats {
     // Keep the reported output token count; reasoning tokens are informational only.
     let total_output_tokens = usage.output_tokens;
     let actual_input_tokens = usage.input_tokens.saturating_sub(usage.cached_input_tokens);
 
-    let cost = calculate_cost_from_tokens(usage, model_name);
+    let cost = calculate_cost_from_tokens(usage, model_name, effective_at);
 
     Stats {
         input_tokens: actual_input_tokens,

--- a/src/analyzers/copilot.rs
+++ b/src/analyzers/copilot.rs
@@ -412,12 +412,14 @@ pub(crate) fn parse_copilot_session_file(session_file: &Path) -> Result<Vec<Conv
         if let Some(cost) = request.cost.filter(|c| *c > 0.0) {
             stats.cost = cost;
         } else if let Some(model_name) = &model {
-            stats.cost = crate::models::calculate_total_cost(
+            stats.cost = crate::models::calculate_total_cost_for_service_tier_at(
                 model_name,
+                crate::models::ServiceTier::Standard,
                 stats.input_tokens,
                 stats.output_tokens,
                 stats.cache_creation_tokens,
                 stats.cache_read_tokens,
+                Some(assistant_date),
             );
         }
 

--- a/src/analyzers/copilot_cli.rs
+++ b/src/analyzers/copilot_cli.rs
@@ -1,6 +1,6 @@
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
-use crate::models::calculate_total_cost;
+use crate::models::{ServiceTier, calculate_total_cost_for_service_tier_at};
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::hash_text;
 use anyhow::{Context, Result};
@@ -217,14 +217,16 @@ impl CopilotCliLiveContext {
     }
 }
 
-fn calculate_copilot_cli_cost(stats: &Stats, model_name: &str) -> f64 {
+fn calculate_copilot_cli_cost(stats: &Stats, model_name: &str, effective_at: DateTime<Utc>) -> f64 {
     let actual_input_tokens = stats.input_tokens.saturating_sub(stats.cache_read_tokens);
-    calculate_total_cost(
+    calculate_total_cost_for_service_tier_at(
         model_name,
+        ServiceTier::Standard,
         actual_input_tokens,
         stats.output_tokens,
         stats.cache_creation_tokens,
         stats.cache_read_tokens,
+        Some(effective_at),
     )
 }
 
@@ -479,7 +481,8 @@ fn apply_copilot_cli_shutdown_metrics(
             message.stats.cache_creation_tokens = cache_write_distribution[position];
             message.stats.cached_tokens =
                 message.stats.cache_read_tokens + message.stats.cache_creation_tokens;
-            message.stats.cost = calculate_copilot_cli_cost(&message.stats, model_name);
+            message.stats.cost =
+                calculate_copilot_cli_cost(&message.stats, model_name, message.date);
         }
     }
 }
@@ -533,7 +536,8 @@ fn apply_copilot_cli_live_prompt_overhead(
             .cache_creation_tokens
             .saturating_add(message.stats.cache_read_tokens);
         if let Some(model_name) = message.model.as_deref() {
-            message.stats.cost = calculate_copilot_cli_cost(&message.stats, model_name);
+            message.stats.cost =
+                calculate_copilot_cli_cost(&message.stats, model_name, message.date);
         }
     }
 }
@@ -602,7 +606,8 @@ fn flush_copilot_cli_turn(
         assistant_stats.cached_tokens =
             assistant_stats.cache_read_tokens + assistant_stats.cache_creation_tokens;
         if let Some(model_name) = model.as_deref() {
-            assistant_stats.cost = calculate_copilot_cli_cost(&assistant_stats, model_name);
+            assistant_stats.cost =
+                calculate_copilot_cli_cost(&assistant_stats, model_name, assistant_date);
         }
 
         entries.push(ConversationMessage {

--- a/src/analyzers/gemini_cli.rs
+++ b/src/analyzers/gemini_cli.rs
@@ -1,6 +1,9 @@
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
-use crate::models::{calculate_cache_cost, calculate_input_cost, calculate_output_cost};
+use crate::models::{
+    ServiceTier, calculate_cache_cost_for_service_tier_at,
+    calculate_input_cost_for_service_tier_at, calculate_output_cost_for_service_tier_at,
+};
 use crate::types::{Application, ConversationMessage, FileCategory, MessageRole, Stats};
 use crate::utils::{deserialize_utc_timestamp, hash_text};
 use anyhow::Result;
@@ -243,12 +246,32 @@ fn extract_and_hash_project_id_gemini_cli(file_path: &Path) -> String {
 }
 
 // Cost calculation using the centralized model system
-fn calculate_gemini_cost(tokens: &GeminiCliTokens, model_name: &str) -> f64 {
+fn calculate_gemini_cost(
+    tokens: &GeminiCliTokens,
+    model_name: &str,
+    effective_at: DateTime<Utc>,
+) -> f64 {
     let total_input_tokens = tokens.input + tokens.thoughts + tokens.tool;
 
-    let input_cost = calculate_input_cost(model_name, total_input_tokens);
-    let output_cost = calculate_output_cost(model_name, tokens.output);
-    let cache_cost = calculate_cache_cost(model_name, 0, tokens.cached); // Gemini CLI doesn't have cache creation
+    let input_cost = calculate_input_cost_for_service_tier_at(
+        model_name,
+        ServiceTier::Standard,
+        total_input_tokens,
+        Some(effective_at),
+    );
+    let output_cost = calculate_output_cost_for_service_tier_at(
+        model_name,
+        ServiceTier::Standard,
+        tokens.output,
+        Some(effective_at),
+    );
+    let cache_cost = calculate_cache_cost_for_service_tier_at(
+        model_name,
+        ServiceTier::Standard,
+        0,
+        tokens.cached,
+        Some(effective_at),
+    ); // Gemini CLI doesn't have cache creation
 
     input_cost + output_cost + cache_cost
 }
@@ -343,7 +366,7 @@ fn messages_from_session(
                 stats.cache_creation_tokens = 0;
                 stats.cache_read_tokens = 0;
                 stats.cached_tokens = tokens.cached;
-                stats.cost = calculate_gemini_cost(&tokens, &model);
+                stats.cost = calculate_gemini_cost(&tokens, &model, timestamp);
                 stats.tool_calls = tool_calls.len() as u32;
 
                 entries.push(ConversationMessage {

--- a/src/analyzers/opencode.rs
+++ b/src/analyzers/opencode.rs
@@ -1,6 +1,6 @@
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
-use crate::models::calculate_total_cost;
+use crate::models::{ServiceTier, calculate_total_cost_for_service_tier_at};
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::hash_text;
 use anyhow::{Context, Result};
@@ -286,7 +286,11 @@ pub(crate) fn ms_to_datetime(ms: Option<i64>) -> DateTime<Utc> {
 
 /// Compute stats from an [`OpenCodeMessage`], optionally merging in pre-loaded
 /// tool-call stats (from parts data).
-pub(crate) fn compute_message_stats(msg: &OpenCodeMessage, tool_stats: Stats) -> Stats {
+pub(crate) fn compute_message_stats_at(
+    msg: &OpenCodeMessage,
+    tool_stats: Stats,
+    effective_at: DateTime<Utc>,
+) -> Stats {
     if msg.role != "assistant" {
         return Stats::default();
     }
@@ -302,12 +306,14 @@ pub(crate) fn compute_message_stats(msg: &OpenCodeMessage, tool_stats: Stats) ->
         s.cached_tokens = tokens.cache.write + tokens.cache.read;
 
         if let Some(model_name) = msg.model_name() {
-            s.cost = calculate_total_cost(
+            s.cost = calculate_total_cost_for_service_tier_at(
                 &model_name,
+                ServiceTier::Standard,
                 s.input_tokens,
                 s.output_tokens,
                 s.cache_creation_tokens,
                 s.cache_read_tokens,
+                Some(effective_at),
             );
         }
     }
@@ -327,6 +333,10 @@ pub(crate) fn compute_message_stats(msg: &OpenCodeMessage, tool_stats: Stats) ->
     }
 
     s
+}
+
+pub(crate) fn compute_message_stats(msg: &OpenCodeMessage, tool_stats: Stats) -> Stats {
+    compute_message_stats_at(msg, tool_stats, ms_to_datetime(msg.time.created))
 }
 
 /// Build a [`ConversationMessage`] from an [`OpenCodeMessage`] and pre-computed stats.

--- a/src/analyzers/opencode_common.rs
+++ b/src/analyzers/opencode_common.rs
@@ -428,7 +428,16 @@ fn to_conversation_message(
     let local_hash = Some(msg.id.clone());
     let global_hash = hash_text(&format!("{}_{}_{}", hash_prefix, msg.session_id, msg.id));
 
+    // `date` is used for display purposes and falls back to the Unix epoch
+    // when the source timestamp is missing/invalid (see `ms_to_datetime`).
+    // For pricing we need to distinguish "no timestamp" from "epoch
+    // timestamp", since the former should use default/undated pricing while
+    // the latter would otherwise spuriously match dated overrides.
     let date = ms_to_datetime(msg.time.created);
+    let effective_at = msg
+        .time
+        .created
+        .and_then(|ms| Utc.timestamp_millis_opt(ms).single());
 
     let mut stats = if msg.role == "assistant" {
         let mut s = extract_tool_stats_from_parts(part_root, &msg.id);
@@ -449,7 +458,7 @@ fn to_conversation_message(
                     s.output_tokens,
                     s.cache_creation_tokens,
                     s.cache_read_tokens,
-                    Some(date),
+                    effective_at,
                 );
             }
         }

--- a/src/analyzers/opencode_common.rs
+++ b/src/analyzers/opencode_common.rs
@@ -8,7 +8,7 @@
 /// individual analyzer modules are thin wrappers.
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
-use crate::models::calculate_total_cost;
+use crate::models::{ServiceTier, calculate_total_cost_for_service_tier_at};
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::hash_text;
 use anyhow::{Context, Result};
@@ -442,12 +442,14 @@ fn to_conversation_message(
             s.cached_tokens = tokens.cache.write + tokens.cache.read;
 
             if let Some(model_name) = msg.model_name() {
-                s.cost = calculate_total_cost(
+                s.cost = calculate_total_cost_for_service_tier_at(
                     &model_name,
+                    ServiceTier::Standard,
                     s.input_tokens,
                     s.output_tokens,
                     s.cache_creation_tokens,
                     s.cache_read_tokens,
+                    Some(date),
                 );
             }
         }

--- a/src/analyzers/piebald.rs
+++ b/src/analyzers/piebald.rs
@@ -5,7 +5,7 @@
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
 use crate::models::{
-    InputTokenSemantics, ServiceTier, calculate_total_cost_for_service_tier, get_model_info,
+    InputTokenSemantics, ServiceTier, calculate_total_cost_for_service_tier_at, get_model_info,
 };
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use crate::utils::hash_text;
@@ -246,13 +246,14 @@ fn convert_messages(
 
             // Calculate cost using splitrail's model pricing
             let cost = if let Some(ref model) = model_str {
-                calculate_total_cost_for_service_tier(
+                calculate_total_cost_for_service_tier_at(
                     model,
                     service_tier,
                     input_tokens,
                     output_tokens,
                     cache_creation_tokens,
                     cache_read_tokens,
+                    Some(date),
                 )
             } else {
                 0.0

--- a/src/analyzers/qwen_code.rs
+++ b/src/analyzers/qwen_code.rs
@@ -1,6 +1,9 @@
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
-use crate::models::{calculate_cache_cost, calculate_input_cost, calculate_output_cost};
+use crate::models::{
+    ServiceTier, calculate_cache_cost_for_service_tier_at,
+    calculate_input_cost_for_service_tier_at, calculate_output_cost_for_service_tier_at,
+};
 use crate::types::{Application, ConversationMessage, FileCategory, MessageRole, Stats};
 use crate::utils::hash_text;
 use anyhow::Result;
@@ -236,15 +239,35 @@ fn extract_and_hash_project_id_qwen_code(file_path: &Path) -> String {
 }
 
 // Cost calculation using the centralized model system.
-fn calculate_qwen_cost(usage: &QwenCodeUsageMetadata, model_name: &str) -> f64 {
+fn calculate_qwen_cost(
+    usage: &QwenCodeUsageMetadata,
+    model_name: &str,
+    effective_at: DateTime<Utc>,
+) -> f64 {
     // `prompt` includes the cached portion; bill non-cached input at the input
     // rate and cached input at the cache-read rate. Reasoning (`thoughts`)
     // tokens are billed at the *output* rate, matching Qwen's pricing.
     let non_cached_input = usage.prompt.saturating_sub(usage.cached);
 
-    let input_cost = calculate_input_cost(model_name, non_cached_input);
-    let output_cost = calculate_output_cost(model_name, usage.candidates + usage.thoughts);
-    let cache_cost = calculate_cache_cost(model_name, 0, usage.cached); // No cache-creation concept here.
+    let input_cost = calculate_input_cost_for_service_tier_at(
+        model_name,
+        ServiceTier::Standard,
+        non_cached_input,
+        Some(effective_at),
+    );
+    let output_cost = calculate_output_cost_for_service_tier_at(
+        model_name,
+        ServiceTier::Standard,
+        usage.candidates + usage.thoughts,
+        Some(effective_at),
+    );
+    let cache_cost = calculate_cache_cost_for_service_tier_at(
+        model_name,
+        ServiceTier::Standard,
+        0,
+        usage.cached,
+        Some(effective_at),
+    ); // No cache-creation concept here.
 
     input_cost + output_cost + cache_cost
 }
@@ -363,7 +386,7 @@ pub fn parse_jsonl_session_file(file_path: &Path) -> Result<Vec<ConversationMess
                 stats.cache_read_tokens = 0;
                 stats.cached_tokens = usage.cached;
                 let model = record.model.unwrap_or_default();
-                stats.cost = calculate_qwen_cost(&usage, &model);
+                stats.cost = calculate_qwen_cost(&usage, &model, timestamp);
 
                 entries.push(ConversationMessage {
                     application: Application::QwenCode,

--- a/src/analyzers/tests/claude_code.rs
+++ b/src/analyzers/tests/claude_code.rs
@@ -381,6 +381,26 @@ fn test_calculate_cost_from_tokens() {
 }
 
 #[test]
+fn test_parse_jsonl_file_uses_sonnet_5_dated_pricing() {
+    let jsonl_data = r#"{"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/code/test","sessionId":"sonnet-5","version":"2.0.0","message":{"id":"msg_intro","type":"message","role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"intro"}],"usage":{"input_tokens":1000000,"cache_creation_input_tokens":1000000,"cache_read_input_tokens":1000000,"output_tokens":1000000}},"requestId":"req_intro","type":"assistant","uuid":"intro-uuid","timestamp":"2026-08-31T23:59:59Z"}
+{"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/code/test","sessionId":"sonnet-5","version":"2.0.0","message":{"id":"msg_sticker","type":"message","role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"sticker"}],"usage":{"input_tokens":1000000,"cache_creation_input_tokens":1000000,"cache_read_input_tokens":1000000,"output_tokens":1000000}},"requestId":"req_sticker","type":"assistant","uuid":"sticker-uuid","timestamp":"2026-09-01T00:00:00Z"}"#;
+
+    let cursor = Cursor::new(jsonl_data);
+    let mut buf_reader = BufReader::new(cursor);
+    let (messages, _, _, _) = parse_jsonl_file(
+        Path::new("sonnet_5_pricing.jsonl"),
+        &mut buf_reader,
+        "proj_hash",
+        "conv_hash",
+    )
+    .unwrap();
+
+    assert_eq!(messages.len(), 2);
+    assert!((messages[0].stats.cost - 14.7).abs() < 0.0001);
+    assert!((messages[1].stats.cost - 22.05).abs() < 0.0001);
+}
+
+#[test]
 fn test_extract_tool_stats_basic_tools() {
     use crate::analyzers::claude_code::{Content, ContentBlock, extract_tool_stats};
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, NaiveDate, Utc};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -95,6 +96,14 @@ pub struct ServiceTierPricing {
     pub caching: CachingSupport,
 }
 
+/// Pricing and caching that apply for usage before an exclusive end date.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatedPricing {
+    pub valid_until: NaiveDate,
+    pub pricing: PricingStructure,
+    pub caching: CachingSupport,
+}
+
 /// How a provider reports input tokens relative to cache reads.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum InputTokenSemantics {
@@ -115,6 +124,10 @@ pub struct ModelInfo {
     /// Optional overrides for provider service tiers such as Priority or Flex.
     #[serde(default)]
     pub service_tiers: HashMap<ServiceTier, ServiceTierPricing>,
+    /// Optional dated standard-pricing overrides, ordered by exclusive end date.
+    /// A dated override applies when the usage date is earlier than `valid_until`.
+    #[serde(default)]
+    pub dated_pricing: Vec<DatedPricing>,
     /// How provider usage reports input tokens relative to cache reads.
     #[serde(default)]
     pub input_token_semantics: InputTokenSemantics,
@@ -161,6 +174,10 @@ impl Registry {
                 .service_tiers
                 .values()
                 .all(|tier| Self::validate_pricing_and_caching(&tier.pricing, &tier.caching))
+            && info
+                .dated_pricing
+                .iter()
+                .all(|dated| Self::validate_pricing_and_caching(&dated.pricing, &dated.caching))
     }
 
     fn validate_pricing_and_caching(pricing: &PricingStructure, caching: &CachingSupport) -> bool {
@@ -247,10 +264,28 @@ fn populate_defaults(
                     pricing: $pricing,
                     caching: $caching,
                     service_tiers: HashMap::new(),
+                    dated_pricing: Vec::new(),
                     input_token_semantics: input_token_semantics_for_model($name),
                     is_estimated: $est,
                 }),
             );
+        };
+    }
+
+    macro_rules! add_dated_pricing {
+        ($name:expr, $valid_until:expr, $pricing:expr, $caching:expr) => {
+            if let Some(model_info) = index.get_mut($name)
+                && let Some(model_info) = Arc::get_mut(model_info)
+            {
+                model_info.dated_pricing.push(DatedPricing {
+                    valid_until: $valid_until,
+                    pricing: $pricing,
+                    caching: $caching,
+                });
+                model_info
+                    .dated_pricing
+                    .sort_by_key(|dated| dated.valid_until);
+            }
         };
     }
 
@@ -969,6 +1004,30 @@ fn populate_defaults(
             cache_read_per_1m: 1.0
         },
         false
+    );
+    add_model!(
+        "claude-sonnet-5",
+        PricingStructure::Flat {
+            input_per_1m: 3.0,
+            output_per_1m: 15.0
+        },
+        CachingSupport::Anthropic {
+            cache_write_per_1m: 3.75,
+            cache_read_per_1m: 0.3
+        },
+        false
+    );
+    add_dated_pricing!(
+        "claude-sonnet-5",
+        NaiveDate::from_ymd_opt(2026, 9, 1).expect("valid date"),
+        PricingStructure::Flat {
+            input_per_1m: 2.0,
+            output_per_1m: 10.0
+        },
+        CachingSupport::Anthropic {
+            cache_write_per_1m: 2.5,
+            cache_read_per_1m: 0.2
+        }
     );
     add_model!(
         "claude-opus-4-8",
@@ -1853,6 +1912,11 @@ fn populate_defaults(
     add_alias!("claude-fable-5.0", "claude-fable-5");
     add_alias!("claude-5-fable", "claude-fable-5");
     add_alias!("claude-5.0-fable", "claude-fable-5");
+    add_alias!("claude-sonnet-5", "claude-sonnet-5");
+    add_alias!("claude-sonnet-5.0", "claude-sonnet-5");
+    add_alias!("claude-5-sonnet", "claude-sonnet-5");
+    add_alias!("claude-5.0-sonnet", "claude-sonnet-5");
+    add_alias!("global.anthropic.claude-sonnet-5", "claude-sonnet-5");
     add_alias!("claude-opus-4.8", "claude-opus-4-8");
     add_alias!("claude-4.8-opus", "claude-opus-4-8");
     add_alias!("claude-opus-4-8", "claude-opus-4-8");
@@ -2007,6 +2071,7 @@ fn get_free_model_info() -> Arc<ModelInfo> {
             },
             caching: CachingSupport::None,
             service_tiers: HashMap::new(),
+            dated_pricing: Vec::new(),
             input_token_semantics: InputTokenSemantics::ExcludesCache,
             is_estimated: false,
         })
@@ -2078,19 +2143,40 @@ pub fn is_model_estimated(model_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn standard_pricing_for_date(
+    model_info: &ModelInfo,
+    effective_at: Option<DateTime<Utc>>,
+) -> (&PricingStructure, &CachingSupport) {
+    if let Some(effective_at) = effective_at {
+        let usage_date = effective_at.date_naive();
+        if let Some(dated) = model_info
+            .dated_pricing
+            .iter()
+            .find(|dated| usage_date < dated.valid_until)
+        {
+            return (&dated.pricing, &dated.caching);
+        }
+    }
+
+    (&model_info.pricing, &model_info.caching)
+}
+
 fn pricing_for_service_tier(
     model_info: &ModelInfo,
     service_tier: ServiceTier,
+    effective_at: Option<DateTime<Utc>>,
 ) -> (&PricingStructure, &CachingSupport) {
+    let standard = standard_pricing_for_date(model_info, effective_at);
+
     if service_tier == ServiceTier::Standard {
-        return (&model_info.pricing, &model_info.caching);
+        return standard;
     }
 
     model_info
         .service_tiers
         .get(&service_tier)
         .map(|tier| (&tier.pricing, &tier.caching))
-        .unwrap_or((&model_info.pricing, &model_info.caching))
+        .unwrap_or(standard)
 }
 
 fn input_cost_for_pricing(pricing: &PricingStructure, input_tokens: u64) -> f64 {
@@ -2105,19 +2191,31 @@ fn input_cost_for_pricing(pricing: &PricingStructure, input_tokens: u64) -> f64 
 }
 
 /// Calculate cost for input tokens using the model's standard pricing structure.
+#[allow(dead_code)]
 pub fn calculate_input_cost(model_name: &str, input_tokens: u64) -> f64 {
     calculate_input_cost_for_service_tier(model_name, ServiceTier::Standard, input_tokens)
 }
 
 /// Calculate cost for input tokens using the requested service tier.
+#[allow(dead_code)]
 pub fn calculate_input_cost_for_service_tier(
     model_name: &str,
     service_tier: ServiceTier,
     input_tokens: u64,
 ) -> f64 {
+    calculate_input_cost_for_service_tier_at(model_name, service_tier, input_tokens, None)
+}
+
+/// Calculate cost for input tokens using the requested service tier and usage date.
+pub fn calculate_input_cost_for_service_tier_at(
+    model_name: &str,
+    service_tier: ServiceTier,
+    input_tokens: u64,
+    effective_at: Option<DateTime<Utc>>,
+) -> f64 {
     match get_model_info(model_name) {
         Some(model_info) => {
-            let (pricing, _) = pricing_for_service_tier(&model_info, service_tier);
+            let (pricing, _) = pricing_for_service_tier(&model_info, service_tier, effective_at);
             input_cost_for_pricing(pricing, input_tokens)
         }
         None => {
@@ -2141,19 +2239,31 @@ fn output_cost_for_pricing(pricing: &PricingStructure, output_tokens: u64) -> f6
 }
 
 /// Calculate cost for output tokens using the model's standard pricing structure.
+#[allow(dead_code)]
 pub fn calculate_output_cost(model_name: &str, output_tokens: u64) -> f64 {
     calculate_output_cost_for_service_tier(model_name, ServiceTier::Standard, output_tokens)
 }
 
 /// Calculate cost for output tokens using the requested service tier.
+#[allow(dead_code)]
 pub fn calculate_output_cost_for_service_tier(
     model_name: &str,
     service_tier: ServiceTier,
     output_tokens: u64,
 ) -> f64 {
+    calculate_output_cost_for_service_tier_at(model_name, service_tier, output_tokens, None)
+}
+
+/// Calculate cost for output tokens using the requested service tier and usage date.
+pub fn calculate_output_cost_for_service_tier_at(
+    model_name: &str,
+    service_tier: ServiceTier,
+    output_tokens: u64,
+    effective_at: Option<DateTime<Utc>>,
+) -> f64 {
     match get_model_info(model_name) {
         Some(model_info) => {
-            let (pricing, _) = pricing_for_service_tier(&model_info, service_tier);
+            let (pricing, _) = pricing_for_service_tier(&model_info, service_tier, effective_at);
             output_cost_for_pricing(pricing, output_tokens)
         }
         None => {
@@ -2197,6 +2307,7 @@ fn cache_cost_for_caching(
 }
 
 /// Calculate cost for cached tokens using the model's standard pricing structure.
+#[allow(dead_code)]
 pub fn calculate_cache_cost(
     model_name: &str,
     cache_creation_tokens: u64,
@@ -2211,15 +2322,33 @@ pub fn calculate_cache_cost(
 }
 
 /// Calculate cost for cached tokens using the requested service tier.
+#[allow(dead_code)]
 pub fn calculate_cache_cost_for_service_tier(
     model_name: &str,
     service_tier: ServiceTier,
     cache_creation_tokens: u64,
     cache_read_tokens: u64,
 ) -> f64 {
+    calculate_cache_cost_for_service_tier_at(
+        model_name,
+        service_tier,
+        cache_creation_tokens,
+        cache_read_tokens,
+        None,
+    )
+}
+
+/// Calculate cost for cached tokens using the requested service tier and usage date.
+pub fn calculate_cache_cost_for_service_tier_at(
+    model_name: &str,
+    service_tier: ServiceTier,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    effective_at: Option<DateTime<Utc>>,
+) -> f64 {
     match get_model_info(model_name) {
         Some(model_info) => {
-            let (_, caching) = pricing_for_service_tier(&model_info, service_tier);
+            let (_, caching) = pricing_for_service_tier(&model_info, service_tier, effective_at);
             cache_cost_for_caching(caching, cache_creation_tokens, cache_read_tokens)
         }
         None => {
@@ -2232,6 +2361,7 @@ pub fn calculate_cache_cost_for_service_tier(
 }
 
 /// Calculate total cost for a model usage using the model's standard pricing structure.
+#[allow(dead_code)]
 pub fn calculate_total_cost(
     model_name: &str,
     input_tokens: u64,
@@ -2250,6 +2380,7 @@ pub fn calculate_total_cost(
 }
 
 /// Calculate total cost for a model usage using the requested service tier.
+#[allow(dead_code)]
 pub fn calculate_total_cost_for_service_tier(
     model_name: &str,
     service_tier: ServiceTier,
@@ -2258,9 +2389,31 @@ pub fn calculate_total_cost_for_service_tier(
     cache_creation_tokens: u64,
     cache_read_tokens: u64,
 ) -> f64 {
+    calculate_total_cost_for_service_tier_at(
+        model_name,
+        service_tier,
+        input_tokens,
+        output_tokens,
+        cache_creation_tokens,
+        cache_read_tokens,
+        None,
+    )
+}
+
+/// Calculate total cost for a model usage using the requested service tier and usage date.
+pub fn calculate_total_cost_for_service_tier_at(
+    model_name: &str,
+    service_tier: ServiceTier,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    effective_at: Option<DateTime<Utc>>,
+) -> f64 {
     match get_model_info(model_name) {
         Some(model_info) => {
-            let (pricing, caching) = pricing_for_service_tier(&model_info, service_tier);
+            let (pricing, caching) =
+                pricing_for_service_tier(&model_info, service_tier, effective_at);
             input_cost_for_pricing(pricing, input_tokens)
                 + output_cost_for_pricing(pricing, output_tokens)
                 + cache_cost_for_caching(caching, cache_creation_tokens, cache_read_tokens)
@@ -2372,12 +2525,15 @@ mod tests {
     use super::{
         CachingSupport, CachingTier, InputTokenSemantics, ModelInfo, PricingStructure, PricingTier,
         Registry, ServiceTier, TieredCaching, TieredPricing, calculate_cache_cost,
-        calculate_cache_cost_for_service_tier, calculate_input_cost,
-        calculate_input_cost_for_service_tier, calculate_output_cost,
-        calculate_output_cost_for_service_tier, get_model_info, get_registry_lock,
+        calculate_cache_cost_for_service_tier, calculate_cache_cost_for_service_tier_at,
+        calculate_input_cost, calculate_input_cost_for_service_tier,
+        calculate_input_cost_for_service_tier_at, calculate_output_cost,
+        calculate_output_cost_for_service_tier, calculate_output_cost_for_service_tier_at,
+        calculate_total_cost_for_service_tier_at, get_model_info, get_registry_lock,
         init_external_models,
     };
 
+    use chrono::{TimeZone, Utc};
     use std::collections::HashMap;
     use std::sync::{Mutex, OnceLock};
 
@@ -2411,6 +2567,7 @@ mod tests {
                 },
                 caching: CachingSupport::None,
                 service_tiers: HashMap::new(),
+                dated_pricing: Vec::new(),
                 input_token_semantics: InputTokenSemantics::default(),
                 is_estimated: false,
             },
@@ -2452,6 +2609,7 @@ mod tests {
                 },
                 caching: CachingSupport::None,
                 service_tiers: HashMap::new(),
+                dated_pricing: Vec::new(),
                 input_token_semantics: InputTokenSemantics::default(),
                 is_estimated: false,
             },
@@ -2475,6 +2633,7 @@ mod tests {
                 },
                 caching: CachingSupport::None,
                 service_tiers: HashMap::new(),
+                dated_pricing: Vec::new(),
                 input_token_semantics: InputTokenSemantics::default(),
                 is_estimated: false,
             },
@@ -2507,6 +2666,7 @@ mod tests {
                 },
                 caching: CachingSupport::None,
                 service_tiers: HashMap::new(),
+                dated_pricing: Vec::new(),
                 input_token_semantics: InputTokenSemantics::default(),
                 is_estimated: false,
             },
@@ -2568,6 +2728,7 @@ mod tests {
                     bracket_pricing: false,
                 }),
                 service_tiers: HashMap::new(),
+                dated_pricing: Vec::new(),
                 input_token_semantics: InputTokenSemantics::default(),
                 is_estimated: false,
             },
@@ -2613,6 +2774,100 @@ mod tests {
         approx_eq(input_cost, 10.0);
         approx_eq(output_cost, 50.0);
         approx_eq(cache_cost, 13.5);
+    }
+
+    #[test]
+    fn claude_sonnet_5_alias_maps_to_sticker_pricing_by_default() {
+        let model_info = get_model_info("claude-5-sonnet").expect("model should exist");
+        assert!(!model_info.is_estimated);
+
+        let input_cost = calculate_input_cost("claude-5-sonnet", 1_000_000);
+        let output_cost = calculate_output_cost("claude-5-sonnet", 1_000_000);
+        let cache_cost = calculate_cache_cost("claude-5-sonnet", 1_000_000, 1_000_000);
+
+        approx_eq(input_cost, 3.0);
+        approx_eq(output_cost, 15.0);
+        approx_eq(cache_cost, 4.05);
+    }
+
+    #[test]
+    fn claude_sonnet_5_uses_introductory_pricing_through_august_2026() {
+        let effective_at = Utc.with_ymd_and_hms(2026, 8, 31, 23, 59, 59).unwrap();
+
+        approx_eq(
+            calculate_input_cost_for_service_tier_at(
+                "claude-5-sonnet",
+                ServiceTier::Standard,
+                1_000_000,
+                Some(effective_at),
+            ),
+            2.0,
+        );
+        approx_eq(
+            calculate_output_cost_for_service_tier_at(
+                "claude-5-sonnet",
+                ServiceTier::Standard,
+                1_000_000,
+                Some(effective_at),
+            ),
+            10.0,
+        );
+        approx_eq(
+            calculate_cache_cost_for_service_tier_at(
+                "claude-5-sonnet",
+                ServiceTier::Standard,
+                1_000_000,
+                1_000_000,
+                Some(effective_at),
+            ),
+            2.7,
+        );
+    }
+
+    #[test]
+    fn claude_sonnet_5_uses_sticker_pricing_after_introductory_window() {
+        let effective_at = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
+
+        approx_eq(
+            calculate_total_cost_for_service_tier_at(
+                "claude-5-sonnet",
+                ServiceTier::Standard,
+                1_000_000,
+                1_000_000,
+                1_000_000,
+                1_000_000,
+                Some(effective_at),
+            ),
+            22.05,
+        );
+    }
+
+    #[test]
+    fn claude_sonnet_5_global_anthropic_alias_maps_to_dated_pricing() {
+        let model_info = get_model_info("global.anthropic.claude-sonnet-5")
+            .expect("global Anthropic alias should resolve");
+        assert!(!model_info.is_estimated);
+
+        let effective_at = Utc.with_ymd_and_hms(2026, 8, 31, 12, 0, 0).unwrap();
+
+        approx_eq(
+            calculate_input_cost_for_service_tier_at(
+                "global.anthropic.claude-sonnet-5",
+                ServiceTier::Standard,
+                1_000_000,
+                Some(effective_at),
+            ),
+            2.0,
+        );
+        approx_eq(
+            calculate_output_cost_for_service_tier_at(
+                "global.anthropic.claude-sonnet-5",
+                ServiceTier::Standard,
+                1_000_000,
+                Some(effective_at),
+            ),
+            10.0,
+        );
     }
 
     #[test]
@@ -3190,6 +3445,7 @@ mod tests {
             "qwen3.6-plus",
             "mimo-v2.5-pro",
             "global.anthropic.claude-sonnet-4-6",
+            "global.anthropic.claude-sonnet-5",
             "deepseek.v3.2",
             "moonshotai.kimi-k2.5",
             "eu.anthropic.claude-opus-4-6-v1",

--- a/src/models.rs
+++ b/src/models.rs
@@ -2149,10 +2149,16 @@ fn standard_pricing_for_date(
 ) -> (&PricingStructure, &CachingSupport) {
     if let Some(effective_at) = effective_at {
         let usage_date = effective_at.date_naive();
+        // Pick the *nearest* matching override rather than the first one in
+        // the vector. Built-in models are kept sorted by `add_dated_pricing!`,
+        // but externally-merged `ModelInfo.dated_pricing` (from
+        // `Registry::merge`) is only validated, not sorted, so `.find(...)`
+        // could otherwise pick the wrong override depending on input order.
         if let Some(dated) = model_info
             .dated_pricing
             .iter()
-            .find(|dated| usage_date < dated.valid_until)
+            .filter(|dated| usage_date < dated.valid_until)
+            .min_by_key(|dated| dated.valid_until)
         {
             return (&dated.pricing, &dated.caching);
         }


### PR DESCRIPTION
## Why

Claude Sonnet 5 pricing is now visible from Claude Code source, including a temporary introductory rate that differs from the durable sticker price. Sonnet 5 uses the `$3 / $15` per-MTok sticker rate, but Claude Code documents an introductory `$2 / $10` per-MTok rate through `2026-08-31`.

Splitrail previously modeled each model with one static default price. That would make Sonnet 5 either correct for the promotional period or correct after the promotional period, but not both. It also would make historical dashboards unstable if the table were manually changed after the promo ended: usage from August 2026 would be repriced at the September 2026 sticker rate.

This PR adds Sonnet 5 support and introduces dated pricing overrides so Splitrail can preserve historical cost semantics when a provider has temporary launch pricing, promotional pricing, or another time-bounded rate.

## What changed

- Added canonical `claude-sonnet-5` pricing in `src/models.rs`.
  - Default/sticker pricing:
    - input: `$3 / MTok`
    - output: `$15 / MTok`
    - cache write: `$3.75 / MTok`
    - cache read: `$0.30 / MTok`
  - Introductory pricing through `2026-08-31`, represented as a dated override with exclusive `valid_until = 2026-09-01`:
    - input: `$2 / MTok`
    - output: `$10 / MTok`
    - cache write: `$2.50 / MTok`
    - cache read: `$0.20 / MTok`
- Marked `claude-sonnet-5` as confirmed pricing with `is_estimated: false`.
- Added Sonnet 5 aliases:
  - `claude-sonnet-5`
  - `claude-sonnet-5.0`
  - `claude-5-sonnet`
  - `claude-5.0-sonnet`
  - `global.anthropic.claude-sonnet-5`
- Added `DatedPricing` to `ModelInfo`.
  - Dated overrides contain `valid_until`, `pricing`, and `caching`.
  - A dated override applies when the usage date is earlier than `valid_until`.
  - The model’s default `pricing` and `caching` remain the durable/sticker rates.
- Added dated pricing selection in the shared model pricing path.
  - Existing undated helpers remain available as compatibility wrappers.
  - New dated helpers, such as `calculate_total_cost_for_service_tier_at(...)`, accept an optional usage timestamp.
  - Undated helpers use the model’s default/sticker pricing and do not apply temporary dated overrides.
- Threaded dated pricing through production analyzer cost paths that have message or event timestamps:
  - `src/analyzers/claude_code.rs`
  - `src/analyzers/piebald.rs`
  - `src/analyzers/opencode.rs`
  - `src/analyzers/opencode_common.rs`
  - `src/analyzers/antigravity.rs`
  - `src/analyzers/copilot.rs`
  - `src/analyzers/copilot_cli.rs`
  - `src/analyzers/codex_cli.rs`
  - `src/analyzers/gemini_cli.rs`
  - `src/analyzers/qwen_code.rs`
- Preserved explicit provider-reported costs where analyzers already prefer those over Splitrail-estimated costs.
- Added model-level regression coverage for Sonnet 5:
  - default undated pricing resolves to sticker `$3 / $15`;
  - usage on `2026-08-31T23:59:59Z` resolves to introductory `$2 / $10`;
  - usage on `2026-09-01T00:00:00Z` resolves to sticker `$3 / $15`;
  - `global.anthropic.claude-sonnet-5` resolves through the dated pricing path;
  - Sonnet 5 remains `is_estimated: false`.
- Added Claude Code parser coverage proving parsed message timestamps affect Sonnet 5 cost calculation across the promo boundary.
- Updated `.claude/skills/pricing/SKILL.md` with maintainer guidance for:
  - the current runtime model registry shape;
  - adding model pricing and aliases;
  - dated pricing override semantics;
  - the exclusive `valid_until` convention;
  - using dated calculator functions from timestamp-aware analyzers.

## Compatibility notes

Existing model pricing behavior is preserved for models without `dated_pricing`: they continue to use their default `pricing` and `caching`.

Existing undated helper APIs remain available, including helpers such as `calculate_total_cost(...)`. They now act as compatibility wrappers around the dated pricing implementation with no usage timestamp. This means they intentionally use the default/sticker price rather than temporary dated overrides.

Analyzers that receive explicit provider-reported cost values still prefer those explicit costs. The dated pricing path only applies where Splitrail computes cost from token counts and the shared pricing table.

## Validation

- `cargo test --quiet models::tests::claude_sonnet_5`
- `cargo test --quiet analyzers::tests::claude_code::test_parse_jsonl_file_uses_sonnet_5_dated_pricing`
- `cargo fmt --all --quiet`
- `cargo build --quiet`
- `cargo test --quiet` passed: `369 passed`
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added time-aware, service-tier pricing APIs and updated pricing so costs can vary by message timestamp.
  * Introduced dated pricing support for select models, including updated alias resolution.
* **Bug Fixes**
  * Updated multiple analyzers’ cost/stat calculations to use timestamp-accurate pricing, including merged/deduplicated messages and timestamp fallback paths.
* **Documentation**
  * Refreshed the pricing guide with clarified dated override semantics and new testing expectations.
* **Tests**
  * Added coverage for dated pricing (including `claude-sonnet-5`) and alias handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->