### PR TITLE
Remove the GPT-5.6 cache write warning

### DIFF
--- a/src/analyzers/piebald.rs
+++ b/src/analyzers/piebald.rs
@@ -8,7 +8,7 @@ use crate::models::{
     InputTokenSemantics, ServiceTier, calculate_total_cost_for_service_tier_at, get_model_info,
 };
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
-use crate::utils::{hash_text, warn_once};
+use crate::utils::hash_text;
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -194,12 +194,6 @@ fn normalize_input_tokens(
     }
 
     let Some(cache_write_tokens) = cache_write_tokens else {
-        if model.is_some_and(|name| name.starts_with("gpt-5.6")) {
-            warn_once(
-                "WARNING: GPT-5.6 cache write usage was not captured; cost is a lower-bound estimate."
-                    .to_string(),
-            );
-        }
         return input_tokens.saturating_sub(cache_read_tokens);
     };
 


### PR DESCRIPTION
## Why

Piebald usage records do not always include cache write token counts for GPT-5.6. The analyzer already handles that case by falling back to cache-read normalization, but it also emits a one-time warning that is noisy for an expected data-availability limitation.

## What changed

- Remove the GPT-5.6-specific warning when `cache_write_tokens` is unavailable.
- Preserve the existing fallback that subtracts cache reads from OpenAI input tokens.
- Remove the now-unused `warn_once` import from the Piebald analyzer.

## Validation

- `cargo test --quiet analyzers::piebald::tests` — 19 passed
- `cargo build --quiet` — passed
- `cargo test --quiet` — 374 passed
- `cargo clippy --quiet -- -D warnings` — passed
- `cargo doc --quiet` — passed
- `cargo fmt --all --quiet -- --check` — passed
