### PR TITLE
feat(tui): filter usage by model

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5,8 +5,8 @@ mod tests;
 use crate::config::TuiConfig;
 use crate::models::is_model_estimated;
 use crate::types::{
-    AnalyzerStatsView, CompactDate, DailyStats, MultiAnalyzerStatsView, SharedAnalyzerView,
-    resolve_model,
+    AnalyzerStatsView, CompactDate, DailyStats, ModelStats, MultiAnalyzerStatsView,
+    SharedAnalyzerView, TuiStats, resolve_model,
 };
 use crate::utils::{
     NumberFormatOptions, format_date_for_display, format_number, format_number_fit,
@@ -239,6 +239,109 @@ fn filtered_session_count(view: &AnalyzerStatsView, period_filter: Option<Period
         .unwrap_or_else(|| view.session_aggregates.len())
 }
 
+fn model_name_matches(model: &str, filter: &str) -> bool {
+    model.to_lowercase().contains(filter)
+}
+
+fn filter_analyzer_view_by_model(
+    view: &AnalyzerStatsView,
+    model_filter: &str,
+) -> AnalyzerStatsView {
+    let filter = model_filter.trim().to_lowercase();
+    if filter.is_empty() {
+        return view.clone();
+    }
+
+    let session_aggregates: Vec<_> = view
+        .session_aggregates
+        .iter()
+        .filter(|session| {
+            session
+                .models
+                .iter()
+                .any(|(model, _)| model_name_matches(resolve_model(*model), &filter))
+        })
+        .cloned()
+        .collect();
+
+    let mut daily_stats = BTreeMap::new();
+    for (date, day_stats) in &view.daily_stats {
+        let mut filtered_day = DailyStats {
+            date: day_stats.date,
+            apps: day_stats.apps.clone(),
+            ..Default::default()
+        };
+
+        for (model, count) in &day_stats.models {
+            if model_name_matches(model, &filter) {
+                filtered_day.models.insert(model.clone(), *count);
+            }
+        }
+
+        for (model, model_stats) in &day_stats.model_stats {
+            if !model_name_matches(model, &filter) {
+                continue;
+            }
+
+            filtered_day.ai_messages = filtered_day
+                .ai_messages
+                .saturating_add(model_stats.message_count);
+            filtered_day.stats += TuiStats {
+                input_tokens: model_stats.input_tokens,
+                output_tokens: model_stats.output_tokens,
+                reasoning_tokens: model_stats.reasoning_tokens,
+                cached_tokens: model_stats.cached_tokens,
+                cost_cents: (model_stats.cost * 100.0).round() as u32,
+                tool_calls: model_stats.tool_calls,
+            };
+            filtered_day
+                .model_stats
+                .insert(model.clone(), model_stats.clone());
+        }
+
+        if !filtered_day.models.is_empty() || !filtered_day.model_stats.is_empty() {
+            daily_stats.insert(date.clone(), filtered_day);
+        }
+    }
+
+    for session in &session_aggregates {
+        let date = session.date.to_string();
+        let original_day = view.daily_stats.get(&date);
+        let day_stats = daily_stats.entry(date).or_insert_with(|| DailyStats {
+            date: session.date,
+            apps: original_day
+                .map(|stats| stats.apps.clone())
+                .unwrap_or_default(),
+            ..Default::default()
+        });
+        day_stats.conversations = day_stats.conversations.saturating_add(1);
+    }
+
+    AnalyzerStatsView {
+        daily_stats,
+        num_conversations: session_aggregates.len() as u64,
+        session_aggregates,
+        analyzer_name: Arc::clone(&view.analyzer_name),
+    }
+}
+
+fn filter_stats_by_model(
+    stats: &[SharedAnalyzerView],
+    model_filter: &str,
+) -> Vec<SharedAnalyzerView> {
+    if model_filter.trim().is_empty() {
+        return stats.to_vec();
+    }
+
+    stats
+        .iter()
+        .map(|stats| {
+            let filtered = filter_analyzer_view_by_model(&stats.read(), model_filter);
+            Arc::new(parking_lot::RwLock::new(filtered))
+        })
+        .collect()
+}
+
 fn clamp_table_selection(table_state: &mut TableState, total_rows: usize) {
     if total_rows == 0 {
         table_state.select(None);
@@ -343,6 +446,8 @@ struct UiState<'a> {
     session_period_filters: &'a mut [Option<PeriodFilter>],
     date_jump_active: bool,
     date_jump_buffer: &'a str,
+    model_filter_active: bool,
+    model_filter: &'a str,
     sort_reversed: bool,
     hide_empty_periods: bool,
     show_totals: bool,
@@ -497,6 +602,9 @@ async fn run_app(
     let mut session_period_filters: Vec<Option<PeriodFilter>> = Vec::new();
     let mut date_jump_active = false;
     let mut date_jump_buffer = String::new();
+    let mut model_filter_active = false;
+    let mut model_filter = String::new();
+    let mut model_filter_before_edit = String::new();
     let mut sort_reversed = tui_config.reverse_sort_default;
     let mut hide_empty_periods = tui_config.hide_empty_periods;
     let mut show_totals = true;
@@ -536,12 +644,13 @@ async fn run_app(
 
     // Filter analyzer stats to only include those with data - calculate once and update when stats change
     // SharedAnalyzerView = Arc<RwLock<AnalyzerStatsView>> - clone is cheap (just Arc pointer)
-    let mut filtered_stats: Vec<SharedAnalyzerView> = current_stats
+    let mut available_stats: Vec<SharedAnalyzerView> = current_stats
         .analyzer_stats
         .iter()
         .filter(|stats| has_data_shared(stats))
         .cloned()
         .collect();
+    let mut filtered_stats = filter_stats_by_model(&available_stats, &model_filter);
     let mut display_stats = build_display_stats(&filtered_stats);
 
     // Open on the configured default tab (matched by tool name; empty or
@@ -572,12 +681,13 @@ async fn run_app(
         if stats_receiver.has_changed()? {
             current_stats = stats_receiver.borrow_and_update().clone();
             // Recalculate filtered stats only when stats change
-            filtered_stats = current_stats
+            available_stats = current_stats
                 .analyzer_stats
                 .iter()
                 .filter(|stats| has_data_shared(stats))
                 .cloned()
                 .collect();
+            filtered_stats = filter_stats_by_model(&available_stats, &model_filter);
             display_stats = build_display_stats(&filtered_stats);
             update_table_states(&mut table_states, &current_stats, selected_tab);
             update_window_offsets(&mut session_window_offsets, &table_states.len());
@@ -632,6 +742,8 @@ async fn run_app(
                     session_period_filters: &mut session_period_filters,
                     date_jump_active,
                     date_jump_buffer: &date_jump_buffer,
+                    model_filter_active,
+                    model_filter: &model_filter,
                     sort_reversed,
                     hide_empty_periods,
                     show_totals,
@@ -672,7 +784,7 @@ async fn run_app(
 
             // Handle quitting. Esc is intentionally *not* a quit key; it acts as
             // a context-aware "go back"/cancel below.
-            if matches!(key.code, KeyCode::Char('q')) {
+            if !model_filter_active && matches!(key.code, KeyCode::Char('q')) {
                 if tui_config.confirm_quit && !quit_pending {
                     quit_pending = true;
                     needs_redraw = true;
@@ -687,7 +799,7 @@ async fn run_app(
             }
 
             // Handle update notification dismissal
-            if matches!(key.code, KeyCode::Char('u')) {
+            if !model_filter_active && matches!(key.code, KeyCode::Char('u')) {
                 let mut status = update_status.lock();
                 if matches!(
                     *status,
@@ -696,6 +808,47 @@ async fn run_app(
                     *status = crate::version_check::UpdateStatus::Dismissed;
                     needs_redraw = true;
                 }
+            }
+
+            if model_filter_active {
+                let mut filter_changed = false;
+                match key.code {
+                    KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        model_filter.clear();
+                        filter_changed = true;
+                    }
+                    KeyCode::Char(c)
+                        if !key
+                            .modifiers
+                            .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) =>
+                    {
+                        model_filter.push(c);
+                        filter_changed = true;
+                    }
+                    KeyCode::Backspace => {
+                        model_filter.pop();
+                        filter_changed = true;
+                    }
+                    KeyCode::Enter => {
+                        model_filter = model_filter.trim().to_string();
+                        model_filter_active = false;
+                        filter_changed = true;
+                    }
+                    KeyCode::Esc => {
+                        model_filter.clone_from(&model_filter_before_edit);
+                        model_filter_active = false;
+                        filter_changed = true;
+                    }
+                    _ => {}
+                }
+
+                if filter_changed {
+                    filtered_stats = filter_stats_by_model(&available_stats, &model_filter);
+                    display_stats = build_display_stats(&filtered_stats);
+                    session_window_offsets.fill(0);
+                }
+                needs_redraw = true;
+                continue;
             }
 
             // Only handle navigation keys if we have data (`display_stats` is non-empty).
@@ -1012,6 +1165,11 @@ async fn run_app(
                         date_jump_buffer.clear();
                         needs_redraw = true;
                     }
+                }
+                KeyCode::Char('f') => {
+                    model_filter_before_edit.clone_from(&model_filter);
+                    model_filter_active = true;
+                    needs_redraw = true;
                 }
                 KeyCode::Char('m') => {
                     *aggregate_view_mode = aggregate_view_mode.next();
@@ -1345,16 +1503,26 @@ fn draw_ui(
                     };
 
                     format!(
-                        "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • e to toggle empty periods • s to toggle summary • / for {jump_label} • m to cycle day/week/month/year • Enter to drill into period • Ctrl+T for all sessions • q to quit"
+                        "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • f to filter models • r to reverse sort • e to toggle empty periods • s to toggle summary • / for {jump_label} • m to cycle day/week/month/year • Enter to drill into period • Ctrl+T for all sessions • q to quit"
                     )
                 }
                 StatsViewMode::Session => {
-                    "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • r to reverse sort • e to toggle empty periods • s to toggle summary • m to cycle day/week/month/year • Esc or Ctrl+T for aggregate view • q to quit".to_string()
+                    "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • f to filter models • r to reverse sort • e to toggle empty periods • s to toggle summary • m to cycle day/week/month/year • Esc or Ctrl+T for aggregate view • q to quit".to_string()
                 }
             };
 
-            let help_text = if ui_state.quit_pending {
+            let help_text = if ui_state.model_filter_active {
+                format!(
+                    "Model filter: {}_  •  Enter to apply  •  Esc to cancel  •  Ctrl+U to clear",
+                    ui_state.model_filter
+                )
+            } else if ui_state.quit_pending {
                 "Quit splitrail?  Press q again to confirm  •  any other key to cancel".to_string()
+            } else if !ui_state.model_filter.is_empty() {
+                format!(
+                    "Model filter: {}  •  f to edit  •  {}",
+                    ui_state.model_filter, base_help_text
+                )
             } else if has_estimated_models {
                 format!("{} • * = estimated pricing", base_help_text)
             } else {
@@ -1469,6 +1637,66 @@ fn cost_heat(cents: u32, max: u32) -> Color {
     let g = (200.0 - t * (200.0 - 80.0)) as u8;
     let b = (110.0 - t * (110.0 - 70.0)) as u8;
     Color::Rgb(r, g, b)
+}
+
+fn format_model_usage_shares(
+    models: &BTreeMap<String, u32>,
+    model_stats: &BTreeMap<String, ModelStats>,
+) -> String {
+    let mut usage: BTreeMap<&str, u64> = models
+        .keys()
+        .map(|model| (model.as_str(), 0))
+        .chain(model_stats.keys().map(|model| (model.as_str(), 0)))
+        .collect();
+
+    for (model, stats) in model_stats {
+        usage.insert(
+            model,
+            stats
+                .input_tokens
+                .saturating_add(stats.output_tokens)
+                .saturating_add(stats.cached_tokens),
+        );
+    }
+
+    let total_tokens = usage.values().copied().sum::<u64>();
+    let has_complete_token_stats = models.keys().all(|model| model_stats.contains_key(model));
+    if total_tokens == 0 || !has_complete_token_stats {
+        for (model, model_usage) in &mut usage {
+            *model_usage = models
+                .get(*model)
+                .copied()
+                .or_else(|| model_stats.get(*model).map(|stats| stats.message_count))
+                .map(u64::from)
+                .unwrap_or(0);
+        }
+    }
+    let total_usage = usage.values().copied().sum::<u64>();
+
+    let mut shares: Vec<_> = usage.into_iter().collect();
+    shares.sort_by(|(left_model, left_usage), (right_model, right_usage)| {
+        right_usage
+            .cmp(left_usage)
+            .then_with(|| left_model.cmp(right_model))
+    });
+
+    shares
+        .into_iter()
+        .map(|(model, model_usage)| {
+            let display_model = if is_model_estimated(model) {
+                format!("{model}*")
+            } else {
+                model.to_string()
+            };
+            let percentage = if total_usage == 0 {
+                0.0
+            } else {
+                model_usage as f64 / total_usage as f64 * 100.0
+            };
+            format!("{display_model} {percentage:.1}%")
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1607,6 +1835,9 @@ fn draw_aggregate_stats_table(
     let mut total_reasoning: u64 = 0;
     let mut total_tool_calls: u64 = 0;
     let mut total_conversations: u64 = 0;
+    let mut total_models = BTreeMap::new();
+    let mut total_model_stats = BTreeMap::new();
+    let mut all_apps = std::collections::BTreeSet::new();
 
     for (i, period) in visible_periods.iter().enumerate() {
         let period_stats = aggregate_stats
@@ -1625,23 +1856,21 @@ fn draw_aggregate_stats_table(
         total_tool_calls += period_stats.stats.tool_calls as u64;
         total_conversations += period_stats.conversations as u64;
 
-        let mut models_vec: Vec<String> = period_stats
-            .models
-            .keys()
-            .map(|model| {
-                if is_model_estimated(model) {
-                    format!("{}*", model)
-                } else {
-                    model.clone()
-                }
-            })
-            .collect();
-        models_vec.sort();
-        let models = models_vec.join(", ");
+        for (model, count) in &period_stats.models {
+            *total_models.entry(model.clone()).or_insert(0) += count;
+        }
+        for (model, stats) in &period_stats.model_stats {
+            total_model_stats
+                .entry(model.clone())
+                .or_insert_with(|| ModelStats::new(model.clone()))
+                .add_model_stats(stats);
+        }
+        let models = format_model_usage_shares(&period_stats.models, &period_stats.model_stats);
 
         let mut apps_vec: Vec<String> = period_stats.apps.keys().cloned().collect();
         apps_vec.sort();
         let apps = apps_vec.join(", ");
+        all_apps.extend(period_stats.apps.keys().cloned());
 
         // Check if this is an empty row
         let is_empty_row = is_empty_period(period_stats);
@@ -1835,35 +2064,13 @@ fn draw_aggregate_stats_table(
         rows.push(Row::new(row_cells));
     }
 
-    // Collect all unique models (and apps) for the totals row
-    let mut all_models = HashSet::new();
-    let mut has_estimated_models = false;
-    let mut all_apps = std::collections::BTreeSet::new();
-    for period_stats in aggregate_stats.values() {
-        for model in period_stats.models.keys() {
-            all_models.insert(model);
-            if is_model_estimated(model) {
-                has_estimated_models = true;
-            }
-        }
-        for app in period_stats.apps.keys() {
-            all_apps.insert(app.clone());
-        }
-    }
+    // Summarize models and apps from the same visible periods as the numeric totals.
+    let has_estimated_models = total_models
+        .keys()
+        .chain(total_model_stats.keys())
+        .any(|model| is_model_estimated(model));
     let all_apps_text = all_apps.into_iter().collect::<Vec<_>>().join(", ");
-
-    let mut all_models_vec: Vec<String> = all_models
-        .iter()
-        .map(|model| {
-            if is_model_estimated(model) {
-                format!("{}*", model)
-            } else {
-                model.to_string()
-            }
-        })
-        .collect();
-    all_models_vec.sort();
-    let all_models_text = all_models_vec.join(", ");
+    let all_models_text = format_model_usage_shares(&total_models, &total_model_stats);
 
     // Add separator row before totals
     let token_sep = "─".repeat(TOKEN_COL_WIDTH as usize);

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -243,6 +243,17 @@ fn model_name_matches(model: &str, filter: &str) -> bool {
     model.to_lowercase().contains(filter)
 }
 
+fn tui_stats_from_model_stats(stats: &ModelStats) -> TuiStats {
+    TuiStats {
+        input_tokens: stats.input_tokens,
+        output_tokens: stats.output_tokens,
+        reasoning_tokens: stats.reasoning_tokens,
+        cached_tokens: stats.cached_tokens,
+        cost_cents: (stats.cost * 100.0).round() as u32,
+        tool_calls: stats.tool_calls,
+    }
+}
+
 fn filter_analyzer_view_by_model(
     view: &AnalyzerStatsView,
     model_filter: &str,
@@ -268,6 +279,7 @@ fn filter_analyzer_view_by_model(
     for (date, day_stats) in &view.daily_stats {
         let mut filtered_day = DailyStats {
             date: day_stats.date,
+            user_messages: day_stats.user_messages,
             apps: day_stats.apps.clone(),
             ..Default::default()
         };
@@ -277,29 +289,54 @@ fn filter_analyzer_view_by_model(
                 filtered_day.models.insert(model.clone(), *count);
             }
         }
+        filtered_day.ai_messages = filtered_day.models.values().copied().sum();
 
         for (model, model_stats) in &day_stats.model_stats {
             if !model_name_matches(model, &filter) {
                 continue;
             }
 
-            filtered_day.ai_messages = filtered_day
-                .ai_messages
-                .saturating_add(model_stats.message_count);
-            filtered_day.stats += TuiStats {
-                input_tokens: model_stats.input_tokens,
-                output_tokens: model_stats.output_tokens,
-                reasoning_tokens: model_stats.reasoning_tokens,
-                cached_tokens: model_stats.cached_tokens,
-                cost_cents: (model_stats.cost * 100.0).round() as u32,
-                tool_calls: model_stats.tool_calls,
-            };
+            if !day_stats.models.contains_key(model) {
+                filtered_day.ai_messages = filtered_day
+                    .ai_messages
+                    .saturating_add(model_stats.message_count);
+            }
+            filtered_day.stats += tui_stats_from_model_stats(model_stats);
             filtered_day
                 .model_stats
                 .insert(model.clone(), model_stats.clone());
         }
 
         if !filtered_day.models.is_empty() || !filtered_day.model_stats.is_empty() {
+            let model_message_count: u32 = day_stats.models.values().copied().sum();
+            let has_unmodeled_messages = model_message_count != day_stats.ai_messages;
+            let all_models_match = day_stats
+                .models
+                .keys()
+                .chain(day_stats.model_stats.keys())
+                .all(|model| model_name_matches(model, &filter));
+            let missing_models: Vec<_> = day_stats
+                .models
+                .keys()
+                .filter(|model| !day_stats.model_stats.contains_key(*model))
+                .collect();
+
+            if !has_unmodeled_messages && all_models_match {
+                filtered_day.ai_messages = day_stats.ai_messages;
+                filtered_day.stats = day_stats.stats;
+            } else if !has_unmodeled_messages
+                && !missing_models.is_empty()
+                && missing_models
+                    .iter()
+                    .all(|model| model_name_matches(model, &filter))
+            {
+                let mut unaccounted_stats = day_stats.stats;
+                for model_stats in day_stats.model_stats.values() {
+                    unaccounted_stats -= tui_stats_from_model_stats(model_stats);
+                }
+                filtered_day.stats += unaccounted_stats;
+            }
+
             daily_stats.insert(date.clone(), filtered_day);
         }
     }
@@ -1519,10 +1556,15 @@ fn draw_ui(
             } else if ui_state.quit_pending {
                 "Quit splitrail?  Press q again to confirm  •  any other key to cancel".to_string()
             } else if !ui_state.model_filter.is_empty() {
-                format!(
+                let filter_help = format!(
                     "Model filter: {}  •  f to edit  •  {}",
                     ui_state.model_filter, base_help_text
-                )
+                );
+                if has_estimated_models {
+                    format!("{filter_help} • * = estimated pricing")
+                } else {
+                    filter_help
+                }
             } else if has_estimated_models {
                 format!("{} • * = estimated pricing", base_help_text)
             } else {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -871,6 +871,7 @@ fn model_filter_recalculates_stats_and_sessions() {
         date.to_string(),
         DailyStats {
             date,
+            user_messages: 4,
             ai_messages: 3,
             conversations: 2,
             models: BTreeMap::from([("claude-sonnet-4".to_string(), 2), ("gpt-5".to_string(), 1)]),
@@ -917,6 +918,7 @@ fn model_filter_recalculates_stats_and_sessions() {
     let day = filtered.daily_stats.get("2025-01-01").unwrap();
 
     assert_eq!(day.ai_messages, 2);
+    assert_eq!(day.user_messages, 4);
     assert_eq!(day.conversations, 1);
     assert_eq!(day.stats.input_tokens, 100);
     assert_eq!(day.stats.output_tokens, 20);
@@ -926,6 +928,22 @@ fn model_filter_recalculates_stats_and_sessions() {
     assert!(day.models.contains_key("claude-sonnet-4"));
     assert_eq!(filtered.num_conversations, 1);
     assert_eq!(filtered.session_aggregates[0].session_id, "claude-session");
+
+    let mut incomplete_view = view.clone();
+    incomplete_view
+        .daily_stats
+        .get_mut("2025-01-01")
+        .unwrap()
+        .model_stats
+        .remove("claude-sonnet-4");
+    let incomplete_filtered = filter_analyzer_view_by_model(&incomplete_view, "sonnet");
+    let incomplete_day = &incomplete_filtered.daily_stats["2025-01-01"];
+    assert_eq!(incomplete_day.user_messages, 4);
+    assert_eq!(incomplete_day.ai_messages, 2);
+    assert_eq!(incomplete_day.stats.input_tokens, 100);
+    assert_eq!(incomplete_day.stats.output_tokens, 20);
+    assert_eq!(incomplete_day.stats.cost_cents, 125);
+    assert_eq!(incomplete_day.stats.tool_calls, 3);
     assert_eq!(
         format_model_usage_shares(
             &view.daily_stats["2025-01-01"].models,

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -5,14 +5,16 @@ use crate::tui::logic::{
 };
 use crate::tui::{
     AggregateViewMode, PeriodFilter, build_display_stats, cost_heat,
-    create_upload_progress_callback, draw_aggregate_stats_table, format_month_for_display,
-    format_week_for_display, format_year_for_display, parse_accent, show_upload_error,
-    show_upload_success, update_period_filters, update_table_states, update_window_offsets,
+    create_upload_progress_callback, draw_aggregate_stats_table, filter_analyzer_view_by_model,
+    format_model_usage_shares, format_month_for_display, format_week_for_display,
+    format_year_for_display, parse_accent, show_upload_error, show_upload_success,
+    update_period_filters, update_table_states, update_window_offsets,
 };
 use crate::types::{
-    AgenticCodingToolStats, AnalyzerStatsView, CompactDate, DailyStats, MultiAnalyzerStats, Stats,
-    TuiStats,
+    AgenticCodingToolStats, AnalyzerStatsView, CompactDate, DailyStats, ModelCounts, ModelStats,
+    MultiAnalyzerStats, SessionAggregate, Stats, TuiStats, intern_model,
 };
+use chrono::{TimeZone, Utc};
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
@@ -840,6 +842,149 @@ fn test_date_filter_exclusions() {
     assert!(!date_matches_buffer("2025-01-15", "2"));
     assert!(!date_matches_buffer("2025-01-15", "2025-02"));
     assert!(!date_matches_buffer("2025-12-31", "2024"));
+}
+
+#[test]
+fn model_filter_recalculates_stats_and_sessions() {
+    let date = CompactDate::from_str("2025-01-01").unwrap();
+    let claude_stats = ModelStats {
+        model: "claude-sonnet-4".to_string(),
+        message_count: 2,
+        input_tokens: 100,
+        output_tokens: 20,
+        reasoning_tokens: 5,
+        cached_tokens: 50,
+        cost: 1.25,
+        tool_calls: 3,
+        ..Default::default()
+    };
+    let gpt_stats = ModelStats {
+        model: "gpt-5".to_string(),
+        message_count: 1,
+        input_tokens: 900,
+        output_tokens: 80,
+        cost: 4.0,
+        tool_calls: 7,
+        ..Default::default()
+    };
+    let daily_stats = BTreeMap::from([(
+        date.to_string(),
+        DailyStats {
+            date,
+            ai_messages: 3,
+            conversations: 2,
+            models: BTreeMap::from([("claude-sonnet-4".to_string(), 2), ("gpt-5".to_string(), 1)]),
+            stats: TuiStats {
+                input_tokens: 1_000,
+                output_tokens: 100,
+                reasoning_tokens: 5,
+                cached_tokens: 50,
+                cost_cents: 525,
+                tool_calls: 10,
+            },
+            model_stats: BTreeMap::from([
+                ("claude-sonnet-4".to_string(), claude_stats),
+                ("gpt-5".to_string(), gpt_stats),
+            ]),
+            ..Default::default()
+        },
+    )]);
+
+    let make_session = |id: &str, model: &str| SessionAggregate {
+        session_id: id.to_string(),
+        first_timestamp: Utc.with_ymd_and_hms(2025, 1, 1, 12, 0, 0).unwrap(),
+        analyzer_name: Arc::from("Test"),
+        stats: TuiStats::default(),
+        models: {
+            let mut models = ModelCounts::new();
+            models.increment(intern_model(model), 1);
+            models
+        },
+        session_name: None,
+        date,
+    };
+    let view = AnalyzerStatsView {
+        daily_stats,
+        session_aggregates: vec![
+            make_session("claude-session", "claude-sonnet-4"),
+            make_session("gpt-session", "gpt-5"),
+        ],
+        num_conversations: 2,
+        analyzer_name: Arc::from("Test"),
+    };
+
+    let filtered = filter_analyzer_view_by_model(&view, "SONNET");
+    let day = filtered.daily_stats.get("2025-01-01").unwrap();
+
+    assert_eq!(day.ai_messages, 2);
+    assert_eq!(day.conversations, 1);
+    assert_eq!(day.stats.input_tokens, 100);
+    assert_eq!(day.stats.output_tokens, 20);
+    assert_eq!(day.stats.cost_cents, 125);
+    assert_eq!(day.stats.tool_calls, 3);
+    assert_eq!(day.models.len(), 1);
+    assert!(day.models.contains_key("claude-sonnet-4"));
+    assert_eq!(filtered.num_conversations, 1);
+    assert_eq!(filtered.session_aggregates[0].session_id, "claude-session");
+    assert_eq!(
+        format_model_usage_shares(
+            &view.daily_stats["2025-01-01"].models,
+            &view.daily_stats["2025-01-01"].model_stats
+        ),
+        "gpt-5 85.2%, claude-sonnet-4 14.8%"
+    );
+    assert_eq!(
+        format_model_usage_shares(
+            &BTreeMap::from([("model-a".to_string(), 2), ("model-b".to_string(), 1)]),
+            &BTreeMap::new()
+        ),
+        "model-a 66.7%, model-b 33.3%"
+    );
+
+    let format_options = crate::utils::NumberFormatOptions {
+        use_comma: false,
+        use_human: false,
+        locale: "en".to_string(),
+        currency_symbol: "$".to_string(),
+        cost_decimal_places: 2,
+        decimal_places: 2,
+    };
+    let backend = TestBackend::new(160, 8);
+    let mut terminal = Terminal::new(backend).unwrap();
+    let mut table_state = TableState::default();
+    terminal
+        .draw(|frame| {
+            draw_aggregate_stats_table(
+                frame,
+                Rect::new(0, 0, 160, 8),
+                &filtered,
+                &format_options,
+                &mut table_state,
+                AggregateViewMode::Daily,
+                "",
+                false,
+                false,
+                Color::Cyan,
+                &HashSet::new(),
+                false,
+            );
+        })
+        .unwrap();
+    let rendered = terminal
+        .backend()
+        .buffer()
+        .content
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect::<String>();
+    assert!(rendered.contains("claude-sonnet-4 100.0%"));
+    assert!(!rendered.contains("gpt-5"));
+    assert!(rendered.contains("$1.25"));
+
+    let unmatched = filter_analyzer_view_by_model(&view, "gemini");
+    assert!(unmatched.daily_stats.is_empty());
+    assert!(unmatched.session_aggregates.is_empty());
+    assert_eq!(unmatched.num_conversations, 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add an interactive TUI model filter and show each model's usage share for the selected period.

## Key changes

- Press `f` to edit a case-insensitive, partial model-name filter; use `Enter` to apply, `Esc` to cancel, and `Ctrl+U` to clear.
- Recalculate aggregate tokens, cost, tool calls, messages, and conversation counts from matching model data.
- Filter the Sessions view to conversations that used a matching model.
- Display per-period and totals-row model shares, using input + output + cached tokens and falling back to message counts when token details are incomplete.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` (401 passed)
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet`
- `git diff --check`
- Ratatui TestBackend rendering coverage for filtered models, recalculated cost, and model shares

## Notes

- The filter is session-local and does not change persistent configuration.
- Session rows are selected by model membership; their numeric values remain whole-session totals because session aggregates do not retain per-model token breakdowns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an interactive model filter accessible with the **`f`** key.
  - Filter model statistics using case-insensitive name matching.
  - Edit, clear, apply, or cancel filters while preserving them during updates.
  - Display active filter status, usage percentages, and estimated-model indicators.
  - Updated keyboard help and disabled quit/update shortcuts while editing.

- **Bug Fixes**
  - Filtering now recalculates statistics, costs, sessions, daily summaries, and usage shares accurately, including when no models match.
  - Aggregate totals now reflect only the currently visible time periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->