### PR TITLE
docs: mention Zoo Code as the Roo Code community successor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Splitrail is a **fast, cross-platform, real-time token usage tracker and cost mo
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) (and [Qwen Code](https://github.com/qwenlm/qwen-code))
 - [Claude Code](https://github.com/anthropics/claude-code)
 - [Codex CLI](https://github.com/openai/codex)
-- [Cline](https://github.com/cline/cline) / [Roo Code](https://github.com/RooCodeInc/Roo-Code) / [Kilo Code](https://github.com/Kilo-Org/kilocode) (VS Code extension + CLI)
+- [Cline](https://github.com/cline/cline) / [Roo Code](https://github.com/RooCodeInc/Roo-Code) / [Zoo Code](https://github.com/Zoo-Code-Org/Zoo-Code/) / [Kilo Code](https://github.com/Kilo-Org/kilocode) (VS Code extension + CLI)
 - [GitHub Copilot](https://github.com/features/copilot) (VS Code)
 - [GitHub Copilot CLI](https://github.com/features/copilot)
 - [OpenCode](https://github.com/sst/opencode)


### PR DESCRIPTION
Roo Code (`RooCodeInc/Roo-Code`) was archived / shut down on May 15, 2026 and is now
read-only. Its own repo notes the community successor here:
https://github.com/RooCodeInc/Roo-Code#disclaimer

Zoo Code is the community-maintained fork that continues where Roo Code left off:
- Site: https://zoocode.dev/
- Source: https://github.com/Zoo-Code-Org/Zoo-Code/

This PR adds a Zoo Code reference alongside the existing Roo Code mention in the README so
readers looking for a maintained alternative can find it.

Do you min updating the about section in your repo as well to include Zoo Code?

<img width="293" height="220" alt="Screenshot 2026-07-18 at 9 33 11 pm" src="https://github.com/user-attachments/assets/cae29b23-8449-4f1f-a147-bac15bf6ca39" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the supported CLI and tool list for Splitrail’s real-time token usage tracker.
  * Added Zoo Code and Kilo Code while retaining the VS Code extension and CLI support details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->