### PR TITLE
fix(codex): include archived sessions in usage stats

### DIFF
--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -4,6 +4,7 @@ use chrono::{DateTime, Utc};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -57,9 +58,73 @@ impl CodexCliAnalyzer {
         Self
     }
 
-    fn data_dir() -> Option<PathBuf> {
-        dirs::home_dir().map(|h| h.join(".codex").join("sessions"))
+    fn data_dirs() -> Vec<PathBuf> {
+        data_dirs_with_home(dirs::home_dir())
     }
+}
+
+pub(crate) fn data_dirs_with_home(home_dir: Option<PathBuf>) -> Vec<PathBuf> {
+    home_dir
+        .map(|home| {
+            let codex_dir = home.join(".codex");
+            vec![
+                codex_dir.join("sessions"),
+                codex_dir.join("archived_sessions"),
+            ]
+        })
+        .unwrap_or_default()
+}
+
+pub(crate) fn canonical_session_path(file_path: &Path) -> PathBuf {
+    let Some(archive_dir) = file_path
+        .ancestors()
+        .find(|path| path.file_name() == Some(OsStr::new("archived_sessions")))
+    else {
+        return file_path.to_path_buf();
+    };
+    let Some(codex_dir) = archive_dir.parent() else {
+        return file_path.to_path_buf();
+    };
+    let Some(file_name) = file_path.file_name().and_then(|name| name.to_str()) else {
+        return file_path.to_path_buf();
+    };
+    let Some(date) = file_name
+        .strip_prefix("rollout-")
+        .and_then(|rest| rest.get(..10))
+        .and_then(|date| chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d").ok())
+    else {
+        return file_path.to_path_buf();
+    };
+
+    codex_dir
+        .join("sessions")
+        .join(date.format("%Y").to_string())
+        .join(date.format("%m").to_string())
+        .join(date.format("%d").to_string())
+        .join(file_name)
+}
+
+pub(crate) fn discover_data_sources_in(
+    data_dirs: impl IntoIterator<Item = PathBuf>,
+) -> Vec<DataSource> {
+    let mut seen_sessions = HashSet::new();
+    data_dirs
+        .into_iter()
+        .filter(|dir| dir.is_dir())
+        .flat_map(|dir| WalkDir::new(dir).into_iter())
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| {
+            entry.file_type().is_file()
+                && entry
+                    .path()
+                    .extension()
+                    .is_some_and(|extension| extension == "jsonl")
+        })
+        .filter(|entry| seen_sessions.insert(canonical_session_path(entry.path())))
+        .map(|entry| DataSource {
+            path: entry.into_path(),
+        })
+        .collect()
 }
 
 #[async_trait]
@@ -74,32 +139,20 @@ impl Analyzer for CodexCliAnalyzer {
         if let Some(home_dir) = dirs::home_dir() {
             let home_str = home_dir.to_string_lossy();
             patterns.push(format!("{home_str}/.codex/sessions/**/*.jsonl"));
+            patterns.push(format!("{home_str}/.codex/archived_sessions/**/*.jsonl"));
         }
 
         patterns
     }
 
     fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
-        let sources = Self::data_dir()
-            .filter(|d| d.is_dir())
-            .into_iter()
-            .flat_map(|dir| WalkDir::new(dir).into_iter())
-            .filter_map(|e| e.ok())
-            .filter(|e| {
-                e.file_type().is_file() && e.path().extension().is_some_and(|ext| ext == "jsonl")
-            })
-            .map(|e| DataSource {
-                path: e.into_path(),
-            })
-            .collect();
-
-        Ok(sources)
+        Ok(discover_data_sources_in(Self::data_dirs()))
     }
 
     fn is_available(&self) -> bool {
-        Self::data_dir()
-            .filter(|d| d.is_dir())
+        Self::data_dirs()
             .into_iter()
+            .filter(|d| d.is_dir())
             .flat_map(|dir| WalkDir::new(dir).into_iter())
             .filter_map(|e| e.ok())
             .any(|e| {
@@ -121,14 +174,14 @@ impl Analyzer for CodexCliAnalyzer {
     }
 
     fn get_watch_directories(&self) -> Vec<PathBuf> {
-        Self::data_dir()
-            .filter(|d| d.is_dir())
+        Self::data_dirs()
             .into_iter()
+            .filter(|d| d.is_dir())
             .collect()
     }
 
     fn is_valid_data_path(&self, path: &Path) -> bool {
-        // Must be a .jsonl file under sessions directory
+        // Must be a .jsonl file under one of the watched Codex data directories.
         path.is_file() && path.extension().is_some_and(|ext| ext == "jsonl")
     }
 
@@ -248,6 +301,9 @@ pub(crate) fn parse_codex_cli_jsonl_file(
     // Pre-allocate for typical session sizes
     let mut entries = Vec::with_capacity(100);
     let file_path_str = file_path.to_string_lossy().into_owned();
+    let session_path_str = canonical_session_path(file_path)
+        .to_string_lossy()
+        .into_owned();
 
     let mut file = File::open(file_path)?;
 
@@ -401,12 +457,12 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                                 date: wrapper.timestamp,
                                 global_hash: hash_text(&format!(
                                     "{}_{}_user_{}",
-                                    file_path_str,
+                                    session_path_str,
                                     wrapper.timestamp.to_rfc3339(),
                                     entries.len()
                                 )),
                                 local_hash: None,
-                                conversation_hash: hash_text(&file_path_str),
+                                conversation_hash: hash_text(&session_path_str),
                                 application: Application::CodexCli,
                                 project_hash: "".to_string(),
                                 model: None,
@@ -438,12 +494,12 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                                 model: Some(model_state.name.clone()),
                                 global_hash: hash_text(&format!(
                                     "{}_{}_assistant_{}",
-                                    file_path_str,
+                                    session_path_str,
                                     wrapper.timestamp.to_rfc3339(),
                                     entries.len()
                                 )),
                                 local_hash: None,
-                                conversation_hash: hash_text(&file_path_str),
+                                conversation_hash: hash_text(&session_path_str),
                                 date: wrapper.timestamp,
                                 project_hash: "".to_string(),
                                 stats: Stats::default(),
@@ -506,12 +562,12 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                                 model: Some(model_state.name.clone()),
                                 global_hash: hash_text(&format!(
                                     "{}_{}_token_{}",
-                                    file_path_str,
+                                    session_path_str,
                                     wrapper.timestamp.to_rfc3339(),
                                     entries.len()
                                 )),
                                 local_hash: None,
-                                conversation_hash: hash_text(&file_path_str),
+                                conversation_hash: hash_text(&session_path_str),
                                 date: wrapper.timestamp,
                                 project_hash: "".to_string(),
                                 stats,

--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -127,6 +127,14 @@ pub(crate) fn discover_data_sources_in(
         .collect()
 }
 
+pub(crate) fn is_valid_data_path_in(path: &Path, data_dirs: &[PathBuf]) -> bool {
+    path.is_file()
+        && path
+            .extension()
+            .is_some_and(|extension| extension == "jsonl")
+        && data_dirs.iter().any(|data_dir| path.starts_with(data_dir))
+}
+
 #[async_trait]
 impl Analyzer for CodexCliAnalyzer {
     fn display_name(&self) -> &'static str {
@@ -182,7 +190,7 @@ impl Analyzer for CodexCliAnalyzer {
 
     fn is_valid_data_path(&self, path: &Path) -> bool {
         // Must be a .jsonl file under one of the watched Codex data directories.
-        path.is_file() && path.extension().is_some_and(|ext| ext == "jsonl")
+        is_valid_data_path_in(path, &Self::data_dirs())
     }
 
     fn contribution_strategy(&self) -> ContributionStrategy {

--- a/src/analyzers/tests/codex_cli.rs
+++ b/src/analyzers/tests/codex_cli.rs
@@ -5,6 +5,89 @@ use crate::analyzer::Analyzer;
 use crate::analyzers::codex_cli::*;
 use crate::models::calculate_total_cost;
 
+const SESSION_FILE_NAME: &str =
+    "rollout-2026-07-22T12-34-56-243232f1-a7ab-44e6-b2c3-045b673746ea.jsonl";
+
+fn write_test_session(path: &std::path::Path) {
+    let content = concat!(
+        r#"{"timestamp":"2026-07-22T12:34:56.000Z","type":"session_meta","payload":{"id":"243232f1-a7ab-44e6-b2c3-045b673746ea","timestamp":"2026-07-22T12:34:56.000Z"}}"#,
+        "\n",
+        r#"{"timestamp":"2026-07-22T12:35:00.000Z","type":"turn_context","payload":{"model":"gpt-5-codex"}}"#,
+        "\n",
+        r#"{"timestamp":"2026-07-22T12:35:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Test archived sessions"}]}}"#,
+        "\n",
+        r#"{"timestamp":"2026-07-22T12:35:02.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5,"total_tokens":150}}}}"#,
+        "\n"
+    );
+    std::fs::write(path, content).unwrap();
+}
+
+#[test]
+fn test_codex_data_dirs_include_active_and_archived_sessions() {
+    let home = std::path::PathBuf::from("/home/test");
+
+    assert_eq!(
+        data_dirs_with_home(Some(home.clone())),
+        vec![
+            home.join(".codex/sessions"),
+            home.join(".codex/archived_sessions")
+        ]
+    );
+}
+
+#[test]
+fn test_archived_session_uses_original_active_path_as_identity() {
+    let home = std::path::PathBuf::from("/home/test");
+    let archived = home
+        .join(".codex/archived_sessions")
+        .join(SESSION_FILE_NAME);
+
+    assert_eq!(
+        canonical_session_path(&archived),
+        home.join(".codex/sessions/2026/07/22")
+            .join(SESSION_FILE_NAME)
+    );
+}
+
+#[test]
+fn test_active_and_archived_copies_are_discovered_once() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let active_dir = temp_dir.path().join(".codex/sessions/2026/07/22");
+    let archived_dir = temp_dir.path().join(".codex/archived_sessions");
+    std::fs::create_dir_all(&active_dir).unwrap();
+    std::fs::create_dir_all(&archived_dir).unwrap();
+    write_test_session(&active_dir.join(SESSION_FILE_NAME));
+    write_test_session(&archived_dir.join(SESSION_FILE_NAME));
+
+    let sources =
+        discover_data_sources_in(vec![temp_dir.path().join(".codex/sessions"), archived_dir]);
+
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].path, active_dir.join(SESSION_FILE_NAME));
+}
+
+#[test]
+fn test_message_hashes_remain_stable_after_archiving() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let active_dir = temp_dir.path().join(".codex/sessions/2026/07/22");
+    let archived_dir = temp_dir.path().join(".codex/archived_sessions");
+    std::fs::create_dir_all(&active_dir).unwrap();
+    std::fs::create_dir_all(&archived_dir).unwrap();
+    let active_path = active_dir.join(SESSION_FILE_NAME);
+    let archived_path = archived_dir.join(SESSION_FILE_NAME);
+    write_test_session(&active_path);
+    write_test_session(&archived_path);
+
+    let (active_messages, _) = parse_codex_cli_jsonl_file(&active_path).unwrap();
+    let (archived_messages, _) = parse_codex_cli_jsonl_file(&archived_path).unwrap();
+
+    assert_eq!(active_messages.len(), archived_messages.len());
+    for (active, archived) in active_messages.iter().zip(&archived_messages) {
+        assert_eq!(active.conversation_hash, archived.conversation_hash);
+        assert_eq!(active.global_hash, archived.global_hash);
+    }
+}
+
 #[test]
 fn test_parse_codex_cli_new_wrapper_format() {
     // Create a temporary file with the new wrapper format

--- a/src/analyzers/tests/codex_cli.rs
+++ b/src/analyzers/tests/codex_cli.rs
@@ -16,6 +16,8 @@ fn write_test_session(path: &std::path::Path) {
         "\n",
         r#"{"timestamp":"2026-07-22T12:35:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Test archived sessions"}]}}"#,
         "\n",
+        r#"{"timestamp":"2026-07-22T12:35:01.500Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Testing hash stability"}]}}"#,
+        "\n",
         r#"{"timestamp":"2026-07-22T12:35:02.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":20,"output_tokens":30,"reasoning_output_tokens":5,"total_tokens":150}}}}"#,
         "\n"
     );
@@ -67,6 +69,23 @@ fn test_active_and_archived_copies_are_discovered_once() {
 }
 
 #[test]
+fn test_valid_codex_data_paths_must_be_inside_watched_directories() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let sessions_dir = temp_dir.path().join(".codex/sessions");
+    let unrelated_dir = temp_dir.path().join("unrelated");
+    std::fs::create_dir_all(&sessions_dir).unwrap();
+    std::fs::create_dir_all(&unrelated_dir).unwrap();
+    let session_path = sessions_dir.join("session.jsonl");
+    let unrelated_path = unrelated_dir.join("session.jsonl");
+    std::fs::write(&session_path, "").unwrap();
+    std::fs::write(&unrelated_path, "").unwrap();
+
+    let data_dirs = vec![sessions_dir];
+    assert!(is_valid_data_path_in(&session_path, &data_dirs));
+    assert!(!is_valid_data_path_in(&unrelated_path, &data_dirs));
+}
+
+#[test]
 fn test_message_hashes_remain_stable_after_archiving() {
     let temp_dir = tempfile::tempdir().unwrap();
     let active_dir = temp_dir.path().join(".codex/sessions/2026/07/22");
@@ -82,6 +101,13 @@ fn test_message_hashes_remain_stable_after_archiving() {
     let (archived_messages, _) = parse_codex_cli_jsonl_file(&archived_path).unwrap();
 
     assert_eq!(active_messages.len(), archived_messages.len());
+    assert_eq!(
+        active_messages
+            .iter()
+            .filter(|message| matches!(message.role, crate::types::MessageRole::Assistant))
+            .count(),
+        2
+    );
     for (active, archived) in active_messages.iter().zip(&archived_messages) {
         assert_eq!(active.conversation_hash, archived.conversation_hash);
         assert_eq!(active.global_hash, archived.global_hash);


### PR DESCRIPTION
## Summary

- discover and watch both active and archived Codex session directories
- preserve existing conversation and message hashes by mapping archived rollouts to their original active-session paths
- deduplicate active and archived copies when a rollout temporarily exists in both locations
- add regression coverage for directory discovery, deduplication, and stable hashes across archival moves

## Motivation

Codex moves completed sessions from `~/.codex/sessions` to `~/.codex/archived_sessions`. Splitrail only scanned the active directory, so usage disappeared from local statistics after a session was archived.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` (397 passed)
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet`
- manual `splitrail stats` verification against active and archived Codex data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Codex CLI session history now automatically discovers and watches both active sessions and archived session files.
  - Archived sessions are treated as the same logical session as their original active copy for browsing and analysis.

- **Bug Fixes**
  - Duplicate session entries are filtered out when the same session exists in multiple locations.
  - Session/message identity calculations are now stable across active vs archived copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->