### PR TITLE
fix(codex): restore fallback warning context

### DIFF
--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -490,7 +490,7 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                                     get_fallback_model().to_string(),
                                 );
                                 warn_once(format!(
-                                    "WARNING: some Codex CLI sessions are missing model metadata; using fallback model {} for cost estimation.",
+                                    "WARNING: session {file_path_str} missing model metadata; using fallback model {} for cost estimation.",
                                     fallback.name
                                 ));
                                 session_model = Some(fallback.clone());
@@ -550,7 +550,7 @@ pub(crate) fn parse_codex_cli_jsonl_file(
                                     get_fallback_model().to_string(),
                                 );
                                 warn_once(format!(
-                                    "WARNING: some Codex CLI sessions are missing model metadata; using fallback model {} for cost estimation.",
+                                    "WARNING: session {file_path_str} missing model metadata; using fallback model {} for cost estimation.",
                                     fallback.name
                                 ));
                                 session_model = Some(fallback.clone());


### PR DESCRIPTION
## Summary

- restore the session path in Codex fallback-model warnings
- keep  used after the archived-session and logging changes were merged

## Root cause

The combination of #210 and #211 removed the final uses of , causing the main-branch Clippy job to fail with .

Failing run: https://github.com/Piebald-AI/splitrail/actions/runs/29936429065
