### PR TITLE
3.5.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.5.9] - 2026-06-10
+- Fix GPT-5.6 priority pricing and cache accounting (#197) - @mike1858
+- Bill OpenAI reasoning tokens as output (#195) - @mike1858
+- Include Copilot CLI in the Leaderboard in the filter - @mike1858
+
 ## [3.5.8] - 2026-06-30
 - GPT-5.6 (Sol, Terra, Luna) (#192) - @mike1858
 - Claude Sonnet 5 (#193) - @mike1858

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "splitrail"
-version = "3.5.8"
+version = "3.5.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "splitrail"
-version = "3.5.8"
+version = "3.5.9"
 edition = "2024"
 license = "MIT"
 authors = ["Piebald LLC <support@piebald.ai>"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected GPT-5.6 priority pricing and cache accounting.
  * Updated billing to count OpenAI reasoning tokens as output tokens.

* **New Features**
  * Added Copilot CLI to the Leaderboard filter.

* **Release**
  * Released version 3.5.9 on June 10, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->