### PR TITLE
Add MiniMax-M3 model pricing to the cost registry

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1711,6 +1711,18 @@ fn populate_defaults(
         CachingSupport::None,
         false
     );
+    // Source: https://platform.minimax.io/docs/api-reference/anthropic-api-compatible-cache
+    add_model!(
+        "minimax-m3",
+        PricingStructure::Flat {
+            input_per_1m: 0.60,
+            output_per_1m: 2.40
+        },
+        CachingSupport::OpenAI {
+            cached_input_per_1m: 0.12
+        },
+        false
+    );
 
     // Moonshot AI Models
     // Source: https://platform.kimi.ai/docs/pricing/chat-k26.md
@@ -2036,6 +2048,7 @@ fn populate_defaults(
     add_alias!("minimax-m2.5", "minimax-m2.5");
     add_alias!("minimax-m2.5-20260211", "minimax-m2.5");
     add_alias!("minimax-m2.7", "minimax-m2.7");
+    add_alias!("minimax-m3", "minimax-m3");
 
     // Moonshot / ByteDance / Qwen / Xiaomi / Meituan aliases
     add_alias!("doubao-seed-code", "doubao-seed-2.0-code");
@@ -3477,6 +3490,10 @@ mod tests {
             calculate_cache_cost("minimax-m2.7", 1_000_000, 1_000_000),
             0.435,
         );
+
+        approx_eq(calculate_input_cost("minimax-m3", 1_000_000), 0.60);
+        approx_eq(calculate_output_cost("minimax-m3", 1_000_000), 2.40);
+        approx_eq(calculate_cache_cost("minimax-m3", 0, 1_000_000), 0.12);
 
         approx_eq(calculate_input_cost("glm-5.1", 1_000_000), 1.40);
         approx_eq(calculate_output_cost("glm-5.1", 1_000_000), 4.40);


### PR DESCRIPTION
Reason: Add the MiniMax-M3 model with its current input, output, and cache-read pricing to the built-in cost registry.

Adds the `minimax-m3` model entry to `src/models.rs` alongside the existing MiniMax models. MiniMax-M3 is priced at $0.60 per 1M input tokens, $2.40 per 1M output tokens, and $0.12 per 1M cache-read tokens (no cache-write pricing). It is registered using the flat cached-input pricing variant and a self-resolving alias is added for the canonical name.

Checks run:
- `cargo check` (clean)
- `cargo test --bin splitrail models::` (36 passed, 0 failed)
- `cargo fmt --check` (clean)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Minimax M3 model, including standard and cached-input pricing.

* **Tests**
  * Added pricing coverage to verify the Minimax M3 model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->