### PR TITLE
Bill OpenAI reasoning tokens as output

### DIFF
--- a/src/analyzers/piebald.rs
+++ b/src/analyzers/piebald.rs
@@ -177,14 +177,25 @@ fn parse_service_tier(service_tier: Option<&str>) -> ServiceTier {
     }
 }
 
-fn normalize_input_tokens(model: Option<&str>, input_tokens: u64, cache_read_tokens: u64) -> u64 {
-    if model
+fn model_uses_openai_token_semantics(model: Option<&str>) -> bool {
+    model
         .and_then(get_model_info)
         .is_some_and(|info| info.input_token_semantics == InputTokenSemantics::IncludesCacheRead)
-    {
+}
+
+fn normalize_input_tokens(model: Option<&str>, input_tokens: u64, cache_read_tokens: u64) -> u64 {
+    if model_uses_openai_token_semantics(model) {
         input_tokens.saturating_sub(cache_read_tokens)
     } else {
         input_tokens
+    }
+}
+
+fn billable_output_tokens(model: Option<&str>, output_tokens: u64, reasoning_tokens: u64) -> u64 {
+    if model_uses_openai_token_semantics(model) {
+        output_tokens.saturating_add(reasoning_tokens)
+    } else {
+        output_tokens
     }
 }
 
@@ -244,13 +255,16 @@ fn convert_messages(
 
             let service_tier = parse_service_tier(msg.service_tier.as_deref());
 
-            // Calculate cost using splitrail's model pricing
+            // Calculate cost using splitrail's model pricing. OpenAI-style reasoning tokens are
+            // billed at the output rate, while remaining separate in display stats.
+            let billable_output =
+                billable_output_tokens(model_str.as_deref(), output_tokens, reasoning_tokens);
             let cost = if let Some(ref model) = model_str {
                 calculate_total_cost_for_service_tier_at(
                     model,
                     service_tier,
                     input_tokens,
-                    output_tokens,
+                    billable_output,
                     cache_creation_tokens,
                     cache_read_tokens,
                     Some(date),
@@ -405,7 +419,7 @@ mod tests {
             model: Some("gpt-5.4".to_string()),
             input_tokens: Some(1_000_000),
             output_tokens: Some(1_000_000),
-            reasoning_tokens: Some(0),
+            reasoning_tokens: Some(100_000),
             cache_read_tokens: Some(0),
             cache_write_tokens: Some(0),
             service_tier: Some("priority".to_string()),
@@ -417,7 +431,22 @@ mod tests {
         let converted = convert_messages(&chats, messages, &tool_call_counts);
 
         assert_eq!(converted.len(), 1);
-        assert_eq!(converted[0].stats.cost, 35.0);
+        assert_eq!(converted[0].stats.output_tokens, 1_000_000);
+        assert_eq!(converted[0].stats.reasoning_tokens, 100_000);
+        assert_eq!(converted[0].stats.cost, 38.0);
+    }
+
+    #[test]
+    fn test_billable_output_tokens_includes_openai_reasoning() {
+        assert_eq!(billable_output_tokens(Some("gpt-5.5"), 1_000, 300), 1_300);
+    }
+
+    #[test]
+    fn test_billable_output_tokens_preserves_anthropic_output() {
+        assert_eq!(
+            billable_output_tokens(Some("claude-sonnet-4-20250514"), 1_000, 300),
+            1_000
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Piebald usage rows can include reasoning tokens alongside output tokens. Splitrail already displays those fields separately, but OpenAI-style model pricing needs reasoning tokens to be billed at the output-token rate. Without that, rows with OpenAI reasoning tokens underreport cost while keeping the token columns otherwise correct.

For example, the same 6/24/2026 row moves from `$348.92` before this fix to `$360.77` after reasoning tokens are included in billable output:

```text
Date               Cost    Cached Tks       Inp Tks      Outp Tks    Reason Tks   Convs   Tools  Models
Old: 6/24/2026       $348.92       223.34m        43.68m       586.70k       392.69k      29   2.68k  claude-opus-4-8, gpt-5.5
New: 6/24/2026       $360.77       223.34m        43.68m       586.70k       392.69k      29   2.68k  claude-opus-4-8, gpt-5.5
```

## What changed

- Added a shared OpenAI-token-semantics helper for the Piebald analyzer.
- Added a billable-output calculation that includes reasoning tokens for OpenAI-style models before passing token counts into Splitrail pricing.
- Preserved the displayed `output_tokens` and `reasoning_tokens` values so the stats table still reports those columns separately.
- Kept Anthropic-style output pricing unchanged.
- Added focused tests covering OpenAI reasoning-token billing and Anthropic output preservation.

## Validation

- `cargo test --quiet piebald` - 16 passed
- `cargo build --quiet` - passed
- `cargo test --quiet` - 370 passed; 1 failed: `models::tests::repeated_tiered_model_lookups_reuse_the_same_tier_storage`
- `cargo test --quiet models::tests::repeated_tiered_model_lookups_reuse_the_same_tier_storage` - passed on focused rerun
- `cargo clippy --quiet -- -D warnings` - passed
- `cargo doc --quiet` - passed
- `cargo fmt --all --quiet` - passed with a clean worktree afterward

Visual proof is not applicable for this non-visual analyzer pricing change; I reviewed the code path and validated it with focused analyzer tests plus the repository Rust checks above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated token counting and billing so costs now better match provider-specific token semantics.
  * Adjusted how cached input reads and reasoning tokens are handled in pricing calculations, improving accuracy for affected models.
  * Preserved existing billing behavior for other providers while aligning output charges with the newer token rules.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->