### PR TITLE
fix(watcher): show new sessions in live monitor

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -297,6 +297,26 @@ pub struct AnalyzerRegistry {
     dirty_files_for_upload: Arc<DashMap<PathBuf, String>>,
 }
 
+fn add_new_sessions_to_view(
+    view: &mut AnalyzerStatsView,
+    messages: &[ConversationMessage],
+    analyzer_name: &Arc<str>,
+) -> bool {
+    let introduces_new_session = messages.iter().any(|message| {
+        !view
+            .session_aggregates
+            .iter()
+            .any(|session| session.session_id == message.conversation_hash)
+    });
+    if !introduces_new_session {
+        return false;
+    }
+
+    let contribution = MultiSessionContribution::from_messages(messages, Arc::clone(analyzer_name));
+    view.add_multi_session_contribution(&contribution);
+    true
+}
+
 impl Default for AnalyzerRegistry {
     fn default() -> Self {
         Self::new()
@@ -621,7 +641,11 @@ impl AnalyzerRegistry {
                 if let Some(old) = old_contribution {
                     view.subtract_single_message_contribution(&old);
                 }
-                view.add_single_message_contribution(&new_contribution);
+                if !add_new_sessions_to_view(&mut view, &new_messages, &analyzer_name_arc)
+                    && !new_messages.is_empty()
+                {
+                    view.add_single_message_contribution(&new_contribution);
+                }
             }
             ContributionStrategy::SingleSession => {
                 let old_contribution = self.contribution_cache.get_single_session(&path_hash);
@@ -635,7 +659,11 @@ impl AnalyzerRegistry {
                 if let Some(old) = old_contribution {
                     view.subtract_single_session_contribution(&old);
                 }
-                view.add_single_session_contribution(&new_contribution);
+                if !add_new_sessions_to_view(&mut view, &new_messages, &analyzer_name_arc)
+                    && !new_messages.is_empty()
+                {
+                    view.add_single_session_contribution(&new_contribution);
+                }
             }
             ContributionStrategy::MultiSession => {
                 let old_contribution = self.contribution_cache.get_multi_session(&path_hash);
@@ -826,7 +854,7 @@ mod tests {
     };
     use async_trait::async_trait;
     use chrono::{TimeZone, Utc};
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashMap};
 
     struct TestAnalyzer {
         name: &'static str,
@@ -834,6 +862,51 @@ mod tests {
         stats: Option<AgenticCodingToolStats>,
         sources: Vec<PathBuf>,
         fail_stats: bool,
+    }
+
+    struct IncrementalSessionAnalyzer {
+        sources: Vec<PathBuf>,
+        messages_by_path: HashMap<PathBuf, Vec<ConversationMessage>>,
+        strategy: ContributionStrategy,
+    }
+
+    #[async_trait]
+    impl Analyzer for IncrementalSessionAnalyzer {
+        fn display_name(&self) -> &'static str {
+            "incremental-sessions"
+        }
+
+        fn get_data_glob_patterns(&self) -> Vec<String> {
+            vec!["*.jsonl".to_string()]
+        }
+
+        fn discover_data_sources(&self) -> Result<Vec<DataSource>> {
+            Ok(self
+                .sources
+                .iter()
+                .cloned()
+                .map(|path| DataSource { path })
+                .collect())
+        }
+
+        fn parse_source(&self, source: &DataSource) -> Result<Vec<ConversationMessage>> {
+            Ok(self
+                .messages_by_path
+                .get(&source.path)
+                .cloned()
+                .unwrap_or_default())
+        }
+
+        fn get_watch_directories(&self) -> Vec<PathBuf> {
+            self.sources
+                .iter()
+                .filter_map(|path| path.parent().map(Path::to_path_buf))
+                .collect()
+        }
+
+        fn contribution_strategy(&self) -> ContributionStrategy {
+            self.strategy
+        }
     }
 
     #[async_trait]
@@ -1196,6 +1269,66 @@ mod tests {
             after_removal, expected_strings,
             "Order changed after removal"
         );
+    }
+
+    #[test]
+    fn incremental_reload_adds_new_session_to_live_view() {
+        use std::fs;
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        for strategy in [
+            ContributionStrategy::SingleMessage,
+            ContributionStrategy::SingleSession,
+        ] {
+            let strategy_dir = temp_dir.path().join(format!("{strategy:?}"));
+            fs::create_dir(&strategy_dir).expect("create strategy directory");
+            let initial_path = strategy_dir.join("initial.jsonl");
+            let new_path = strategy_dir.join("new.jsonl");
+            fs::write(&initial_path, "{}").expect("write initial source");
+            fs::write(&new_path, "{}").expect("write new source");
+
+            let mut initial_message = sample_stats("incremental-sessions").messages.remove(0);
+            initial_message.conversation_hash = "initial-session".into();
+            initial_message.global_hash = "initial-message".into();
+
+            let mut new_message = initial_message.clone();
+            new_message.conversation_hash = "new-session".into();
+            new_message.global_hash = "new-message".into();
+            new_message.session_name = Some("New session".into());
+            new_message.stats.input_tokens = 42;
+
+            let mut registry = AnalyzerRegistry::new();
+            registry.register(IncrementalSessionAnalyzer {
+                sources: vec![initial_path.clone()],
+                messages_by_path: HashMap::from([
+                    (initial_path, vec![initial_message]),
+                    (new_path.clone(), vec![new_message]),
+                ]),
+                strategy,
+            });
+
+            registry
+                .load_all_stats_views_parallel()
+                .expect("initial load");
+            registry
+                .reload_file_incremental("incremental-sessions", &new_path)
+                .expect("incremental reload");
+
+            let view = registry
+                .get_cached_view("incremental-sessions")
+                .expect("cached view");
+            let view = view.read();
+
+            assert_eq!(view.num_conversations, 2, "strategy: {strategy:?}");
+            assert_eq!(view.session_aggregates.len(), 2, "strategy: {strategy:?}");
+            let new_session = view
+                .session_aggregates
+                .iter()
+                .find(|session| session.session_id == "new-session")
+                .expect("new session should be visible");
+            assert_eq!(new_session.session_name.as_deref(), Some("New session"));
+            assert_eq!(new_session.stats.input_tokens, 42);
+        }
     }
 
     // =========================================================================

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -9,10 +9,11 @@ use walkdir::WalkDir;
 
 use crate::contribution_cache::{
     ContributionCache, ContributionStrategy, MultiSessionContribution, PathHash,
-    RemovedContribution, SingleMessageContribution, SingleSessionContribution,
+    RemovedContribution, SessionHash, SingleMessageContribution, SingleSessionContribution,
 };
 use crate::types::{
-    AgenticCodingToolStats, AnalyzerStatsView, ConversationMessage, SharedAnalyzerView,
+    AgenticCodingToolStats, AnalyzerStatsView, ConversationMessage, DailyStats, ModelCounts,
+    SharedAnalyzerView, TuiStats,
 };
 
 /// VSCode GUI forks that might have extensions installed
@@ -301,20 +302,55 @@ fn add_new_sessions_to_view(
     view: &mut AnalyzerStatsView,
     messages: &[ConversationMessage],
     analyzer_name: &Arc<str>,
-) -> bool {
-    let introduces_new_session = messages.iter().any(|message| {
-        !view
+) {
+    let contribution = MultiSessionContribution::from_messages(messages, Arc::clone(analyzer_name));
+    for mut session in contribution.session_aggregates {
+        if view
             .session_aggregates
             .iter()
-            .any(|session| session.session_id == message.conversation_hash)
-    });
-    if !introduces_new_session {
-        return false;
-    }
+            .any(|existing| existing.session_id == session.session_id)
+        {
+            continue;
+        }
 
-    let contribution = MultiSessionContribution::from_messages(messages, Arc::clone(analyzer_name));
-    view.add_multi_session_contribution(&contribution);
-    true
+        session.stats = TuiStats::default();
+        session.models = ModelCounts::new();
+        let date = session.date;
+        view.session_aggregates.push(session);
+        view.num_conversations += 1;
+
+        let day_stats = view
+            .daily_stats
+            .entry(date.to_string())
+            .or_insert_with(|| DailyStats {
+                date,
+                ..Default::default()
+            });
+        day_stats.conversations += 1;
+    }
+    view.session_aggregates.sort_by_key(|s| s.first_timestamp);
+}
+
+fn remove_session_from_view(view: &mut AnalyzerStatsView, session_hash: SessionHash) {
+    let Some(position) = view.session_aggregates.iter().position(|session| {
+        SingleMessageContribution::hash_session_id(&session.session_id) == session_hash
+    }) else {
+        return;
+    };
+
+    let session = view.session_aggregates.remove(position);
+    view.num_conversations = view.num_conversations.saturating_sub(1);
+
+    let date = session.date.to_string();
+    if let Some(day_stats) = view.daily_stats.get_mut(&date) {
+        day_stats.conversations = day_stats.conversations.saturating_sub(1);
+        if day_stats.user_messages == 0
+            && day_stats.ai_messages == 0
+            && day_stats.conversations == 0
+        {
+            view.daily_stats.remove(&date);
+        }
+    }
 }
 
 impl Default for AnalyzerRegistry {
@@ -640,10 +676,15 @@ impl AnalyzerRegistry {
                 let mut view = shared_view.write();
                 if let Some(old) = old_contribution {
                     view.subtract_single_message_contribution(&old);
+                    if !self
+                        .contribution_cache
+                        .contains_single_message_session(old.session_hash)
+                    {
+                        remove_session_from_view(&mut view, old.session_hash);
+                    }
                 }
-                if !add_new_sessions_to_view(&mut view, &new_messages, &analyzer_name_arc)
-                    && !new_messages.is_empty()
-                {
+                if !new_messages.is_empty() {
+                    add_new_sessions_to_view(&mut view, &new_messages, &analyzer_name_arc);
                     view.add_single_message_contribution(&new_contribution);
                 }
             }
@@ -658,10 +699,15 @@ impl AnalyzerRegistry {
                 let mut view = shared_view.write();
                 if let Some(old) = old_contribution {
                     view.subtract_single_session_contribution(&old);
+                    if !self
+                        .contribution_cache
+                        .contains_single_session(old.session_hash)
+                    {
+                        remove_session_from_view(&mut view, old.session_hash);
+                    }
                 }
-                if !add_new_sessions_to_view(&mut view, &new_messages, &analyzer_name_arc)
-                    && !new_messages.is_empty()
-                {
+                if !new_messages.is_empty() {
+                    add_new_sessions_to_view(&mut view, &new_messages, &analyzer_name_arc);
                     view.add_single_session_contribution(&new_contribution);
                 }
             }
@@ -720,9 +766,21 @@ impl AnalyzerRegistry {
                 match removed {
                     RemovedContribution::SingleMessage(old) => {
                         view.subtract_single_message_contribution(&old);
+                        if !self
+                            .contribution_cache
+                            .contains_single_message_session(old.session_hash)
+                        {
+                            remove_session_from_view(&mut view, old.session_hash);
+                        }
                     }
                     RemovedContribution::SingleSession(old) => {
                         view.subtract_single_session_contribution(&old);
+                        if !self
+                            .contribution_cache
+                            .contains_single_session(old.session_hash)
+                        {
+                            remove_session_from_view(&mut view, old.session_hash);
+                        }
                     }
                     RemovedContribution::MultiSession(old) => {
                         view.subtract_multi_session_contribution(&old);
@@ -1328,6 +1386,25 @@ mod tests {
                 .expect("new session should be visible");
             assert_eq!(new_session.session_name.as_deref(), Some("New session"));
             assert_eq!(new_session.stats.input_tokens, 42);
+            drop(view);
+
+            assert!(
+                registry.remove_file_from_cache("incremental-sessions", &new_path),
+                "strategy: {strategy:?}"
+            );
+
+            let view = registry
+                .get_cached_view("incremental-sessions")
+                .expect("cached view");
+            let view = view.read();
+            assert_eq!(view.num_conversations, 1, "strategy: {strategy:?}");
+            assert_eq!(view.session_aggregates.len(), 1, "strategy: {strategy:?}");
+            assert!(
+                view.session_aggregates
+                    .iter()
+                    .all(|session| session.session_id != "new-session"),
+                "strategy: {strategy:?}"
+            );
         }
     }
 

--- a/src/contribution_cache/mod.rs
+++ b/src/contribution_cache/mod.rs
@@ -127,6 +127,13 @@ impl ContributionCache {
         self.single_message.get(key).map(|r| *r)
     }
 
+    /// Check whether another single-message contribution belongs to a session.
+    pub fn contains_single_message_session(&self, session_hash: SessionHash) -> bool {
+        self.single_message
+            .iter()
+            .any(|entry| entry.value().session_hash == session_hash)
+    }
+
     // --- Single Session operations ---
 
     /// Insert a single-session contribution.
@@ -139,6 +146,13 @@ impl ContributionCache {
     #[inline]
     pub fn get_single_session(&self, key: &PathHash) -> Option<SingleSessionContribution> {
         self.single_session.get(key).map(|r| r.clone())
+    }
+
+    /// Check whether another single-session contribution belongs to a session.
+    pub fn contains_single_session(&self, session_hash: SessionHash) -> bool {
+        self.single_session
+            .iter()
+            .any(|entry| entry.value().session_hash == session_hash)
     }
 
     // --- Multi Session operations ---


### PR DESCRIPTION
## Summary

Fix the live monitor so sessions created after startup appear immediately without restarting Splitrail.

## Key changes

- Detect session IDs that are missing from the cached live view during incremental reloads.
- Initialize full session metadata and conversation counts only for newly observed sessions.
- Preserve the existing incremental path for sessions already present in the view.
- Add regression coverage for both SingleMessage and SingleSession contribution strategies.

## Validation

- cargo build --quiet
- cargo test --quiet (399 passed)
- cargo clippy --quiet -- -D warnings
- cargo doc --quiet
- cargo fmt --all --quiet
- git diff --check

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incremental reloads now correctly display newly discovered conversation sessions.
  * Updated views remain accurate when using single-message or single-session contribution modes.

* **Tests**
  * Added coverage to verify that new sessions appear in live views after incremental file updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->