### PR TITLE
Remove unused Codex file path allocation

### DIFF
--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -308,7 +308,6 @@ pub(crate) fn parse_codex_cli_jsonl_file(
 ) -> Result<(Vec<ConversationMessage>, Option<String>)> {
     // Pre-allocate for typical session sizes
     let mut entries = Vec::with_capacity(100);
-    let file_path_str = file_path.to_string_lossy().into_owned();
     let session_path_str = canonical_session_path(file_path)
         .to_string_lossy()
         .into_owned();


### PR DESCRIPTION
## Why

The Codex CLI analyzer creates a raw file-path string that is no longer used. Message and conversation hashes use the canonical session path instead, so the stale binding causes `cargo clippy -- -D warnings` to fail with an `unused variable` error.

## What changed

- Remove the unused `file_path_str` allocation from `parse_codex_cli_jsonl_file`.
- Preserve the existing canonical session-path behavior for message and conversation hashes.

## Validation

Validation will be filled with the exact commands and results from the post-creation verification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal processing without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->