### PR TITLE
Preserve Claude Code usage across session rewrites

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -239,6 +239,11 @@ pub trait Analyzer: Send + Sync {
     /// - `MultiSession`: 1 file = many sessions (~100+ bytes/file) - e.g., Piebald
     fn contribution_strategy(&self) -> ContributionStrategy;
 
+    /// Remove analyzer-owned persistent state for a source that was deleted.
+    fn remove_source_state(&self, _path: &Path) -> Result<()> {
+        Ok(())
+    }
+
     /// Get stats with pre-discovered sources (avoids double discovery).
     /// Default implementation parses sources in parallel via `parse_sources_parallel()`.
     /// Override for analyzers with complex cross-file logic (e.g., claude_code).
@@ -576,18 +581,9 @@ impl AnalyzerRegistry {
         let source = DataSource {
             path: changed_path.to_path_buf(),
         };
-        let new_messages = match analyzer.parse_source(&source) {
-            Ok(msgs) => crate::utils::deduplicate_by_global_hash(msgs),
-            Err(e) => {
-                eprintln!(
-                    "Failed to parse {} source {:?}: {}",
-                    analyzer.display_name(),
-                    source.path,
-                    e
-                );
-                Vec::new()
-            }
-        };
+        let new_messages = analyzer
+            .parse_source(&source)
+            .map(crate::utils::deduplicate_by_global_hash)?;
 
         // Get or create the cached view for this analyzer
         let shared_view = self
@@ -661,6 +657,17 @@ impl AnalyzerRegistry {
     /// Returns true if the file was found and removed.
     /// Also marks the file as dirty for upload if it was in the cache.
     pub fn remove_file_from_cache(&self, analyzer_name: &str, path: &std::path::Path) -> bool {
+        if let Some(analyzer) = self.get_analyzer_by_display_name(analyzer_name)
+            && let Err(error) = analyzer.remove_source_state(path)
+        {
+            eprintln!(
+                "Failed to remove {} state for {:?}: {}",
+                analyzer.display_name(),
+                path,
+                error
+            );
+        }
+
         let path_hash = PathHash::new(path);
 
         // Try to remove from any cache and update view accordingly

--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
 use std::collections::{HashMap, HashSet};
@@ -32,6 +33,27 @@ impl ClaudeCodeAnalyzer {
 
     fn data_dir() -> Option<PathBuf> {
         dirs::home_dir().map(|h| h.join(".claude").join("projects"))
+    }
+
+    fn parse_live_source(source: &DataSource) -> Result<Vec<ConversationMessage>> {
+        let project_hash = extract_and_hash_project_id(&source.path);
+        let conversation_hash = crate::utils::hash_text(&source.path.to_string_lossy());
+        let file = File::open(&source.path)?;
+        let (mut messages, summaries, _uuids, fallback) =
+            parse_jsonl_file(&source.path, file, &project_hash, &conversation_hash)?;
+        let name = summaries
+            .into_iter()
+            .next()
+            .map(|(_, name)| name)
+            .or(fallback);
+        if let Some(name) = name {
+            for message in &mut messages {
+                if message.session_name.is_none() {
+                    message.session_name = Some(name.clone());
+                }
+            }
+        }
+        Ok(messages)
     }
 }
 
@@ -73,22 +95,36 @@ impl Analyzer for ClaudeCodeAnalyzer {
     }
 
     fn parse_source(&self, source: &DataSource) -> Result<Vec<ConversationMessage>> {
-        let project_hash = extract_and_hash_project_id(&source.path);
         let conversation_hash = crate::utils::hash_text(&source.path.to_string_lossy());
-        let file = File::open(&source.path)?;
-        let (mut messages, summaries, _uuids, fallback) =
-            parse_jsonl_file(&source.path, file, &project_hash, &conversation_hash)?;
-        // Apply the within-file session name (summary, else first-message fallback)
-        // so the live TUI session view shows real titles, not just the upload path.
-        let name = summaries.into_iter().next().map(|(_, n)| n).or(fallback);
-        if let Some(name) = name {
-            for m in &mut messages {
-                if m.session_name.is_none() {
-                    m.session_name = Some(name.clone());
+        let messages = Self::parse_live_source(source)?;
+        Ok(deduplicate_messages(
+            super::claude_code_history::merge_session(messages, &conversation_hash),
+        ))
+    }
+
+    fn parse_sources_parallel_with_paths(
+        &self,
+        sources: &[DataSource],
+    ) -> Vec<(PathBuf, Vec<ConversationMessage>)> {
+        let grouped = sources
+            .par_iter()
+            .map(|source| match Self::parse_live_source(source) {
+                Ok(messages) => (source.path.clone(), messages),
+                Err(error) => {
+                    eprintln!(
+                        "Failed to parse {} source {:?}: {}",
+                        self.display_name(),
+                        source.path,
+                        error
+                    );
+                    (source.path.clone(), Vec::new())
                 }
-            }
-        }
-        Ok(messages)
+            })
+            .collect();
+        super::claude_code_history::merge_grouped(grouped)
+            .into_iter()
+            .map(|(path, messages)| (path, deduplicate_messages(messages)))
+            .collect()
     }
 
     // Claude Code has complex cross-file deduplication, so we override get_stats_with_sources
@@ -96,133 +132,12 @@ impl Analyzer for ClaudeCodeAnalyzer {
         &self,
         sources: Vec<DataSource>,
     ) -> Result<crate::types::AgenticCodingToolStats> {
-        // Type for deduplication entry: (insertion_order, message, seen_fingerprints)
-        type TokenFingerprint = (u64, u64, u64, u64, u64);
-        type DedupEntry = (usize, ConversationMessage, HashSet<TokenFingerprint>);
-
-        // Deduplication map and session tracking
-        let mut dedup_map: HashMap<String, DedupEntry> = HashMap::with_capacity(sources.len() * 50);
-        let mut insertion_counter: usize = 0;
-        let mut no_hash_counter: usize = 0;
-
-        // Session name mappings
-        let mut session_names: HashMap<String, String> = HashMap::new();
-        let mut conversation_summaries: HashMap<String, String> = HashMap::new();
-        let mut conversation_fallbacks: HashMap<String, String> = HashMap::new();
-        let mut conversation_uuids: HashMap<String, Vec<String>> = HashMap::new();
-
-        // Parse all files sequentially, deduplicating as we go
-        for source in sources {
-            let project_hash = extract_and_hash_project_id(&source.path);
-            let conversation_hash = crate::utils::hash_text(&source.path.to_string_lossy());
-
-            let file = match File::open(&source.path) {
-                Ok(f) => f,
-                Err(e) => {
-                    eprintln!("Failed to open Claude Code file {:?}: {}", source.path, e);
-                    continue;
-                }
-            };
-
-            let (msgs, summaries, uuids, fallback) =
-                match parse_jsonl_file(&source.path, file, &project_hash, &conversation_hash) {
-                    Ok(result) => result,
-                    Err(e) => {
-                        eprintln!("Failed to parse Claude Code file {:?}: {}", source.path, e);
-                        continue;
-                    }
-                };
-
-            // Store summaries
-            for (uuid, name) in summaries {
-                session_names.insert(uuid, name);
-            }
-
-            // Store UUIDs for this conversation
-            conversation_uuids.insert(conversation_hash.clone(), uuids);
-
-            // Store fallback
-            if let Some(fb) = fallback {
-                conversation_fallbacks.insert(conversation_hash.clone(), fb);
-            }
-
-            // Deduplicate messages as we insert
-            for msg in msgs {
-                if let Some(local_hash) = &msg.local_hash {
-                    let order = insertion_counter;
-                    insertion_counter += 1;
-                    let fp = (
-                        msg.stats.input_tokens,
-                        msg.stats.output_tokens,
-                        msg.stats.cache_creation_tokens,
-                        msg.stats.cache_read_tokens,
-                        msg.stats.cached_tokens,
-                    );
-
-                    dedup_map
-                        .entry(local_hash.clone())
-                        .and_modify(|(_, existing, seen_fps)| {
-                            merge_message_into(existing, &msg, seen_fps, fp);
-                        })
-                        .or_insert_with(|| {
-                            let mut fps = HashSet::new();
-                            fps.insert(fp);
-                            (order, msg, fps)
-                        });
-                } else {
-                    // No local hash, always keep with unique key
-                    let order = insertion_counter;
-                    insertion_counter += 1;
-                    let unique_key = format!("__no_hash_{}", no_hash_counter);
-                    no_hash_counter += 1;
-                    let fp = (
-                        msg.stats.input_tokens,
-                        msg.stats.output_tokens,
-                        msg.stats.cache_creation_tokens,
-                        msg.stats.cache_read_tokens,
-                        msg.stats.cached_tokens,
-                    );
-                    let mut fps = HashSet::new();
-                    fps.insert(fp);
-                    dedup_map.insert(unique_key, (order, msg, fps));
-                }
-            }
-        }
-
-        // Link session names to conversations (after all parsing complete)
-        for (conversation_hash, uuids) in &conversation_uuids {
-            let mut found_summary = false;
-            for uuid in uuids {
-                if let Some(name) = session_names.get(uuid) {
-                    conversation_summaries.insert(conversation_hash.clone(), name.clone());
-                    found_summary = true;
-                    break;
-                }
-            }
-
-            if !found_summary && let Some(fb) = conversation_fallbacks.get(conversation_hash) {
-                conversation_summaries.insert(conversation_hash.clone(), fb.clone());
-            }
-        }
-
-        // Apply session names to messages and collect results
-        let mut result: Vec<_> = dedup_map
-            .into_iter()
-            .map(|(_, (order, mut msg, _))| {
-                // Apply session name if available
-                if msg.session_name.is_none()
-                    && let Some(name) = conversation_summaries.get(&msg.conversation_hash)
-                {
-                    msg.session_name = Some(name.clone());
-                }
-                (order, msg)
-            })
-            .collect();
-
-        // Sort by insertion order for deterministic output
-        result.sort_by_key(|(order, _)| *order);
-
-        let messages: Vec<ConversationMessage> = result.into_iter().map(|(_, msg)| msg).collect();
+        let messages: Vec<ConversationMessage> = deduplicate_messages(
+            self.parse_sources_parallel_with_paths(&sources)
+                .into_iter()
+                .flat_map(|(_, messages)| messages)
+                .collect(),
+        );
 
         // Aggregate stats
         let mut daily_stats = crate::utils::aggregate_by_date(&messages);
@@ -238,6 +153,12 @@ impl Analyzer for ClaudeCodeAnalyzer {
             messages,
             analyzer_name: self.display_name().to_string(),
         })
+    }
+
+    fn remove_source_state(&self, path: &Path) -> Result<()> {
+        super::claude_code_history::remove_session(&crate::utils::hash_text(
+            &path.to_string_lossy(),
+        ))
     }
 
     fn get_watch_directories(&self) -> Vec<PathBuf> {
@@ -280,6 +201,45 @@ impl Analyzer for ClaudeCodeAnalyzer {
 }
 
 // Claude Code specific implementation functions
+
+type DedupEntry = (usize, ConversationMessage, HashSet<TokenFingerprint>);
+
+pub(crate) fn deduplicate_messages(messages: Vec<ConversationMessage>) -> Vec<ConversationMessage> {
+    let mut dedup_map: HashMap<String, DedupEntry> = HashMap::with_capacity(messages.len());
+    let mut no_hash_messages = Vec::new();
+
+    for (order, message) in messages.into_iter().enumerate() {
+        let Some(local_hash) = message.local_hash.clone() else {
+            no_hash_messages.push((order, message));
+            continue;
+        };
+        let fingerprint = (
+            message.stats.input_tokens,
+            message.stats.output_tokens,
+            message.stats.cache_creation_tokens,
+            message.stats.cache_read_tokens,
+            message.stats.cached_tokens,
+        );
+        dedup_map
+            .entry(local_hash)
+            .and_modify(|(_, existing, seen_fingerprints)| {
+                merge_message_into(existing, &message, seen_fingerprints, fingerprint);
+            })
+            .or_insert_with(|| {
+                let mut seen_fingerprints = HashSet::new();
+                seen_fingerprints.insert(fingerprint);
+                (order, message, seen_fingerprints)
+            });
+    }
+
+    let mut result: Vec<_> = dedup_map
+        .into_values()
+        .map(|(order, message, _)| (order, message))
+        .chain(no_hash_messages)
+        .collect();
+    result.sort_by_key(|(order, _)| *order);
+    result.into_iter().map(|(_, message)| message).collect()
+}
 
 // Helper function to extract project ID from Claude Code file path and hash it
 pub fn extract_and_hash_project_id(file_path: &Path) -> String {

--- a/src/analyzers/claude_code_history.rs
+++ b/src/analyzers/claude_code_history.rs
@@ -132,7 +132,7 @@ where
             )
             .context("Failed to record discovered Claude Code session")?;
     }
-    if prune_missing {
+    if prune_missing && !conversation_hashes.is_empty() {
         transaction
             .execute(
                 "DELETE FROM messages
@@ -376,6 +376,30 @@ mod tests {
         let stored = simd_json::from_slice::<ConversationMessage>(&mut payload).unwrap();
         assert_eq!(stored.stats.input_tokens, 25);
         assert_eq!(stored.session_name, None);
+    }
+
+    #[test]
+    fn empty_discovery_does_not_prune_retained_sessions() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join(HISTORY_FILE_NAME);
+        let conversation = "session".to_string();
+        let mut initial = vec![message("retained", &conversation, "local-retained", 10)];
+        merge_at(
+            &path,
+            &mut initial,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+
+        let mut empty: Vec<ConversationMessage> = Vec::new();
+        merge_at(&path, &mut empty, &[], true).unwrap();
+
+        let connection = Connection::open(&path).unwrap();
+        let count: i64 = connection
+            .query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
     }
 
     #[test]

--- a/src/analyzers/claude_code_history.rs
+++ b/src/analyzers/claude_code_history.rs
@@ -1,0 +1,506 @@
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use crate::types::ConversationMessage;
+
+const HISTORY_FILE_NAME: &str = "claude-code-messages.sqlite3";
+
+pub(crate) fn merge_session(
+    live_messages: Vec<ConversationMessage>,
+    conversation_hash: &str,
+) -> Vec<ConversationMessage> {
+    let path = match history_path() {
+        Ok(path) => path,
+        Err(error) => {
+            warn_history_error("locate", None, &error);
+            return live_messages;
+        }
+    };
+
+    let mut messages = live_messages;
+    if let Err(error) = merge_at(
+        &path,
+        &mut messages,
+        &[conversation_hash.to_string()],
+        false,
+    ) {
+        warn_history_error("update", Some(&path), &error);
+    }
+    messages
+}
+
+pub(crate) fn remove_session(conversation_hash: &str) -> Result<()> {
+    let path = history_path()?;
+    if !path.exists() {
+        return Ok(());
+    }
+    let connection = Connection::open(&path).context("Failed to open Claude Code history store")?;
+    connection
+        .busy_timeout(std::time::Duration::from_secs(5))
+        .context("Failed to configure Claude Code history store")?;
+    connection
+        .execute(
+            "DELETE FROM messages WHERE conversation_hash = ?1",
+            [conversation_hash],
+        )
+        .context("Failed to remove deleted Claude Code session")?;
+    Ok(())
+}
+
+pub(crate) fn merge_grouped(
+    grouped: Vec<(PathBuf, Vec<ConversationMessage>)>,
+) -> Vec<(PathBuf, Vec<ConversationMessage>)> {
+    let path = match history_path() {
+        Ok(path) => path,
+        Err(error) => {
+            warn_history_error("locate", None, &error);
+            return grouped;
+        }
+    };
+    let conversation_hashes: Vec<_> = grouped
+        .iter()
+        .map(|(source_path, _)| crate::utils::hash_text(&source_path.to_string_lossy()))
+        .collect();
+
+    let mut grouped = grouped;
+    if let Err(error) = merge_at(&path, &mut grouped, &conversation_hashes, true) {
+        warn_history_error("update", Some(&path), &error);
+    }
+    grouped
+}
+
+fn history_path() -> Result<PathBuf> {
+    let state_root = dirs::state_dir()
+        .or_else(dirs::data_local_dir)
+        .context("Could not find platform state directory")?;
+    Ok(state_root.join("splitrail").join(HISTORY_FILE_NAME))
+}
+
+fn merge_at<T>(
+    path: &Path,
+    grouped: &mut T,
+    conversation_hashes: &[String],
+    prune_missing: bool,
+) -> Result<()>
+where
+    T: MessageGroups,
+{
+    let Some(parent) = path.parent() else {
+        anyhow::bail!("Claude Code history path has no parent directory");
+    };
+    create_private_directory(parent)?;
+
+    let mut connection =
+        Connection::open(path).context("Failed to open Claude Code history store")?;
+    set_private_file_permissions(path)?;
+    connection
+        .busy_timeout(std::time::Duration::from_secs(5))
+        .context("Failed to configure Claude Code history store")?;
+    connection
+        .execute_batch(
+            "CREATE TABLE IF NOT EXISTS messages (
+                global_hash TEXT PRIMARY KEY NOT NULL,
+                conversation_hash TEXT NOT NULL,
+                payload BLOB NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS messages_conversation_hash
+                ON messages(conversation_hash);",
+        )
+        .context("Failed to initialize Claude Code history store")?;
+
+    let transaction = connection
+        .transaction()
+        .context("Failed to begin Claude Code history transaction")?;
+    transaction
+        .execute("DROP TABLE IF EXISTS current_conversations", [])
+        .context("Failed to reset Claude Code history discovery set")?;
+    transaction
+        .execute(
+            "CREATE TEMP TABLE current_conversations (
+                conversation_hash TEXT PRIMARY KEY NOT NULL
+            )",
+            [],
+        )
+        .context("Failed to create Claude Code history discovery set")?;
+    for conversation_hash in conversation_hashes {
+        transaction
+            .execute(
+                "INSERT INTO current_conversations (conversation_hash) VALUES (?1)",
+                [conversation_hash],
+            )
+            .context("Failed to record discovered Claude Code session")?;
+    }
+    if prune_missing {
+        transaction
+            .execute(
+                "DELETE FROM messages
+                 WHERE conversation_hash NOT IN (SELECT conversation_hash FROM current_conversations)",
+                [],
+            )
+            .context("Failed to prune deleted Claude Code sessions")?;
+    }
+    for messages in grouped.groups() {
+        for message in messages {
+            let mut stored = message.clone();
+            stored.session_name = None;
+            let payload = simd_json::to_vec(&stored)
+                .context("Failed to serialize Claude Code history entry")?;
+            transaction
+                .execute(
+                    "INSERT INTO messages (global_hash, conversation_hash, payload)
+                     VALUES (?1, ?2, ?3)
+                     ON CONFLICT(global_hash) DO UPDATE SET
+                         conversation_hash = excluded.conversation_hash,
+                         payload = excluded.payload",
+                    params![stored.global_hash, stored.conversation_hash, payload],
+                )
+                .context("Failed to persist Claude Code history entry")?;
+        }
+    }
+    transaction
+        .commit()
+        .context("Failed to commit Claude Code history transaction")?;
+
+    let live_hashes: HashSet<_> = grouped
+        .groups()
+        .flat_map(|messages| messages.iter().map(|message| message.global_hash.clone()))
+        .collect();
+    let mut retained_by_conversation: HashMap<String, Vec<ConversationMessage>> = HashMap::new();
+    let mut statement = connection
+        .prepare("SELECT payload FROM messages WHERE conversation_hash = ?1")
+        .context("Failed to prepare Claude Code history query")?;
+    for conversation_hash in conversation_hashes {
+        let rows = statement
+            .query_map([conversation_hash], |row| row.get::<_, Vec<u8>>(0))
+            .context("Failed to query Claude Code history")?;
+        for payload in rows {
+            let mut payload = payload.context("Failed to read Claude Code history entry")?;
+            match simd_json::from_slice::<ConversationMessage>(&mut payload) {
+                Ok(message) if !live_hashes.contains(&message.global_hash) => {
+                    retained_by_conversation
+                        .entry(message.conversation_hash.clone())
+                        .or_default()
+                        .push(message);
+                }
+                Ok(_) => {}
+                Err(error) => crate::utils::warn_once(format!(
+                    "Skipping invalid Claude Code history entry: {error}"
+                )),
+            }
+        }
+    }
+
+    grouped.extend_groups(&mut retained_by_conversation, conversation_hashes);
+    Ok(())
+}
+
+trait MessageGroups {
+    fn groups(&self) -> impl Iterator<Item = &[ConversationMessage]>;
+    fn extend_groups(
+        &mut self,
+        retained: &mut HashMap<String, Vec<ConversationMessage>>,
+        conversation_hashes: &[String],
+    );
+}
+
+impl MessageGroups for Vec<(PathBuf, Vec<ConversationMessage>)> {
+    fn groups(&self) -> impl Iterator<Item = &[ConversationMessage]> {
+        self.iter().map(|(_, messages)| messages.as_slice())
+    }
+
+    fn extend_groups(
+        &mut self,
+        retained: &mut HashMap<String, Vec<ConversationMessage>>,
+        conversation_hashes: &[String],
+    ) {
+        for ((_, messages), conversation_hash) in self.iter_mut().zip(conversation_hashes) {
+            if let Some(mut history) = retained.remove(conversation_hash) {
+                messages.append(&mut history);
+            }
+        }
+    }
+}
+
+impl MessageGroups for Vec<ConversationMessage> {
+    fn groups(&self) -> impl Iterator<Item = &[ConversationMessage]> {
+        std::iter::once(self.as_slice())
+    }
+
+    fn extend_groups(
+        &mut self,
+        retained: &mut HashMap<String, Vec<ConversationMessage>>,
+        conversation_hashes: &[String],
+    ) {
+        if let Some(conversation_hash) = conversation_hashes.first()
+            && let Some(mut history) = retained.remove(conversation_hash)
+        {
+            self.append(&mut history);
+        }
+    }
+}
+
+fn create_private_directory(path: &Path) -> Result<()> {
+    std::fs::create_dir_all(path).context("Failed to create Claude Code history directory")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .context("Failed to secure Claude Code history directory")?;
+    }
+    Ok(())
+}
+
+fn set_private_file_permissions(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .context("Failed to secure Claude Code history store")?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn warn_history_error(action: &str, path: Option<&Path>, error: &anyhow::Error) {
+    let location = path
+        .map(|path| format!(" {}", path.display()))
+        .unwrap_or_default();
+    crate::utils::warn_once(format!(
+        "Could not {action} Claude Code history store{location}: {error}"
+    ));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{Application, MessageRole, Stats};
+    use chrono::{TimeZone, Utc};
+    use rusqlite::OptionalExtension;
+    use tempfile::tempdir;
+
+    fn message(
+        hash: &str,
+        conversation: &str,
+        local_hash: &str,
+        input_tokens: u64,
+    ) -> ConversationMessage {
+        ConversationMessage {
+            application: Application::ClaudeCode,
+            date: Utc.with_ymd_and_hms(2025, 8, 2, 14, 5, 17).unwrap(),
+            project_hash: "project".to_string(),
+            conversation_hash: conversation.to_string(),
+            local_hash: Some(local_hash.to_string()),
+            global_hash: hash.to_string(),
+            model: Some("claude-sonnet-4-20250514".to_string()),
+            stats: Stats {
+                input_tokens,
+                ..Stats::default()
+            },
+            role: MessageRole::Assistant,
+            uuid: Some(hash.to_string()),
+            session_name: Some("Session prompt".to_string()),
+        }
+    }
+
+    #[test]
+    fn retains_messages_removed_from_rewritten_session() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join(HISTORY_FILE_NAME);
+        let conversation = "session".to_string();
+        let mut initial = vec![
+            message("first", &conversation, "local-first", 10),
+            message("second", &conversation, "local-second", 20),
+        ];
+        merge_at(
+            &path,
+            &mut initial,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+
+        let mut after_rewrite = vec![message("second", &conversation, "local-second", 20)];
+        merge_at(
+            &path,
+            &mut after_rewrite,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+        assert_eq!(after_rewrite.len(), 2);
+        assert!(
+            after_rewrite
+                .iter()
+                .any(|message| message.global_hash == "first")
+        );
+    }
+
+    #[test]
+    fn live_message_updates_matching_history_record() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join(HISTORY_FILE_NAME);
+        let conversation = "session".to_string();
+        let mut initial = vec![message("same", &conversation, "local", 10)];
+        merge_at(
+            &path,
+            &mut initial,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+
+        let mut merged = vec![message("same", &conversation, "local", 25)];
+        merge_at(
+            &path,
+            &mut merged,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].stats.input_tokens, 25);
+
+        let connection = Connection::open(&path).unwrap();
+        let mut payload: Vec<u8> = connection
+            .query_row(
+                "SELECT payload FROM messages WHERE global_hash = 'same'",
+                [],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap()
+            .unwrap();
+        let stored = simd_json::from_slice::<ConversationMessage>(&mut payload).unwrap();
+        assert_eq!(stored.stats.input_tokens, 25);
+        assert_eq!(stored.session_name, None);
+    }
+
+    #[test]
+    fn only_restores_currently_discovered_sessions() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join(HISTORY_FILE_NAME);
+        let first = "first-session".to_string();
+        let deleted = "deleted-session".to_string();
+        let mut initial = vec![
+            (
+                PathBuf::from("first.jsonl"),
+                vec![message("first", &first, "local-first", 10)],
+            ),
+            (
+                PathBuf::from("deleted.jsonl"),
+                vec![message("deleted", &deleted, "local-deleted", 20)],
+            ),
+        ];
+        merge_at(&path, &mut initial, &[first.clone(), deleted], true).unwrap();
+
+        let mut current = vec![(PathBuf::from("first.jsonl"), Vec::new())];
+        merge_at(&path, &mut current, std::slice::from_ref(&first), true).unwrap();
+        assert_eq!(current.len(), 1);
+        assert_eq!(current[0].1.len(), 1);
+        assert_eq!(current[0].1[0].global_hash, "first");
+    }
+
+    #[test]
+    fn removing_session_prevents_history_resurrection() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join(HISTORY_FILE_NAME);
+        let conversation = "session".to_string();
+        let mut initial = vec![message("old", &conversation, "local-old", 10)];
+        merge_at(
+            &path,
+            &mut initial,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute(
+                "DELETE FROM messages WHERE conversation_hash = ?1",
+                [&conversation],
+            )
+            .unwrap();
+
+        let mut recreated: Vec<ConversationMessage> = Vec::new();
+        merge_at(
+            &path,
+            &mut recreated,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+        assert!(recreated.is_empty());
+    }
+
+    #[test]
+    fn corrupt_payload_does_not_hide_other_retained_messages() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join(HISTORY_FILE_NAME);
+        let conversation = "session".to_string();
+        let mut initial = vec![message("valid", &conversation, "local-valid", 10)];
+        merge_at(
+            &path,
+            &mut initial,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+        let connection = Connection::open(&path).unwrap();
+        connection
+            .execute(
+                "INSERT INTO messages (global_hash, conversation_hash, payload)
+                 VALUES ('corrupt', ?1, X'FF')",
+                [&conversation],
+            )
+            .unwrap();
+
+        let mut restored: Vec<ConversationMessage> = Vec::new();
+        merge_at(
+            &path,
+            &mut restored,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+        assert_eq!(restored.len(), 1);
+        assert_eq!(restored[0].global_hash, "valid");
+    }
+
+    #[test]
+    fn raw_records_are_restored_before_local_hash_deduplication() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join(HISTORY_FILE_NAME);
+        let conversation = "session".to_string();
+        let mut initial = vec![
+            message("uuid-a", &conversation, "shared-local", 10),
+            message("uuid-b", &conversation, "shared-local", 20),
+        ];
+        merge_at(
+            &path,
+            &mut initial,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+
+        let mut restored = vec![message("uuid-a", &conversation, "shared-local", 10)];
+        merge_at(
+            &path,
+            &mut restored,
+            std::slice::from_ref(&conversation),
+            false,
+        )
+        .unwrap();
+        assert_eq!(restored.len(), 2);
+        assert_eq!(
+            restored
+                .iter()
+                .map(|message| message.stats.input_tokens)
+                .sum::<u64>(),
+            30
+        );
+    }
+}

--- a/src/analyzers/mod.rs
+++ b/src/analyzers/mod.rs
@@ -1,5 +1,6 @@
 pub mod antigravity;
 pub mod claude_code;
+mod claude_code_history;
 pub mod cline;
 pub mod codex_cli;
 pub mod copilot;

--- a/src/analyzers/tests/claude_code.rs
+++ b/src/analyzers/tests/claude_code.rs
@@ -1,6 +1,6 @@
 use crate::analyzers::claude_code::{
-    TokenFingerprint, calculate_cost_from_tokens, extract_and_hash_project_id, merge_message_into,
-    parse_jsonl_file,
+    TokenFingerprint, calculate_cost_from_tokens, deduplicate_messages,
+    extract_and_hash_project_id, merge_message_into, parse_jsonl_file,
 };
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use chrono::{TimeZone, Utc};
@@ -75,6 +75,39 @@ static DUPLICATE_MESSAGES_DATA: LazyLock<String> = LazyLock::new(|| {
     r#"{"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"D:\\splitrail","sessionId":"dup-session","version":"1.0.51","message":{"id":"msg_duplicate","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[{"type":"text","text":"First message"}],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"cache_creation_input_tokens":100,"cache_read_input_tokens":20,"output_tokens":5,"service_tier":"standard"}},"requestId":"req_dup_test","type":"assistant","uuid":"dup-uuid-1","timestamp":"2025-08-02T16:00:00.000Z"}
 {"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"D:\\splitrail","sessionId":"dup-session","version":"1.0.51","message":{"id":"msg_duplicate","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[{"type":"text","text":"Second message (duplicate)"}],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":150,"cache_read_input_tokens":30,"output_tokens":10,"service_tier":"standard"}},"requestId":"req_dup_test","type":"assistant","uuid":"dup-uuid-2","timestamp":"2025-08-02T16:00:01.000Z"}"#.to_string()
 });
+
+#[test]
+fn test_deduplicate_messages_merges_same_local_hash_across_uuids() {
+    let mut first = ConversationMessage {
+        application: Application::ClaudeCode,
+        date: Utc.with_ymd_and_hms(2025, 8, 2, 16, 0, 0).unwrap(),
+        project_hash: "project".to_string(),
+        conversation_hash: "conversation".to_string(),
+        local_hash: Some("shared-local-hash".to_string()),
+        global_hash: "uuid-a".to_string(),
+        model: Some("claude-sonnet-4-20250514".to_string()),
+        stats: Stats {
+            input_tokens: 10,
+            ..Stats::default()
+        },
+        role: MessageRole::Assistant,
+        uuid: Some("uuid-a".to_string()),
+        session_name: None,
+    };
+    let mut second = first.clone();
+    second.global_hash = "uuid-b".to_string();
+    second.uuid = Some("uuid-b".to_string());
+    second.stats.input_tokens = 20;
+
+    let deduplicated = deduplicate_messages(vec![first.clone(), second]);
+    assert_eq!(deduplicated.len(), 1);
+    assert_eq!(deduplicated[0].stats.input_tokens, 30);
+
+    first.stats.input_tokens = 10;
+    let duplicate_fingerprint = deduplicate_messages(vec![first.clone(), first]);
+    assert_eq!(duplicate_fingerprint.len(), 1);
+    assert_eq!(duplicate_fingerprint[0].stats.input_tokens, 10);
+}
 
 #[test]
 fn test_parse_jsonl_file_basic() {


### PR DESCRIPTION
## Why

Claude Code can rewrite a session JSONL file when a conversation is resumed or compacted. Messages that were present in an earlier version can disappear from the live file even though their token usage and cost were already incurred.

Splitrail previously treated each file as the complete authoritative history. A live update subtracted the old session contribution and replaced it with the rewritten file, while a restart rebuilt statistics only from the current JSONL. Both paths could therefore make historical totals drift downward. Incremental parse failures could also replace a valid cached contribution with an empty one.

## What changed

- Add a local SQLite history store for normalized Claude Code accounting records, keyed by the existing stable `global_hash`.
- Restore retained records for still-discovered sessions before applying Claude's `local_hash` and token-fingerprint deduplication.
- Use the same Claude-specific deduplication semantics for TUI startup, incremental reloads, CLI statistics, MCP statistics, and uploads.
- Upsert corrected normalized metadata without allowing the store to grow with duplicate revisions.
- Strip `session_name` before persistence and apply owner-only directory and database permissions on Unix.
- Skip isolated malformed stored payloads instead of disabling all retained history.
- Distinguish single-session incremental merges from complete discovery reconciliation so one file event cannot prune unrelated sessions.
- Prune records for sessions absent from complete discovery and remove persisted session state immediately on confirmed file deletion.
- Propagate incremental parse errors to the watcher's existing full-reload fallback instead of replacing the prior contribution with zero.
- Add regression coverage for rewrite retention, corrected metadata, deduplication parity, failed and deleted sessions, malformed payloads, and non-resurrection after deletion.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` — 382 passed
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Claude Code conversation history handling across reloads and deleted source files.
  * Persisted and merged conversation history via local state, including group-wise merging.
  * Enhanced message deduplication for accurate token-stat aggregation.
* **Bug Fixes**
  * Incremental reload now properly reports parse failures instead of silently skipping them.
  * Corrupt historical records no longer block restoration of other valid history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->