### PR TITLE
Add Zoo Code usage tracking

### DIFF
--- a/src/analyzers/mod.rs
+++ b/src/analyzers/mod.rs
@@ -13,6 +13,7 @@ pub mod pi_agent;
 pub mod piebald;
 pub mod qwen_code;
 pub mod roo_code;
+pub mod zoo_code;
 
 pub use antigravity::AntigravityCliAnalyzer;
 pub use claude_code::ClaudeCodeAnalyzer;
@@ -28,6 +29,7 @@ pub use pi_agent::PiAgentAnalyzer;
 pub use piebald::PiebaldAnalyzer;
 pub use qwen_code::QwenCodeAnalyzer;
 pub use roo_code::RooCodeAnalyzer;
+pub use zoo_code::ZooCodeAnalyzer;
 
 #[cfg(test)]
 pub mod tests;

--- a/src/analyzers/roo_code.rs
+++ b/src/analyzers/roo_code.rs
@@ -14,6 +14,13 @@ use std::path::{Path, PathBuf};
 
 const ROO_CODE_EXTENSION_ID: &str = "rooveterinaryinc.roo-cline";
 
+pub(crate) fn parse_roo_format_task_directory(
+    task_dir: &Path,
+    application: Application,
+) -> Result<Vec<ConversationMessage>> {
+    parse_roo_code_task_directory(task_dir, application)
+}
+
 pub struct RooCodeAnalyzer;
 
 impl RooCodeAnalyzer {
@@ -125,7 +132,10 @@ fn extract_model_from_text(text: &str) -> Option<String> {
 }
 
 // Parse a single Roo Code task directory
-fn parse_roo_code_task_directory(task_dir: &Path) -> Result<Vec<ConversationMessage>> {
+fn parse_roo_code_task_directory(
+    task_dir: &Path,
+    application: Application,
+) -> Result<Vec<ConversationMessage>> {
     let project_hash = extract_and_hash_project_id_roo_code(task_dir);
 
     // Get the conversation hash from the task directory name (UUID)
@@ -204,7 +214,7 @@ fn parse_roo_code_task_directory(task_dir: &Path) -> Result<Vec<ConversationMess
                         };
 
                         entries.push(ConversationMessage {
-                            application: Application::RooCode,
+                            application: application.clone(),
                             date,
                             project_hash: project_hash.clone(),
                             conversation_hash: conversation_hash.clone(),
@@ -254,7 +264,7 @@ fn parse_roo_code_task_directory(task_dir: &Path) -> Result<Vec<ConversationMess
                     }
 
                     entries.push(ConversationMessage {
-                        application: Application::RooCode,
+                        application: application.clone(),
                         date,
                         project_hash: project_hash.clone(),
                         conversation_hash: conversation_hash.clone(),
@@ -334,7 +344,7 @@ impl Analyzer for RooCodeAnalyzer {
     }
 
     fn parse_source(&self, source: &DataSource) -> Result<Vec<ConversationMessage>> {
-        parse_roo_code_task_directory(&source.path)
+        parse_roo_code_task_directory(&source.path, Application::RooCode)
     }
 
     fn get_watch_directories(&self) -> Vec<PathBuf> {

--- a/src/analyzers/tests/mod.rs
+++ b/src/analyzers/tests/mod.rs
@@ -10,3 +10,4 @@ mod kilo_code;
 mod opencode;
 mod qwen_code;
 mod roo_code;
+mod zoo_code;

--- a/src/analyzers/tests/zoo_code.rs
+++ b/src/analyzers/tests/zoo_code.rs
@@ -1,0 +1,87 @@
+use crate::analyzer::{Analyzer, DataSource};
+use crate::analyzers::zoo_code::ZooCodeAnalyzer;
+use crate::types::{Application, MessageRole};
+use std::fs;
+use tempfile::tempdir;
+
+#[test]
+fn test_zoo_code_analyzer_creation() {
+    let analyzer = ZooCodeAnalyzer::new();
+    assert_eq!(analyzer.display_name(), "Zoo Code");
+}
+
+#[test]
+fn test_zoo_code_glob_patterns_use_zoo_extension_id() {
+    let analyzer = ZooCodeAnalyzer::new();
+    let patterns = analyzer.get_data_glob_patterns();
+
+    assert!(!patterns.is_empty());
+    assert!(
+        patterns
+            .iter()
+            .all(|pattern| pattern.contains("zoocodeorganization.zoo-code"))
+    );
+}
+
+#[test]
+fn test_zoo_code_is_available() {
+    let analyzer = ZooCodeAnalyzer::new();
+    let _ = analyzer.is_available();
+}
+
+#[test]
+fn test_zoo_code_discover_data_sources_no_panic() {
+    let analyzer = ZooCodeAnalyzer::new();
+    assert!(analyzer.discover_data_sources().is_ok());
+}
+
+#[test]
+fn test_zoo_code_parses_roo_format_as_zoo_code() {
+    let temp_dir = tempdir().unwrap();
+    let task_dir = temp_dir
+        .path()
+        .join("zoocodeorganization.zoo-code/tasks/task-123");
+    fs::create_dir_all(&task_dir).unwrap();
+    fs::write(
+        task_dir.join("api_conversation_history.json"),
+        r#"[{"role":"user","content":[{"type":"text","text":"<environment_details><model>claude-sonnet-4</model></environment_details>"}]}]"#,
+    )
+    .unwrap();
+    fs::write(
+        task_dir.join("ui_messages.json"),
+        r#"[
+            {"type":"ask","ts":1710000000000,"ask":"followup","text":"Add Zoo Code support"},
+            {"type":"say","ts":1710000001000,"say":"api_req_started","text":"{\"apiProtocol\":\"anthropic\",\"tokensIn\":120,\"tokensOut\":30,\"cacheWrites\":10,\"cacheReads\":20,\"cost\":0.0123}"}
+        ]"#,
+    )
+    .unwrap();
+
+    let analyzer = ZooCodeAnalyzer::new();
+    let messages = analyzer
+        .parse_source(&DataSource { path: task_dir })
+        .unwrap();
+
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0].application, Application::ZooCode);
+    assert_eq!(messages[0].role, MessageRole::User);
+    assert_eq!(
+        messages[0].session_name.as_deref(),
+        Some("Add Zoo Code support")
+    );
+    assert_eq!(messages[1].application, Application::ZooCode);
+    assert_eq!(messages[1].role, MessageRole::Assistant);
+    assert_eq!(messages[1].model.as_deref(), Some("claude-sonnet-4"));
+    assert_eq!(messages[1].stats.input_tokens, 120);
+    assert_eq!(messages[1].stats.output_tokens, 30);
+    assert_eq!(messages[1].stats.cache_creation_tokens, 10);
+    assert_eq!(messages[1].stats.cache_read_tokens, 20);
+    assert_eq!(messages[1].stats.cached_tokens, 30);
+    assert_eq!(messages[1].stats.cost, 0.0123);
+}
+
+#[tokio::test]
+async fn test_zoo_code_get_stats_empty_sources() {
+    let analyzer = ZooCodeAnalyzer::new();
+    let result = analyzer.get_stats_with_sources(vec![]).unwrap();
+    assert!(result.messages.is_empty());
+}

--- a/src/analyzers/zoo_code.rs
+++ b/src/analyzers/zoo_code.rs
@@ -1,0 +1,95 @@
+use crate::analyzer::{
+    Analyzer, DataSource, discover_vscode_extension_sources, get_vscode_extension_tasks_dirs,
+    vscode_extension_has_sources,
+};
+use crate::analyzers::roo_code::parse_roo_format_task_directory;
+use crate::contribution_cache::ContributionStrategy;
+use crate::types::{Application, ConversationMessage};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+
+const ZOO_CODE_EXTENSION_ID: &str = "zoocodeorganization.zoo-code";
+
+pub struct ZooCodeAnalyzer;
+
+impl ZooCodeAnalyzer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl Analyzer for ZooCodeAnalyzer {
+    fn display_name(&self) -> &'static str {
+        "Zoo Code"
+    }
+
+    fn get_data_glob_patterns(&self) -> Vec<String> {
+        let mut patterns = Vec::new();
+        let vscode_gui_forks = [
+            "Antigravity",
+            "Code",
+            "Code - Insiders",
+            "Cursor",
+            "Positron",
+            "VSCodium",
+            "Windsurf",
+        ];
+        let vscode_cli_forks = ["vscode-server-insiders", "vscode-server"];
+
+        if let Some(home_dir) = dirs::home_dir() {
+            let home_str = home_dir.to_string_lossy();
+
+            for fork in &vscode_gui_forks {
+                patterns.push(format!(
+                    "{home_str}/.config/{fork}/User/globalStorage/{ZOO_CODE_EXTENSION_ID}/tasks/*/ui_messages.json"
+                ));
+            }
+            for fork in &vscode_cli_forks {
+                patterns.push(format!(
+                    "{home_str}/.{fork}/data/User/globalStorage/{ZOO_CODE_EXTENSION_ID}/tasks/*/ui_messages.json"
+                ));
+            }
+            for fork in &vscode_gui_forks {
+                patterns.push(format!(
+                    "{home_str}/Library/Application Support/{fork}/User/globalStorage/{ZOO_CODE_EXTENSION_ID}/tasks/*/ui_messages.json"
+                ));
+            }
+        }
+
+        if let Ok(appdata) = std::env::var("APPDATA") {
+            for fork in &vscode_gui_forks {
+                patterns.push(format!(
+                    "{appdata}\\{fork}\\User\\globalStorage\\{ZOO_CODE_EXTENSION_ID}\\tasks\\*\\ui_messages.json"
+                ));
+            }
+        }
+
+        patterns
+    }
+
+    fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
+        discover_vscode_extension_sources(ZOO_CODE_EXTENSION_ID, "ui_messages.json", true)
+    }
+
+    fn is_available(&self) -> bool {
+        vscode_extension_has_sources(ZOO_CODE_EXTENSION_ID, "ui_messages.json")
+    }
+
+    fn parse_source(&self, source: &DataSource) -> Result<Vec<ConversationMessage>> {
+        parse_roo_format_task_directory(&source.path, Application::ZooCode)
+    }
+
+    fn get_watch_directories(&self) -> Vec<PathBuf> {
+        get_vscode_extension_tasks_dirs(ZOO_CODE_EXTENSION_ID)
+    }
+
+    fn is_valid_data_path(&self, path: &Path) -> bool {
+        path.is_file() && path.file_name().is_some_and(|n| n == "ui_messages.json")
+    }
+
+    fn contribution_strategy(&self) -> ContributionStrategy {
+        ContributionStrategy::SingleSession
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use analyzer::AnalyzerRegistry;
 use analyzers::{
     AntigravityCliAnalyzer, ClaudeCodeAnalyzer, ClineAnalyzer, CodexCliAnalyzer, CopilotAnalyzer,
     CopilotCliAnalyzer, GeminiCliAnalyzer, KiloCliAnalyzer, KiloCodeAnalyzer, OpenCodeAnalyzer,
-    PiAgentAnalyzer, PiebaldAnalyzer, QwenCodeAnalyzer, RooCodeAnalyzer,
+    PiAgentAnalyzer, PiebaldAnalyzer, QwenCodeAnalyzer, RooCodeAnalyzer, ZooCodeAnalyzer,
 };
 
 mod analyzer;
@@ -199,6 +199,7 @@ pub fn create_analyzer_registry() -> AnalyzerRegistry {
     registry.register(ClaudeCodeAnalyzer::new());
     registry.register(ClineAnalyzer::new());
     registry.register(RooCodeAnalyzer::new());
+    registry.register(ZooCodeAnalyzer::new());
     registry.register(KiloCodeAnalyzer::new());
     registry.register(KiloCliAnalyzer::new());
     registry.register(GeminiCliAnalyzer::new());

--- a/src/types.rs
+++ b/src/types.rs
@@ -214,6 +214,7 @@ pub enum Application {
     CodexCli,
     Cline,
     RooCode,
+    ZooCode,
     KiloCode,
     KiloCli,
     Copilot,


### PR DESCRIPTION
## Why

Zoo Code is a community-maintained fork of Roo Code, but it uses the distinct VS Code extension storage ID `zoocodeorganization.zoo-code`. Splitrail's Roo Code analyzer only discovers `rooveterinaryinc.roo-cline`, so new Zoo Code sessions are not found even though their task files retain the Roo-compatible format.

Zoo Code should be tracked independently so usage is discovered from its own storage namespace and attributed accurately in statistics, uploads, and MCP queries.

## What changed

- Add a dedicated `ZooCodeAnalyzer` that discovers and watches Zoo Code task directories across supported VS Code variants and platforms.
- Add `Application::ZooCode` and register the analyzer alongside Roo Code.
- Reuse the Roo-compatible task parser while parameterizing application attribution, avoiding duplicate parsing logic.
- Add focused coverage for the Zoo extension ID, analyzer discovery, empty statistics, model and session extraction, token/cache accounting, cost, and Zoo Code attribution.

## Validation

- `cargo test --quiet zoo_code` — 6 passed
- `cargo build --quiet`
- `cargo test --quiet` — 389 passed
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet -- --check`

## Documentation

The supported-tools README update is intentionally handled separately by a pending contributor change.
