### PR TITLE
Include Claude Code subagent transcripts

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -775,6 +775,7 @@ impl AnalyzerRegistry {
     pub fn load_messages_for_upload(
         &self,
         last_upload_timestamp: i64,
+        full_reload_messages: Option<(String, Vec<ConversationMessage>)>,
     ) -> Result<Vec<ConversationMessage>> {
         if self.dirty_files_for_upload.is_empty() {
             return Ok(Vec::new());
@@ -784,6 +785,10 @@ impl AnalyzerRegistry {
         // cross-source ownership must load their complete canonical message set.
         let mut all_messages = Vec::with_capacity(4);
         let mut fully_loaded_analyzers = HashSet::new();
+        if let Some((analyzer_name, messages)) = full_reload_messages {
+            fully_loaded_analyzers.insert(analyzer_name);
+            all_messages.extend(messages);
+        }
         for entry in self.dirty_files_for_upload.iter() {
             let (path, analyzer_name) = entry.pair();
             if let Some(analyzer) = self.get_analyzer_by_display_name(analyzer_name) {
@@ -1230,7 +1235,7 @@ mod tests {
         let registry = AnalyzerRegistry::new();
 
         // No analyzers, no dirty files - should return empty
-        let messages = registry.load_messages_for_upload(0).expect("load");
+        let messages = registry.load_messages_for_upload(0, None).expect("load");
         assert!(messages.is_empty());
     }
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use dashmap::DashMap;
 use rayon::prelude::*;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use walkdir::WalkDir;
@@ -242,6 +242,12 @@ pub trait Analyzer: Send + Sync {
     /// Remove analyzer-owned persistent state for a source that was deleted.
     fn remove_source_state(&self, _path: &Path) -> Result<()> {
         Ok(())
+    }
+
+    /// Whether a source change can alter contributions owned by other source paths.
+    /// Analyzers with cross-source deduplication require an analyzer-wide cache rebuild.
+    fn requires_full_reload_for_source_change(&self) -> bool {
+        false
     }
 
     /// Get stats with pre-discovered sources (avoids double discovery).
@@ -653,10 +659,12 @@ impl AnalyzerRegistry {
         Ok(())
     }
 
-    /// Remove a file from the cache and update the view (for file deletion events).
-    /// Returns true if the file was found and removed.
-    /// Also marks the file as dirty for upload if it was in the cache.
-    pub fn remove_file_from_cache(&self, analyzer_name: &str, path: &std::path::Path) -> bool {
+    pub fn requires_full_reload_for_source_change(&self, analyzer_name: &str) -> bool {
+        self.get_analyzer_by_display_name(analyzer_name)
+            .is_some_and(Analyzer::requires_full_reload_for_source_change)
+    }
+
+    pub fn remove_source_state(&self, analyzer_name: &str, path: &std::path::Path) {
         if let Some(analyzer) = self.get_analyzer_by_display_name(analyzer_name)
             && let Err(error) = analyzer.remove_source_state(path)
         {
@@ -667,6 +675,13 @@ impl AnalyzerRegistry {
                 error
             );
         }
+    }
+
+    /// Remove a file from the cache and update the view (for file deletion events).
+    /// Returns true if the file was found and removed.
+    /// Also marks the file as dirty for upload if it was in the cache.
+    pub fn remove_file_from_cache(&self, analyzer_name: &str, path: &std::path::Path) -> bool {
+        self.remove_source_state(analyzer_name, path);
 
         let path_hash = PathHash::new(path);
 
@@ -765,14 +780,24 @@ impl AnalyzerRegistry {
             return Ok(Vec::new());
         }
 
-        // Parse dirty files sequentially (typically only 1-2 files)
+        // Parse dirty files sequentially (typically only 1-2 files). Analyzers with
+        // cross-source ownership must load their complete canonical message set.
         let mut all_messages = Vec::with_capacity(4);
+        let mut fully_loaded_analyzers = HashSet::new();
         for entry in self.dirty_files_for_upload.iter() {
             let (path, analyzer_name) = entry.pair();
             if let Some(analyzer) = self.get_analyzer_by_display_name(analyzer_name) {
-                let source = DataSource { path: path.clone() };
-                if let Ok(msgs) = analyzer.parse_source(&source) {
-                    all_messages.extend(msgs);
+                if analyzer.requires_full_reload_for_source_change() {
+                    if fully_loaded_analyzers.insert(analyzer_name.clone())
+                        && let Ok(stats) = analyzer.get_stats()
+                    {
+                        all_messages.extend(stats.messages);
+                    }
+                } else {
+                    let source = DataSource { path: path.clone() };
+                    if let Ok(msgs) = analyzer.parse_source(&source) {
+                        all_messages.extend(msgs);
+                    }
                 }
             }
         }

--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::analyzer::{Analyzer, DataSource};
 use crate::contribution_cache::ContributionStrategy;
@@ -24,18 +25,59 @@ type ParseResult = (
     Option<String>,
 );
 
-pub struct ClaudeCodeAnalyzer;
+pub struct ClaudeCodeAnalyzer {
+    discovery_was_complete: AtomicBool,
+}
 
 impl ClaudeCodeAnalyzer {
     pub fn new() -> Self {
-        Self
+        Self {
+            discovery_was_complete: AtomicBool::new(true),
+        }
     }
 
     fn data_dir() -> Option<PathBuf> {
         dirs::home_dir().map(|h| h.join(".claude").join("projects"))
     }
 
-    fn parse_live_source(source: &DataSource) -> Result<Vec<ConversationMessage>> {
+    pub(crate) fn discover_sources_in(&self, projects_dir: &Path) -> Vec<DataSource> {
+        let mut sources = Vec::new();
+        let mut complete = true;
+        for entry in WalkDir::new(projects_dir)
+            .min_depth(2)
+            .into_iter()
+            .filter_entry(|entry| is_claude_transcript_tree_path(projects_dir, entry.path()))
+        {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    complete = false;
+                    crate::utils::warn_once(format!(
+                        "Skipping unreadable Claude Code transcript path: {error}"
+                    ));
+                    continue;
+                }
+            };
+            if entry.file_type().is_file() && is_claude_transcript_path(projects_dir, entry.path())
+            {
+                sources.push(DataSource {
+                    path: entry.into_path(),
+                });
+            }
+        }
+        self.discovery_was_complete
+            .store(complete, Ordering::Release);
+        sources.sort_by(|left, right| {
+            left.path
+                .components()
+                .count()
+                .cmp(&right.path.components().count())
+                .then_with(|| left.path.cmp(&right.path))
+        });
+        sources
+    }
+
+    pub(crate) fn parse_live_source(source: &DataSource) -> Result<Vec<ConversationMessage>> {
         let project_hash = extract_and_hash_project_id(&source.path);
         let conversation_hash = crate::utils::hash_text(&source.path.to_string_lossy());
         let file = File::open(&source.path)?;
@@ -69,29 +111,19 @@ impl Analyzer for ClaudeCodeAnalyzer {
         if let Some(home_dir) = dirs::home_dir() {
             let home_str = home_dir.to_string_lossy();
             patterns.push(format!("{home_str}/.claude/projects/*/*.jsonl"));
+            patterns.push(format!(
+                "{home_str}/.claude/projects/*/*/subagents/**/*.jsonl"
+            ));
         }
 
         patterns
     }
 
     fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
-        let sources = Self::data_dir()
-            .filter(|d| d.is_dir())
-            .into_iter()
-            .flat_map(|projects_dir| {
-                WalkDir::new(projects_dir)
-                    .min_depth(2)
-                    .max_depth(2)
-                    .into_iter()
-            })
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "jsonl"))
-            .map(|e| DataSource {
-                path: e.into_path(),
-            })
-            .collect();
-
-        Ok(sources)
+        Ok(Self::data_dir()
+            .filter(|directory| directory.is_dir())
+            .map(|projects_dir| self.discover_sources_in(&projects_dir))
+            .unwrap_or_default())
     }
 
     fn parse_source(&self, source: &DataSource) -> Result<Vec<ConversationMessage>> {
@@ -121,10 +153,10 @@ impl Analyzer for ClaudeCodeAnalyzer {
                 }
             })
             .collect();
-        super::claude_code_history::merge_grouped(grouped)
-            .into_iter()
-            .map(|(path, messages)| (path, deduplicate_messages(messages)))
-            .collect()
+        deduplicate_grouped_messages(super::claude_code_history::merge_grouped(
+            grouped,
+            self.discovery_was_complete.load(Ordering::Acquire),
+        ))
     }
 
     // Claude Code has complex cross-file deduplication, so we override get_stats_with_sources
@@ -169,40 +201,76 @@ impl Analyzer for ClaudeCodeAnalyzer {
     }
 
     fn is_valid_data_path(&self, path: &Path) -> bool {
-        // Must be a .jsonl file at depth 2 from projects dir
-        if !path.is_file() || path.extension().is_none_or(|ext| ext != "jsonl") {
-            return false;
-        }
-        if let Some(data_dir) = Self::data_dir()
-            && let Ok(relative) = path.strip_prefix(&data_dir)
-        {
-            return relative.components().count() == 2;
-        }
-        false
+        path.is_file()
+            && Self::data_dir()
+                .is_some_and(|projects_dir| is_claude_transcript_path(&projects_dir, path))
     }
 
     fn is_available(&self) -> bool {
         Self::data_dir()
-            .filter(|d| d.is_dir())
-            .into_iter()
-            .flat_map(|projects_dir| {
-                WalkDir::new(projects_dir)
-                    .min_depth(2)
-                    .max_depth(2)
-                    .into_iter()
-            })
-            .filter_map(|e| e.ok())
-            .any(|e| e.path().extension().is_some_and(|ext| ext == "jsonl"))
+            .filter(|directory| directory.is_dir())
+            .is_some_and(|projects_dir| !self.discover_sources_in(&projects_dir).is_empty())
     }
 
     fn contribution_strategy(&self) -> ContributionStrategy {
         ContributionStrategy::SingleSession
+    }
+
+    fn requires_full_reload_for_source_change(&self) -> bool {
+        true
     }
 }
 
 // Claude Code specific implementation functions
 
 type DedupEntry = (usize, ConversationMessage, HashSet<TokenFingerprint>);
+
+pub(crate) fn deduplicate_grouped_messages(
+    grouped: Vec<(PathBuf, Vec<ConversationMessage>)>,
+) -> Vec<(PathBuf, Vec<ConversationMessage>)> {
+    let mut result: Vec<_> = grouped
+        .iter()
+        .map(|(path, _)| (path.clone(), Vec::new()))
+        .collect();
+    let mut deduplicated: HashMap<String, (usize, usize, HashSet<TokenFingerprint>)> =
+        HashMap::new();
+
+    for (source_index, (_, messages)) in grouped.into_iter().enumerate() {
+        for message in messages {
+            let Some(local_hash) = message.local_hash.clone() else {
+                result[source_index].1.push(message);
+                continue;
+            };
+            let fingerprint = (
+                message.stats.input_tokens,
+                message.stats.output_tokens,
+                message.stats.cache_creation_tokens,
+                message.stats.cache_read_tokens,
+                message.stats.cached_tokens,
+            );
+
+            if let Some((owner_source, owner_message, seen_fingerprints)) =
+                deduplicated.get_mut(&local_hash)
+            {
+                merge_message_into(
+                    &mut result[*owner_source].1[*owner_message],
+                    &message,
+                    seen_fingerprints,
+                    fingerprint,
+                );
+            } else {
+                let owner_message = result[source_index].1.len();
+                result[source_index].1.push(message);
+                deduplicated.insert(
+                    local_hash,
+                    (source_index, owner_message, HashSet::from([fingerprint])),
+                );
+            }
+        }
+    }
+
+    result
+}
 
 pub(crate) fn deduplicate_messages(messages: Vec<ConversationMessage>) -> Vec<ConversationMessage> {
     let mut dedup_map: HashMap<String, DedupEntry> = HashMap::with_capacity(messages.len());
@@ -241,18 +309,40 @@ pub(crate) fn deduplicate_messages(messages: Vec<ConversationMessage>) -> Vec<Co
     result.into_iter().map(|(_, message)| message).collect()
 }
 
+fn is_claude_transcript_tree_path(projects_dir: &Path, path: &Path) -> bool {
+    let Ok(relative) = path.strip_prefix(projects_dir) else {
+        return false;
+    };
+    let components: Vec<_> = relative.components().collect();
+
+    matches!(components.as_slice(), [] | [_] | [_, _])
+        || matches!(components.as_slice(), [_, _, subagents, ..] if subagents.as_os_str() == "subagents")
+}
+
+pub(crate) fn is_claude_transcript_path(projects_dir: &Path, path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|extension| extension == "jsonl")
+        && is_claude_transcript_tree_path(projects_dir, path)
+        && path
+            .strip_prefix(projects_dir)
+            .is_ok_and(|relative| relative.components().count() >= 2)
+}
+
 // Helper function to extract project ID from Claude Code file path and hash it
 pub fn extract_and_hash_project_id(file_path: &Path) -> String {
-    // Claude Code path format: ~/.claude/projects/{PROJECT_ID}/{conversation_uuid}.jsonl
+    // Claude Code path formats:
+    // ~/.claude/projects/{PROJECT_ID}/{conversation_uuid}.jsonl
+    // ~/.claude/projects/{PROJECT_ID}/{conversation_uuid}/subagents/**/agent-{AGENT_ID}.jsonl
+    let components: Vec<_> = file_path.components().collect();
+    let project_id = components.windows(3).find_map(|components| {
+        (components[0].as_os_str() == ".claude" && components[1].as_os_str() == "projects")
+            .then(|| components[2].as_os_str().to_str())
+            .flatten()
+    });
 
-    if let Some(parent) = file_path.parent()
-        && let Some(project_id) = parent.file_name().and_then(|name| name.to_str())
-    {
-        return hash_text(project_id);
-    }
-
-    // Fallback: hash the full file path if we can't extract project ID
-    hash_text(&file_path.to_string_lossy())
+    project_id
+        .map(hash_text)
+        .unwrap_or_else(|| hash_text(&file_path.to_string_lossy()))
 }
 
 // CLAUDE CODE JSONL FILES SCHEMA

--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -30,6 +30,8 @@ pub struct ClaudeCodeAnalyzer {
 }
 
 impl ClaudeCodeAnalyzer {
+    pub const DISPLAY_NAME: &str = "Claude Code";
+
     pub fn new() -> Self {
         Self {
             discovery_was_complete: AtomicBool::new(true),
@@ -102,7 +104,7 @@ impl ClaudeCodeAnalyzer {
 #[async_trait]
 impl Analyzer for ClaudeCodeAnalyzer {
     fn display_name(&self) -> &'static str {
-        "Claude Code"
+        Self::DISPLAY_NAME
     }
 
     fn get_data_glob_patterns(&self) -> Vec<String> {
@@ -209,7 +211,19 @@ impl Analyzer for ClaudeCodeAnalyzer {
     fn is_available(&self) -> bool {
         Self::data_dir()
             .filter(|directory| directory.is_dir())
-            .is_some_and(|projects_dir| !self.discover_sources_in(&projects_dir).is_empty())
+            .is_some_and(|projects_dir| {
+                WalkDir::new(&projects_dir)
+                    .min_depth(2)
+                    .into_iter()
+                    .filter_entry(|entry| {
+                        is_claude_transcript_tree_path(&projects_dir, entry.path())
+                    })
+                    .filter_map(Result::ok)
+                    .any(|entry| {
+                        entry.file_type().is_file()
+                            && is_claude_transcript_path(&projects_dir, entry.path())
+                    })
+            })
     }
 
     fn contribution_strategy(&self) -> ContributionStrategy {

--- a/src/analyzers/claude_code_history.rs
+++ b/src/analyzers/claude_code_history.rs
@@ -51,6 +51,7 @@ pub(crate) fn remove_session(conversation_hash: &str) -> Result<()> {
 
 pub(crate) fn merge_grouped(
     grouped: Vec<(PathBuf, Vec<ConversationMessage>)>,
+    prune_missing: bool,
 ) -> Vec<(PathBuf, Vec<ConversationMessage>)> {
     let path = match history_path() {
         Ok(path) => path,
@@ -65,7 +66,7 @@ pub(crate) fn merge_grouped(
         .collect();
 
     let mut grouped = grouped;
-    if let Err(error) = merge_at(&path, &mut grouped, &conversation_hashes, true) {
+    if let Err(error) = merge_at(&path, &mut grouped, &conversation_hashes, prune_missing) {
         warn_history_error("update", Some(&path), &error);
     }
     grouped

--- a/src/analyzers/tests/claude_code.rs
+++ b/src/analyzers/tests/claude_code.rs
@@ -1,11 +1,14 @@
+use crate::analyzer::{Analyzer, DataSource};
 use crate::analyzers::claude_code::{
-    TokenFingerprint, calculate_cost_from_tokens, deduplicate_messages,
-    extract_and_hash_project_id, merge_message_into, parse_jsonl_file,
+    ClaudeCodeAnalyzer, TokenFingerprint, calculate_cost_from_tokens, deduplicate_grouped_messages,
+    deduplicate_messages, extract_and_hash_project_id, is_claude_transcript_path,
+    merge_message_into, parse_jsonl_file,
 };
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use chrono::{TimeZone, Utc};
 use simd_json::json;
 use std::collections::{HashMap, HashSet};
+use std::fs;
 use std::io::{BufReader, Cursor};
 use std::path::Path;
 use std::sync::LazyLock;
@@ -184,18 +187,157 @@ fn test_extract_and_hash_project_id() {
     let path1 = Path::new("/home/user/.claude/projects/proj123/conversation.jsonl");
     let path2 = Path::new("/home/user/.claude/projects/proj123/other.jsonl");
     let path3 = Path::new("/home/user/.claude/projects/proj456/conversation.jsonl");
+    let subagent = Path::new(
+        "/home/user/.claude/projects/proj123/conversation/subagents/nested/agent-1.jsonl",
+    );
+    let nested_projects = Path::new(
+        "/home/user/.claude/projects/proj123/conversation/subagents/cache/projects/agent-2.jsonl",
+    );
 
     let hash1 = extract_and_hash_project_id(path1);
     let hash2 = extract_and_hash_project_id(path2);
     let hash3 = extract_and_hash_project_id(path3);
+    let subagent_hash = extract_and_hash_project_id(subagent);
+    let nested_projects_hash = extract_and_hash_project_id(nested_projects);
 
-    // Same project should have same hash
+    // Main and subagent transcripts under the same project should share a project hash.
     assert_eq!(hash1, hash2);
-    // Different projects should have different hashes
+    assert_eq!(hash1, subagent_hash);
+    assert_eq!(hash1, nested_projects_hash);
+    // Different projects should have different hashes.
     assert_ne!(hash1, hash3);
-    // Hashes should not be empty
+    // Hashes should not be empty.
     assert!(!hash1.is_empty());
     assert!(!hash3.is_empty());
+}
+
+#[test]
+fn test_claude_transcript_path_classification() {
+    let projects = Path::new("/home/user/.claude/projects");
+
+    assert!(is_claude_transcript_path(
+        projects,
+        &projects.join("project/session.jsonl")
+    ));
+    assert!(is_claude_transcript_path(
+        projects,
+        &projects.join("project/session/subagents/agent-1.jsonl")
+    ));
+    assert!(is_claude_transcript_path(
+        projects,
+        &projects.join("project/session/subagents/nested/agent-2.jsonl")
+    ));
+
+    assert!(!is_claude_transcript_path(
+        projects,
+        &projects.join("project/session/subagents/agent-1.meta.json")
+    ));
+    assert!(!is_claude_transcript_path(
+        projects,
+        &projects.join("project/session/other/agent-1.jsonl")
+    ));
+    assert!(!is_claude_transcript_path(
+        projects,
+        &projects.join("project/session.jsonl/extra.jsonl")
+    ));
+}
+
+#[test]
+fn test_claude_discovery_includes_subagent_transcripts() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let projects = temp_dir.path().join("projects");
+    let project = projects.join("project");
+    let nested_subagents = project.join("session/subagents/nested");
+    let unrelated = project.join("session/other");
+    fs::create_dir_all(&nested_subagents).unwrap();
+    fs::create_dir_all(&unrelated).unwrap();
+
+    let main = project.join("session.jsonl");
+    let subagent = nested_subagents.join("agent-1.jsonl");
+    let metadata = nested_subagents.join("agent-1.meta.json");
+    let unrelated_jsonl = unrelated.join("agent-2.jsonl");
+    for path in [&main, &subagent, &metadata, &unrelated_jsonl] {
+        fs::write(path, "").unwrap();
+    }
+
+    let paths: Vec<_> = ClaudeCodeAnalyzer::new()
+        .discover_sources_in(&projects)
+        .into_iter()
+        .map(|source| source.path)
+        .collect();
+
+    // Main transcripts own duplicate accounting records before nested subagent sources.
+    assert_eq!(paths, vec![main, subagent]);
+}
+
+#[test]
+fn test_claude_glob_patterns_include_subagent_transcripts() {
+    let analyzer = ClaudeCodeAnalyzer::new();
+    let patterns = analyzer.get_data_glob_patterns();
+
+    assert!(analyzer.requires_full_reload_for_source_change());
+
+    assert!(
+        patterns
+            .iter()
+            .any(|pattern| pattern.ends_with("*/*.jsonl"))
+    );
+    assert!(
+        patterns
+            .iter()
+            .any(|pattern| pattern.ends_with("*/*/subagents/**/*.jsonl"))
+    );
+}
+
+#[test]
+fn test_main_and_subagent_transcripts_add_unique_usage_without_duplicate_inflation() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let project = temp_dir.path().join(".claude/projects/project");
+    let main = project.join("session.jsonl");
+    let subagent = project.join("session/subagents/agent-1.jsonl");
+    fs::create_dir_all(subagent.parent().unwrap()).unwrap();
+
+    let duplicate = r#"{"parentUuid":null,"isSidechain":false,"sessionId":"session","message":{"id":"msg-shared","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":20}},"requestId":"req-shared","type":"assistant","uuid":"main-uuid","timestamp":"2025-08-02T15:00:00.000Z"}"#;
+    let duplicate_from_subagent = r#"{"parentUuid":null,"isSidechain":true,"sessionId":"session","agentId":"agent-1","message":{"id":"msg-shared","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"usage":{"input_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":20}},"requestId":"req-shared","type":"assistant","uuid":"subagent-duplicate-uuid","timestamp":"2025-08-02T15:00:00.000Z"}"#;
+    let unique_subagent = r#"{"parentUuid":null,"isSidechain":true,"sessionId":"session","agentId":"agent-1","message":{"id":"msg-unique","role":"assistant","model":"claude-haiku-4-5-20251001","content":[],"usage":{"input_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":7}},"requestId":"req-unique","type":"assistant","uuid":"subagent-unique-uuid","timestamp":"2025-08-02T15:01:00.000Z"}"#;
+    fs::write(&main, duplicate).unwrap();
+    fs::write(
+        &subagent,
+        format!("{duplicate_from_subagent}\n{unique_subagent}"),
+    )
+    .unwrap();
+
+    let grouped = deduplicate_grouped_messages(
+        [&main, &subagent]
+            .into_iter()
+            .map(|path| {
+                (
+                    path.to_path_buf(),
+                    ClaudeCodeAnalyzer::parse_live_source(&DataSource {
+                        path: path.to_path_buf(),
+                    })
+                    .unwrap(),
+                )
+            })
+            .collect(),
+    );
+    let messages: Vec<_> = grouped.iter().flat_map(|(_, messages)| messages).collect();
+
+    assert_eq!(grouped[0].1.len(), 1);
+    assert_eq!(grouped[1].1.len(), 1);
+    assert_eq!(messages.len(), 2);
+    assert_eq!(
+        messages
+            .iter()
+            .map(|message| message.stats.output_tokens)
+            .sum::<u64>(),
+        27
+    );
+    assert!(
+        messages
+            .iter()
+            .all(|message| { message.project_hash == extract_and_hash_project_id(&main) })
+    );
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,9 @@ pub struct UploadState {
     /// Timestamp (milliseconds since Unix epoch) of the last successfully uploaded message.
     /// Used to filter out already-uploaded messages on the next run.
     pub last_date_uploaded: i64,
+    /// Whether Claude transcripts were uploaded after subagent discovery was introduced.
+    #[serde(default)]
+    pub claude_subagent_backfill_completed: bool,
 }
 
 fn default_currency_symbol() -> String {
@@ -312,7 +315,10 @@ impl UploadState {
         Ok(legacy
             .upload
             .last_date_uploaded
-            .map(|last_date_uploaded| Self { last_date_uploaded }))
+            .map(|last_date_uploaded| Self {
+                last_date_uploaded,
+                ..Self::default()
+            }))
     }
 }
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -524,7 +524,10 @@ pub async fn perform_background_upload(
         let mut all_messages = Vec::new();
         let backfill_claude = !upload_state.claude_subagent_backfill_completed;
         for analyzer_stats in stats.analyzer_stats {
-            if backfill_claude && analyzer_stats.analyzer_name == "Claude Code" {
+            if backfill_claude
+                && analyzer_stats.analyzer_name
+                    == crate::analyzers::claude_code::ClaudeCodeAnalyzer::DISPLAY_NAME
+            {
                 all_messages.extend(analyzer_stats.messages);
             } else {
                 all_messages.extend(

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -248,11 +248,9 @@ fn save_chunk_progress(
     // uses >=) doesn't re-include this exact message.
     if let Some(last_msg) = sorted_messages.get(messages_processed - 1) {
         let checkpoint = last_msg.date.timestamp_millis() + 1;
-        if let Err(e) = (UploadState {
-            last_date_uploaded: checkpoint,
-        })
-        .save()
-        {
+        let mut state = UploadState::load().unwrap_or_default();
+        state.last_date_uploaded = state.last_date_uploaded.max(checkpoint);
+        if let Err(e) = state.save() {
             if upload_debug {
                 upload_debug_log(format!(
                     "[splitrail upload] warning: failed to save chunk progress: {e:#}"
@@ -515,29 +513,47 @@ pub async fn perform_background_upload(
             return None;
         }
 
-        let last_date_uploaded = match UploadState::load() {
-            Ok(state) => state.last_date_uploaded,
+        let upload_state = match UploadState::load() {
+            Ok(state) => state,
             Err(e) => {
                 eprintln!("Failed to load upload state: {e:#}");
                 return None;
             }
         };
 
-        let all_messages: Vec<_> = stats
-            .analyzer_stats
-            .into_iter()
-            .flat_map(|s| s.messages)
-            .collect();
+        let mut all_messages = Vec::new();
+        let backfill_claude = !upload_state.claude_subagent_backfill_completed;
+        for analyzer_stats in stats.analyzer_stats {
+            if backfill_claude && analyzer_stats.analyzer_name == "Claude Code" {
+                all_messages.extend(analyzer_stats.messages);
+            } else {
+                all_messages.extend(
+                    utils::get_messages_later_than(
+                        upload_state.last_date_uploaded,
+                        analyzer_stats.messages,
+                    )
+                    .await
+                    .ok()?,
+                );
+            }
+        }
 
-        utils::get_messages_later_than(last_date_uploaded, all_messages)
-            .await
-            .ok()
+        Some((all_messages, backfill_claude))
     }
     .await;
 
-    if let Some(msgs) = messages {
-        // Delegate to the messages-based upload (no additional delay, no callback)
-        perform_background_upload_messages::<fn()>(msgs, upload_status, None, None).await;
+    if let Some((msgs, backfilled_claude)) = messages {
+        let backfill_completed = move || {
+            if backfilled_claude {
+                let mut state = UploadState::load().unwrap_or_default();
+                state.claude_subagent_backfill_completed = true;
+                if let Err(error) = state.save() {
+                    eprintln!("Failed to save Claude Code upload backfill state: {error:#}");
+                }
+            }
+        };
+        perform_background_upload_messages(msgs, upload_status, None, Some(backfill_completed))
+            .await;
     }
 }
 

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -167,21 +167,34 @@ impl RealtimeStatsManager {
     pub async fn handle_watcher_event(&mut self, event: WatcherEvent) -> Result<()> {
         match event {
             WatcherEvent::FileChanged(analyzer_name, path) => {
-                // True incremental update - O(1), only reparses the changed file
-                if self.registry.has_cached_contributions(&analyzer_name) {
+                if self
+                    .registry
+                    .requires_full_reload_for_source_change(&analyzer_name)
+                {
+                    self.registry.mark_file_dirty(&analyzer_name, &path);
+                    self.reload_analyzer_stats(&analyzer_name).await;
+                } else if self.registry.has_cached_contributions(&analyzer_name) {
+                    // True incremental update - O(1), only reparses the changed file.
                     self.reload_single_file_incremental(&analyzer_name, &path)
                         .await;
                 } else {
-                    // Fallback to full reload if cache not populated (shouldn't happen normally)
+                    // Fallback to full reload if cache not populated (shouldn't happen normally).
                     self.reload_analyzer_stats(&analyzer_name).await;
                 }
             }
             WatcherEvent::FileDeleted(analyzer_name, path) => {
-                // Remove file from cache and get updated view
-                if self.registry.remove_file_from_cache(&analyzer_name, &path) {
+                if self
+                    .registry
+                    .requires_full_reload_for_source_change(&analyzer_name)
+                {
+                    self.registry.remove_source_state(&analyzer_name, &path);
+                    self.registry.mark_file_dirty(&analyzer_name, &path);
+                    self.reload_analyzer_stats(&analyzer_name).await;
+                } else if self.registry.remove_file_from_cache(&analyzer_name, &path) {
+                    // Remove file from cache and get updated view.
                     self.apply_view_update().await;
                 } else {
-                    // Fallback to full reload
+                    // Fallback to full reload.
                     self.reload_analyzer_stats(&analyzer_name).await;
                 }
             }

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -192,7 +192,7 @@ impl RealtimeStatsManager {
                     self.reload_analyzer_stats(&analyzer_name).await;
                 } else if self.registry.remove_file_from_cache(&analyzer_name, &path) {
                     // Remove file from cache and get updated view.
-                    self.apply_view_update().await;
+                    self.apply_view_update(None).await;
                 } else {
                     // Fallback to full reload.
                     self.reload_analyzer_stats(&analyzer_name).await;
@@ -212,10 +212,13 @@ impl RealtimeStatsManager {
             // Full parse of all files for this analyzer (sync, no threadpool for incremental)
             match analyzer.get_stats() {
                 Ok(new_stats) => {
+                    let full_reload_messages = analyzer
+                        .requires_full_reload_for_source_change()
+                        .then(|| (analyzer_name.to_string(), new_stats.messages.clone()));
                     // Update the cache with the new view
                     self.registry
                         .update_cached_view(analyzer_name, new_stats.into_view());
-                    self.apply_view_update().await;
+                    self.apply_view_update(full_reload_messages).await;
                 }
                 Err(e) => {
                     eprintln!("Error reloading {analyzer_name} stats: {e}");
@@ -229,7 +232,7 @@ impl RealtimeStatsManager {
         // True incremental update - subtract old, add new (sync, no threadpool for single file)
         match self.registry.reload_file_incremental(analyzer_name, path) {
             Ok(()) => {
-                self.apply_view_update().await;
+                self.apply_view_update(None).await;
             }
             Err(e) => {
                 eprintln!("Error in incremental reload for {analyzer_name}: {e}");
@@ -241,7 +244,10 @@ impl RealtimeStatsManager {
 
     /// Broadcast the current cache state to listeners.
     /// The view is already updated in place via RwLock; we just rebuild and broadcast.
-    async fn apply_view_update(&mut self) {
+    async fn apply_view_update(
+        &mut self,
+        full_reload_messages: Option<(String, Vec<crate::types::ConversationMessage>)>,
+    ) {
         // Build fresh MultiAnalyzerStatsView from cache - just clones Arc pointers
         let stats = MultiAnalyzerStatsView {
             analyzer_stats: self.registry.get_all_cached_views(),
@@ -251,10 +257,14 @@ impl RealtimeStatsManager {
         let _ = self.update_tx.send(stats);
 
         // Trigger auto-upload if enabled and debounce time has passed
-        self.trigger_auto_upload_if_enabled().await;
+        self.trigger_auto_upload_if_enabled(full_reload_messages)
+            .await;
     }
 
-    async fn trigger_auto_upload_if_enabled(&mut self) {
+    async fn trigger_auto_upload_if_enabled(
+        &mut self,
+        full_reload_messages: Option<(String, Vec<crate::types::ConversationMessage>)>,
+    ) {
         // Check if auto-upload is enabled
         match Config::load() {
             Ok(Some(cfg)) if cfg.upload.auto_upload && cfg.is_configured() => {}
@@ -295,7 +305,10 @@ impl RealtimeStatsManager {
 
         // For incremental upload, load only changed/new messages
         // This avoids loading all historical data into memory
-        let messages = match self.registry.load_messages_for_upload(last_date_uploaded) {
+        let messages = match self
+            .registry
+            .load_messages_for_upload(last_date_uploaded, full_reload_messages)
+        {
             Ok(msgs) => msgs,
             Err(_) => {
                 *self.upload_in_progress.lock() = false;


### PR DESCRIPTION
## Why

Claude Code writes Task, Explore, general-purpose, and custom-agent transcripts beneath `~/.claude/projects/<project>/<session>/subagents/**`. Splitrail only discovered main transcripts at `~/.claude/projects/<project>/<session>.jsonl`, so subagent-heavy workflows could omit most Claude messages and token usage from local statistics, live TUI updates, uploads, and leaderboard totals.

Simply lifting the directory-depth cap is insufficient. Main and subagent transcripts can repeat the same Claude response, while Splitrail's TUI cache and incremental upload paths calculate per-source contributions. Those paths need the same cross-file `local_hash` and token-fingerprint semantics as complete CLI statistics or the newly discovered files can inflate totals.

## What changed

- Discover main Claude transcripts plus JSONL files under `<project>/<session>/subagents/**`, while rejecting metadata and unrelated nested JSONL formats.
- Use the same transcript classifier for cold-start discovery, availability checks, watcher validation, and advertised glob patterns.
- Prune unrelated directory trees during recursive discovery and preserve readable sources when an individual path cannot be traversed.
- Keep SQLite history pruning disabled after an incomplete discovery so a transient unreadable subtree cannot erase retained usage.
- Derive nested transcript project identity from the top-level Claude project slug.
- Order main transcripts before subagent sources and assign canonical, deduplicated messages to one source before constructing TUI contributions.
- Preserve Claude's existing deduplication behavior: merge shared `local_hash` records, accumulate distinct token fingerprints once, and keep records without a `local_hash` independent.
- Rebuild Claude's analyzer-wide view after watched source changes because one file can affect cross-source message ownership.
- Load the complete canonical Claude message set for incremental uploads instead of deduplicating dirty files in isolation.
- Add a success-gated, one-time Claude upload backfill so existing users receive historical subagent usage that predates `last_date_uploaded`; preserve monotonic upload checkpoints and retry the backfill after failures.
- Add regression coverage for path classification, recursive discovery, project identity, deterministic source ownership, and main/subagent token accounting.

## User impact

Claude Code users who rely on subagents will see previously omitted usage appear after upgrading. Local totals should increase to include subagent work without double-counting responses repeated in main transcripts. Existing configured Cloud users will perform one canonical Claude history backfill; stable message hashes allow already-uploaded records to be deduplicated server-side.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` — 393 passed
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claude Code usage tracking now discovers transcripts from nested subagent sessions.
  - Subagent activity is included in project usage totals.

- **Bug Fixes**
  - Prevented duplicate transcript records from inflating token and usage totals.
  - Improved project identification across main and nested subagent transcripts.
  - File changes and deletions now update statistics more reliably, including cases requiring a full refresh.
  - Upload progress and backfill state are preserved more safely across updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->