### PR TITLE
Fix clipped tool-call totals in TUI tables

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -2398,7 +2398,7 @@ fn draw_session_stats_table(
                     Style::default().add_modifier(Modifier::DIM),
                 )),
                 Line::from(Span::styled(
-                    "──────",
+                    "─".repeat(COUNT_COL_WIDTH as usize),
                     Style::default().add_modifier(Modifier::DIM),
                 )),
                 Line::from(Span::styled(

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -417,6 +417,13 @@ pub(crate) fn build_display_stats(
 /// by `format_number_fit` which falls back to human-readable format.
 const TOKEN_COL_WIDTH: u16 = 12;
 
+/// Column width for conversation and tool-call counts.
+///
+/// Human-readable totals can require seven characters (for example, "204.92k").
+/// Keeping both count columns at this width prevents right-aligned totals from
+/// being clipped on the left.
+const COUNT_COL_WIDTH: u16 = 7;
+
 pub fn run_tui(
     stats_receiver: watch::Receiver<MultiAnalyzerStatsView>,
     format_options: &NumberFormatOptions,
@@ -1876,11 +1883,12 @@ fn draw_aggregate_stats_table(
     if show("reason") {
         sep_cells.push(dim(token_sep.clone()));
     }
+    let count_sep = "─".repeat(COUNT_COL_WIDTH as usize);
     if show("convs") {
-        sep_cells.push(dim("──────".into()));
+        sep_cells.push(dim(count_sep.clone()));
     }
     if show("tools") {
-        sep_cells.push(dim("──────".into()));
+        sep_cells.push(dim(count_sep));
     }
     if show("apps") {
         sep_cells.push(dim("─".repeat(all_apps_text.len().max(16))));
@@ -2017,10 +2025,10 @@ fn draw_aggregate_stats_table(
         widths.push(Constraint::Length(TOKEN_COL_WIDTH));
     }
     if show("convs") {
-        widths.push(Constraint::Length(6));
+        widths.push(Constraint::Length(COUNT_COL_WIDTH));
     }
     if show("tools") {
-        widths.push(Constraint::Length(6));
+        widths.push(Constraint::Length(COUNT_COL_WIDTH));
     }
     if show("apps") {
         widths.push(Constraint::Min(16));
@@ -2473,7 +2481,7 @@ fn draw_session_stats_table(
             Constraint::Length(TOKEN_COL_WIDTH), // Input
             Constraint::Length(TOKEN_COL_WIDTH), // Output
             Constraint::Length(TOKEN_COL_WIDTH), // Reason Tks
-            Constraint::Length(6),               // Tools
+            Constraint::Length(COUNT_COL_WIDTH), // Tools
             Constraint::Min(10),                 // Models
         ],
     )

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -242,6 +242,10 @@ fn aggregate_table_preserves_leading_digit_in_large_tool_total() {
         rendered.contains("204.92k"),
         "rendered table clipped the tool total: {rendered}"
     );
+    assert!(
+        rendered.contains("───────"),
+        "rendered table did not align count separators to their columns: {rendered}"
+    );
 }
 
 #[test]

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -5,16 +5,21 @@ use crate::tui::logic::{
 };
 use crate::tui::{
     AggregateViewMode, PeriodFilter, build_display_stats, cost_heat,
-    create_upload_progress_callback, format_month_for_display, format_week_for_display,
-    format_year_for_display, parse_accent, show_upload_error, show_upload_success,
-    update_period_filters, update_table_states, update_window_offsets,
+    create_upload_progress_callback, draw_aggregate_stats_table, format_month_for_display,
+    format_week_for_display, format_year_for_display, parse_accent, show_upload_error,
+    show_upload_success, update_period_filters, update_table_states, update_window_offsets,
 };
 use crate::types::{
-    AgenticCodingToolStats, CompactDate, DailyStats, MultiAnalyzerStats, Stats, TuiStats,
+    AgenticCodingToolStats, AnalyzerStatsView, CompactDate, DailyStats, MultiAnalyzerStats, Stats,
+    TuiStats,
 };
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::widgets::TableState;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
 
 // ============================================================================
 // CONFIG-DRIVEN APPEARANCE TESTS
@@ -177,6 +182,66 @@ fn test_update_window_offsets_and_period_filters_resize() {
 
     assert_eq!(offsets, vec![5]);
     assert_eq!(filters, vec![Some(PeriodFilter::Day(day))]);
+}
+
+#[test]
+fn aggregate_table_preserves_leading_digit_in_large_tool_total() {
+    let mut daily_stats = BTreeMap::new();
+    for day in 1..=20 {
+        let date = format!("2025-01-{day:02}");
+        let mut stats = make_daily_stats(&date, 1, 0, 1);
+        stats.stats.tool_calls = if day == 20 { 14_920 } else { 10_000 };
+        daily_stats.insert(date, stats);
+    }
+
+    let stats = AnalyzerStatsView {
+        daily_stats,
+        session_aggregates: Vec::new(),
+        num_conversations: 20,
+        analyzer_name: Arc::from("Test"),
+    };
+    let format_options = crate::utils::NumberFormatOptions {
+        use_comma: false,
+        use_human: true,
+        locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
+        decimal_places: 2,
+    };
+    let backend = TestBackend::new(160, 24);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut table_state = TableState::default();
+
+    terminal
+        .draw(|frame| {
+            draw_aggregate_stats_table(
+                frame,
+                Rect::new(0, 0, 160, 24),
+                &stats,
+                &format_options,
+                &mut table_state,
+                AggregateViewMode::Daily,
+                "",
+                false,
+                false,
+                Color::Cyan,
+                &HashSet::new(),
+                false,
+            );
+        })
+        .unwrap();
+
+    let rendered = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect::<String>();
+    assert!(
+        rendered.contains("204.92k"),
+        "rendered table clipped the tool total: {rendered}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Why

The aggregate TUI allocated six characters to the `Tools` column, but human-readable totals can require seven characters. A total such as `204.92k` was therefore clipped on its left edge and displayed as `04.92k`, making the reported usage incorrect at a glance.

The session table used the same six-character tool-call width, and the aggregate separator widths were hard-coded separately from the column constraints.

## What changed

- Add a shared seven-character width for conversation and tool-call count columns.
- Apply the count width to aggregate conversation/tool columns and the session tool-call column.
- Generate aggregate count separators from the same width so separators remain aligned with their columns.
- Add a Ratatui buffer-level regression test that renders an aggregate total of `204.92k` and verifies that the leading digit remains visible.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` — 375 passed
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet`
- `git diff --check`
- `cargo test --quiet aggregate_table_preserves_leading_digit_in_large_tool_total`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the TUI “Convs”/“Tools” count column sizing so separator and alignment render consistently across aggregate and session stats tables.

* **Tests**
  * Added a regression test to ensure large tool-call totals preserve leading digits (e.g., rendering `204.92k`) and maintain correct column separator alignment in the aggregate stats view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->