### PR TITLE
Upgrade crossbeam-epoch for cargo audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Why

The existing `cargo audit` check reports `RUSTSEC-2026-0204` for `crossbeam-epoch 0.9.18`, which blocks PR CI even when the code change is unrelated to dependency security. The advisory recommends upgrading `crossbeam-epoch` to `>=0.9.20`.

`crossbeam-epoch` is a transitive dependency through `crossbeam-deque` -> `rayon-core` -> `rayon`, so this can be fixed with a targeted lockfile update instead of broad dependency churn.

## What changed

- Updated the `Cargo.lock` entry for `crossbeam-epoch` from `0.9.18` to `0.9.20`.
- Left the rest of the dependency graph unchanged behind latest versions.
- Kept the branch based directly on `origin/main` so this PR is not stacked on any unrelated feature branch.

## Validation

- `cargo audit` - passed with only the existing allowed `anyhow` warning; no `crossbeam-epoch` vulnerability remained
- `cargo build --quiet` - passed
- `cargo test --quiet` - 369 passed
- `cargo clippy --quiet -- -D warnings` - passed
- `cargo fmt --all --quiet` - passed
