### PR TITLE
fix(tui): correct session details for selected periods

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -318,6 +318,8 @@ fn add_new_sessions_to_view(
         for activity in session.daily.values_mut() {
             activity.stats = TuiStats::default();
             activity.models = ModelCounts::new();
+            activity.message_count = 0;
+            activity.ai_message_count = 0;
         }
         let date = session.date;
         view.session_aggregates.push(session);
@@ -1390,6 +1392,13 @@ mod tests {
                 .expect("new session should be visible");
             assert_eq!(new_session.session_name.as_deref(), Some("New session"));
             assert_eq!(new_session.stats.input_tokens, 42);
+            let activity = new_session
+                .daily
+                .values()
+                .next()
+                .expect("new session daily activity");
+            assert_eq!(activity.message_count, 1, "strategy: {strategy:?}");
+            assert_eq!(activity.ai_message_count, 1, "strategy: {strategy:?}");
             drop(view);
 
             assert!(

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -315,6 +315,10 @@ fn add_new_sessions_to_view(
 
         session.stats = TuiStats::default();
         session.models = ModelCounts::new();
+        for activity in session.daily.values_mut() {
+            activity.stats = TuiStats::default();
+            activity.models = ModelCounts::new();
+        }
         let date = session.date;
         view.session_aggregates.push(session);
         view.num_conversations += 1;

--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -298,6 +298,7 @@ fn is_probably_tool_json_text(text: &str) -> bool {
 fn is_noise_title_candidate(text: &str) -> bool {
     let trimmed = text.trim_start();
     is_probably_tool_json_text(trimmed)
+        || trimmed.starts_with("<recommended_plugins>")
         || trimmed.starts_with("<environment_context>")
         || trimmed.starts_with("# AGENTS.md instructions for")
 }

--- a/src/analyzers/tests/codex_cli.rs
+++ b/src/analyzers/tests/codex_cli.rs
@@ -240,6 +240,42 @@ fn test_codex_cli_fallback_session_name_from_first_user_message() {
 }
 
 #[test]
+fn test_codex_cli_session_name_skips_recommended_plugins_context() {
+    let mut temp_file = NamedTempFile::new().unwrap();
+
+    writeln!(
+        temp_file,
+        r#"{{"timestamp":"2026-07-30T00:00:00.000Z","type":"turn_context","payload":{{"model":"gpt-5.6-sol"}}}}"#
+    )
+    .unwrap();
+    writeln!(
+        temp_file,
+        r#"{{"timestamp":"2026-07-30T00:00:01.000Z","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"<recommended_plugins>\nHere is a list of plugins that are available but not installed.\n</recommended_plugins>"}}]}}}}"#
+    )
+    .unwrap();
+    writeln!(
+        temp_file,
+        r#"{{"timestamp":"2026-07-30T00:00:02.000Z","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"分析下这两个网关 issue"}}]}}}}"#
+    )
+    .unwrap();
+
+    let (messages, _model) = parse_codex_cli_jsonl_file(temp_file.path()).unwrap();
+
+    assert!(
+        messages
+            .iter()
+            .filter_map(|message| message.session_name.as_deref())
+            .all(|name| !name.starts_with("<recommended_plugins>"))
+    );
+    assert_eq!(
+        messages
+            .last()
+            .and_then(|message| message.session_name.as_deref()),
+        Some("分析下这两个网关 issue")
+    );
+}
+
+#[test]
 fn test_parse_codex_cli_counts_tool_calls() {
     let mut temp_file = NamedTempFile::new().unwrap();
 

--- a/src/contribution_cache/mod.rs
+++ b/src/contribution_cache/mod.rs
@@ -222,9 +222,15 @@ impl AnalyzerStatsView {
         if let Some(existing) = self.session_aggregates.iter_mut().find(|s| {
             SingleMessageContribution::hash_session_id(&s.session_id) == contrib.session_hash
         }) {
-            existing.stats += contrib.to_tui_stats();
+            let stats = contrib.to_tui_stats();
+            existing.stats += stats;
+            let daily = existing.daily.entry(date).or_default();
+            daily.message_count = daily.message_count.saturating_add(1);
+            daily.stats += stats;
             if let Some(model) = contrib.model {
+                daily.ai_message_count = daily.ai_message_count.saturating_add(1);
                 existing.models.increment(model, 1);
+                daily.models.increment(model, 1);
             }
         }
         // Note: We don't create new sessions here - they should already exist from initial load.
@@ -253,27 +259,42 @@ impl AnalyzerStatsView {
         if let Some(existing) = self.session_aggregates.iter_mut().find(|s| {
             SingleMessageContribution::hash_session_id(&s.session_id) == contrib.session_hash
         }) {
-            existing.stats -= contrib.to_tui_stats();
+            let stats = contrib.to_tui_stats();
+            existing.stats -= stats;
+            if let Some(daily) = existing.daily.get_mut(&contrib.date()) {
+                daily.message_count = daily.message_count.saturating_sub(1);
+                daily.stats -= stats;
+                if let Some(model) = contrib.model {
+                    daily.ai_message_count = daily.ai_message_count.saturating_sub(1);
+                    daily.models.decrement(model, 1);
+                }
+            }
             if let Some(model) = contrib.model {
                 existing.models.decrement(model, 1);
             }
+            existing
+                .daily
+                .retain(|_, activity| activity.message_count > 0);
         }
     }
 
     /// Add a single-session contribution to this view.
     pub fn add_single_session_contribution(&mut self, contrib: &SingleSessionContribution) {
         // Update daily stats
-        let date_str = contrib.date.to_string();
-        let day_stats = self
-            .daily_stats
-            .entry(date_str)
-            .or_insert_with(|| DailyStats {
-                date: contrib.date,
-                ..Default::default()
-            });
-
-        day_stats.ai_messages += contrib.ai_message_count;
-        day_stats.stats += contrib.stats;
+        for (date, activity) in &contrib.daily {
+            let day_stats =
+                self.daily_stats
+                    .entry(date.to_string())
+                    .or_insert_with(|| DailyStats {
+                        date: *date,
+                        ..Default::default()
+                    });
+            day_stats.ai_messages += activity.ai_message_count;
+            day_stats.stats += activity.stats;
+            if *date != contrib.date {
+                day_stats.conversations = day_stats.conversations.saturating_add(1);
+            }
+        }
 
         // Find session by hash and update
         if let Some(existing) = self.session_aggregates.iter_mut().find(|s| {
@@ -283,25 +304,40 @@ impl AnalyzerStatsView {
             for &(model, count) in contrib.models.iter() {
                 existing.models.increment(model, count);
             }
+            for (date, activity) in &contrib.daily {
+                let daily = existing.daily.entry(*date).or_default();
+                daily.message_count = daily.message_count.saturating_add(activity.message_count);
+                daily.ai_message_count = daily
+                    .ai_message_count
+                    .saturating_add(activity.ai_message_count);
+                daily.stats += activity.stats;
+                for &(model, count) in activity.models.iter() {
+                    daily.models.increment(model, count);
+                }
+            }
         }
     }
 
     /// Subtract a single-session contribution from this view.
     pub fn subtract_single_session_contribution(&mut self, contrib: &SingleSessionContribution) {
         // Update daily stats
-        let date_str = contrib.date.to_string();
-        if let Some(day_stats) = self.daily_stats.get_mut(&date_str) {
-            day_stats.ai_messages = day_stats
-                .ai_messages
-                .saturating_sub(contrib.ai_message_count);
-            day_stats.stats -= contrib.stats;
+        for (date, activity) in &contrib.daily {
+            let date_str = date.to_string();
+            if let Some(day_stats) = self.daily_stats.get_mut(&date_str) {
+                day_stats.ai_messages = day_stats
+                    .ai_messages
+                    .saturating_sub(activity.ai_message_count);
+                day_stats.stats -= activity.stats;
+                if *date != contrib.date {
+                    day_stats.conversations = day_stats.conversations.saturating_sub(1);
+                }
 
-            // Remove if empty
-            if day_stats.user_messages == 0
-                && day_stats.ai_messages == 0
-                && day_stats.conversations == 0
-            {
-                self.daily_stats.remove(&date_str);
+                if day_stats.user_messages == 0
+                    && day_stats.ai_messages == 0
+                    && day_stats.conversations == 0
+                {
+                    self.daily_stats.remove(&date_str);
+                }
             }
         }
 
@@ -313,6 +349,22 @@ impl AnalyzerStatsView {
             for &(model, count) in contrib.models.iter() {
                 existing.models.decrement(model, count);
             }
+            for (date, activity) in &contrib.daily {
+                if let Some(daily) = existing.daily.get_mut(date) {
+                    daily.message_count =
+                        daily.message_count.saturating_sub(activity.message_count);
+                    daily.ai_message_count = daily
+                        .ai_message_count
+                        .saturating_sub(activity.ai_message_count);
+                    daily.stats -= activity.stats;
+                    for &(model, count) in activity.models.iter() {
+                        daily.models.decrement(model, count);
+                    }
+                }
+            }
+            existing
+                .daily
+                .retain(|_, activity| activity.message_count > 0);
         }
     }
 
@@ -340,6 +392,18 @@ impl AnalyzerStatsView {
                 existing.stats += new_session.stats;
                 for &(model, count) in new_session.models.iter() {
                     existing.models.increment(model, count);
+                }
+                for (date, activity) in &new_session.daily {
+                    let daily = existing.daily.entry(*date).or_default();
+                    daily.message_count =
+                        daily.message_count.saturating_add(activity.message_count);
+                    daily.ai_message_count = daily
+                        .ai_message_count
+                        .saturating_add(activity.ai_message_count);
+                    daily.stats += activity.stats;
+                    for &(model, count) in activity.models.iter() {
+                        daily.models.increment(model, count);
+                    }
                 }
                 if new_session.first_timestamp < existing.first_timestamp {
                     existing.first_timestamp = new_session.first_timestamp;
@@ -387,6 +451,22 @@ impl AnalyzerStatsView {
                 for &(model, count) in old_session.models.iter() {
                     existing.models.decrement(model, count);
                 }
+                for (date, activity) in &old_session.daily {
+                    if let Some(daily) = existing.daily.get_mut(date) {
+                        daily.message_count =
+                            daily.message_count.saturating_sub(activity.message_count);
+                        daily.ai_message_count = daily
+                            .ai_message_count
+                            .saturating_sub(activity.ai_message_count);
+                        daily.stats -= activity.stats;
+                        for &(model, count) in activity.models.iter() {
+                            daily.models.decrement(model, count);
+                        }
+                    }
+                }
+                existing
+                    .daily
+                    .retain(|_, activity| activity.message_count > 0);
             }
         }
 

--- a/src/contribution_cache/mod.rs
+++ b/src/contribution_cache/mod.rs
@@ -13,12 +13,49 @@ pub use multi_session::MultiSessionContribution;
 pub use single_message::SingleMessageContribution;
 pub use single_session::SingleSessionContribution;
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use dashmap::DashMap;
 use xxhash_rust::xxh3::xxh3_64;
 
-use crate::types::{AnalyzerStatsView, CompactDate, DailyStats};
+use crate::types::{AnalyzerStatsView, CompactDate, DailyStats, SessionPeriodAggregate};
+
+fn merge_daily_add(
+    dst: &mut BTreeMap<CompactDate, SessionPeriodAggregate>,
+    src: &BTreeMap<CompactDate, SessionPeriodAggregate>,
+) {
+    for (date, activity) in src {
+        let daily = dst.entry(*date).or_default();
+        daily.message_count = daily.message_count.saturating_add(activity.message_count);
+        daily.ai_message_count = daily
+            .ai_message_count
+            .saturating_add(activity.ai_message_count);
+        daily.stats += activity.stats;
+        for &(model, count) in activity.models.iter() {
+            daily.models.increment(model, count);
+        }
+    }
+}
+
+fn merge_daily_subtract(
+    dst: &mut BTreeMap<CompactDate, SessionPeriodAggregate>,
+    src: &BTreeMap<CompactDate, SessionPeriodAggregate>,
+) {
+    for (date, activity) in src {
+        if let Some(daily) = dst.get_mut(date) {
+            daily.message_count = daily.message_count.saturating_sub(activity.message_count);
+            daily.ai_message_count = daily
+                .ai_message_count
+                .saturating_sub(activity.ai_message_count);
+            daily.stats -= activity.stats;
+            for &(model, count) in activity.models.iter() {
+                daily.models.decrement(model, count);
+            }
+        }
+    }
+    dst.retain(|_, activity| activity.message_count > 0);
+}
 
 // ============================================================================
 // PathHash - Cache key type
@@ -304,17 +341,7 @@ impl AnalyzerStatsView {
             for &(model, count) in contrib.models.iter() {
                 existing.models.increment(model, count);
             }
-            for (date, activity) in &contrib.daily {
-                let daily = existing.daily.entry(*date).or_default();
-                daily.message_count = daily.message_count.saturating_add(activity.message_count);
-                daily.ai_message_count = daily
-                    .ai_message_count
-                    .saturating_add(activity.ai_message_count);
-                daily.stats += activity.stats;
-                for &(model, count) in activity.models.iter() {
-                    daily.models.increment(model, count);
-                }
-            }
+            merge_daily_add(&mut existing.daily, &contrib.daily);
         }
     }
 
@@ -349,22 +376,7 @@ impl AnalyzerStatsView {
             for &(model, count) in contrib.models.iter() {
                 existing.models.decrement(model, count);
             }
-            for (date, activity) in &contrib.daily {
-                if let Some(daily) = existing.daily.get_mut(date) {
-                    daily.message_count =
-                        daily.message_count.saturating_sub(activity.message_count);
-                    daily.ai_message_count = daily
-                        .ai_message_count
-                        .saturating_sub(activity.ai_message_count);
-                    daily.stats -= activity.stats;
-                    for &(model, count) in activity.models.iter() {
-                        daily.models.decrement(model, count);
-                    }
-                }
-            }
-            existing
-                .daily
-                .retain(|_, activity| activity.message_count > 0);
+            merge_daily_subtract(&mut existing.daily, &contrib.daily);
         }
     }
 
@@ -393,18 +405,7 @@ impl AnalyzerStatsView {
                 for &(model, count) in new_session.models.iter() {
                     existing.models.increment(model, count);
                 }
-                for (date, activity) in &new_session.daily {
-                    let daily = existing.daily.entry(*date).or_default();
-                    daily.message_count =
-                        daily.message_count.saturating_add(activity.message_count);
-                    daily.ai_message_count = daily
-                        .ai_message_count
-                        .saturating_add(activity.ai_message_count);
-                    daily.stats += activity.stats;
-                    for &(model, count) in activity.models.iter() {
-                        daily.models.increment(model, count);
-                    }
-                }
+                merge_daily_add(&mut existing.daily, &new_session.daily);
                 if new_session.first_timestamp < existing.first_timestamp {
                     existing.first_timestamp = new_session.first_timestamp;
                     existing.date = new_session.date;
@@ -451,22 +452,7 @@ impl AnalyzerStatsView {
                 for &(model, count) in old_session.models.iter() {
                     existing.models.decrement(model, count);
                 }
-                for (date, activity) in &old_session.daily {
-                    if let Some(daily) = existing.daily.get_mut(date) {
-                        daily.message_count =
-                            daily.message_count.saturating_sub(activity.message_count);
-                        daily.ai_message_count = daily
-                            .ai_message_count
-                            .saturating_sub(activity.ai_message_count);
-                        daily.stats -= activity.stats;
-                        for &(model, count) in activity.models.iter() {
-                            daily.models.decrement(model, count);
-                        }
-                    }
-                }
-                existing
-                    .daily
-                    .retain(|_, activity| activity.message_count > 0);
+                merge_daily_subtract(&mut existing.daily, &old_session.daily);
             }
         }
 

--- a/src/contribution_cache/single_session.rs
+++ b/src/contribution_cache/single_session.rs
@@ -1,8 +1,11 @@
 //! Single-session contribution type for 1-file-1-session analyzers.
 
+use std::collections::BTreeMap;
+
 use super::SessionHash;
 use crate::types::{
-    CompactDate, ConversationMessage, MessageRole, ModelCounts, TuiStats, intern_model,
+    CompactDate, ConversationMessage, MessageRole, ModelCounts, SessionPeriodAggregate, TuiStats,
+    intern_model,
 };
 
 // ============================================================================
@@ -24,6 +27,8 @@ pub struct SingleSessionContribution {
     pub session_hash: SessionHash,
     /// Number of AI messages (for daily_stats.ai_messages)
     pub ai_message_count: u32,
+    /// Per-day session activity for period drill-down and incremental updates.
+    pub daily: BTreeMap<CompactDate, SessionPeriodAggregate>,
 }
 
 impl SingleSessionContribution {
@@ -34,19 +39,30 @@ impl SingleSessionContribution {
         let mut ai_message_count = 0u32;
         let mut first_date = CompactDate::default();
         let mut session_hash = SessionHash::default();
+        let mut daily = BTreeMap::new();
 
         for (i, msg) in messages.iter().enumerate() {
+            let date = CompactDate::from_local(&msg.date);
             if i == 0 {
-                first_date = CompactDate::from_local(&msg.date);
+                first_date = date;
                 session_hash = SessionHash::from_str(&msg.conversation_hash);
             }
 
+            let day = daily
+                .entry(date)
+                .or_insert_with(SessionPeriodAggregate::default);
+            day.message_count = day.message_count.saturating_add(1);
             if msg.role == MessageRole::Assistant {
                 ai_message_count += 1;
-                stats += TuiStats::from(&msg.stats);
+                day.ai_message_count = day.ai_message_count.saturating_add(1);
+                let message_stats = TuiStats::from(&msg.stats);
+                stats += message_stats;
+                day.stats += message_stats;
 
                 if let Some(model) = &msg.model {
-                    models.increment(intern_model(model), 1);
+                    let model = intern_model(model);
+                    models.increment(model, 1);
+                    day.models.increment(model, 1);
                 }
             }
         }
@@ -57,6 +73,7 @@ impl SingleSessionContribution {
             models,
             session_hash,
             ai_message_count,
+            daily,
         }
     }
 }

--- a/src/contribution_cache/tests/basic_operations.rs
+++ b/src/contribution_cache/tests/basic_operations.rs
@@ -55,6 +55,7 @@ fn test_contribution_cache_single_session_insert_get() {
         models: crate::types::ModelCounts::new(),
         session_hash: SessionHash::from_str("session1"),
         ai_message_count: 5,
+        daily: Default::default(),
     };
 
     cache.insert_single_session(path_hash, contrib);
@@ -106,6 +107,7 @@ fn test_contribution_cache_remove_any() {
             models: crate::types::ModelCounts::new(),
             session_hash: SessionHash::from_str("s2"),
             ai_message_count: 0,
+            daily: Default::default(),
         },
     );
     cache.insert_multi_session(

--- a/src/contribution_cache/tests/mod.rs
+++ b/src/contribution_cache/tests/mod.rs
@@ -91,6 +91,7 @@ pub fn make_view_with_session(analyzer_name: &str, session_id: &str) -> Analyzer
             models: crate::types::ModelCounts::new(),
             session_name: Some(format!("Session {}", session_id)),
             date: CompactDate::from_str("2025-01-01").unwrap(),
+            daily: BTreeMap::new(),
         }],
         num_conversations: 0,
         analyzer_name,

--- a/src/contribution_cache/tests/single_session.rs
+++ b/src/contribution_cache/tests/single_session.rs
@@ -382,7 +382,21 @@ fn test_date_boundary_handling() {
 
     view.add_single_session_contribution(&contrib);
 
-    // Daily stats use the first message's date for SingleSession
-    assert!(view.daily_stats.contains_key("2025-01-15"));
-    // Second message's date is not separately tracked in SingleSession strategy
+    assert_eq!(view.daily_stats["2025-01-15"].stats.input_tokens, 500);
+    assert_eq!(view.daily_stats["2025-01-16"].stats.input_tokens, 800);
+    assert_eq!(view.daily_stats["2025-01-15"].conversations, 0);
+    assert_eq!(view.daily_stats["2025-01-16"].conversations, 1);
+    let session = &view.session_aggregates[0];
+    assert_eq!(
+        session.daily[&crate::types::CompactDate::from_str("2025-01-15").unwrap()]
+            .stats
+            .input_tokens,
+        500
+    );
+    assert_eq!(
+        session.daily[&crate::types::CompactDate::from_str("2025-01-16").unwrap()]
+            .stats
+            .input_tokens,
+        800
+    );
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -5,8 +5,8 @@ mod tests;
 use crate::config::TuiConfig;
 use crate::models::is_model_estimated;
 use crate::types::{
-    AnalyzerStatsView, CompactDate, DailyStats, MultiAnalyzerStatsView, SharedAnalyzerView,
-    resolve_model,
+    AnalyzerStatsView, CompactDate, DailyStats, ModelCounts, MultiAnalyzerStatsView,
+    SharedAnalyzerView, TuiStats, resolve_model,
 };
 use crate::utils::{
     NumberFormatOptions, format_date_for_display, format_number, format_number_fit,
@@ -233,10 +233,57 @@ fn filtered_session_count(view: &AnalyzerStatsView, period_filter: Option<Period
         .map(|filter| {
             view.session_aggregates
                 .iter()
-                .filter(|session| filter.matches_compact_date(session.date))
+                .filter(|session| {
+                    if session.daily.is_empty() {
+                        filter.matches_compact_date(session.date)
+                    } else {
+                        session
+                            .daily
+                            .keys()
+                            .any(|date| filter.matches_compact_date(*date))
+                    }
+                })
                 .count()
         })
         .unwrap_or_else(|| view.session_aggregates.len())
+}
+
+fn sessions_for_period(
+    sessions: &[SessionAggregate],
+    period_filter: Option<PeriodFilter>,
+) -> Vec<SessionAggregate> {
+    let Some(filter) = period_filter else {
+        return sessions.to_vec();
+    };
+
+    sessions
+        .iter()
+        .filter_map(|session| {
+            if session.daily.is_empty() {
+                return filter
+                    .matches_compact_date(session.date)
+                    .then(|| session.clone());
+            }
+
+            let mut filtered = session.clone();
+            filtered.stats = TuiStats::default();
+            filtered.models = ModelCounts::new();
+
+            let mut has_activity = false;
+            for (date, activity) in &session.daily {
+                if !filter.matches_compact_date(*date) {
+                    continue;
+                }
+                has_activity = true;
+                filtered.stats += activity.stats;
+                for &(model, count) in activity.models.iter() {
+                    filtered.models.increment(model, count);
+                }
+            }
+
+            has_activity.then_some(filtered)
+        })
+        .collect()
 }
 
 fn clamp_table_selection(table_state: &mut TableState, total_rows: usize) {
@@ -2081,14 +2128,8 @@ fn draw_session_stats_table(
     .style(Style::default().add_modifier(Modifier::BOLD))
     .height(1);
 
-    let filtered_sessions: Vec<&SessionAggregate> = {
-        let mut sessions: Vec<_> = match period_filter {
-            Some(filter) => sessions
-                .iter()
-                .filter(|session| filter.matches_compact_date(session.date))
-                .collect(),
-            None => sessions.iter().collect(),
-        };
+    let filtered_sessions: Vec<SessionAggregate> = {
+        let mut sessions = sessions_for_period(sessions, period_filter);
         if sort_reversed {
             sessions.reverse();
         }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -265,9 +265,16 @@ fn sessions_for_period(
                     .then(|| session.clone());
             }
 
-            let mut filtered = session.clone();
-            filtered.stats = TuiStats::default();
-            filtered.models = ModelCounts::new();
+            let mut filtered = SessionAggregate {
+                session_id: session.session_id.clone(),
+                first_timestamp: session.first_timestamp,
+                analyzer_name: Arc::clone(&session.analyzer_name),
+                stats: TuiStats::default(),
+                models: ModelCounts::new(),
+                session_name: session.session_name.clone(),
+                date: session.date,
+                daily: BTreeMap::new(),
+            };
 
             let mut has_activity = false;
             for (date, activity) in &session.daily {

--- a/src/tui/logic.rs
+++ b/src/tui/logic.rs
@@ -417,19 +417,28 @@ pub fn aggregate_sessions_from_messages(
                 models: ModelCounts::new(),
                 session_name: None,
                 date: CompactDate::from_local(&msg.date),
+                daily: BTreeMap::new(),
             });
+
+        let activity_date = CompactDate::from_local(&msg.date);
+        let daily = entry.daily.entry(activity_date).or_default();
+        daily.message_count = daily.message_count.saturating_add(1);
 
         if msg.date < entry.first_timestamp {
             entry.first_timestamp = msg.date;
-            entry.date = CompactDate::from_local(&msg.date);
+            entry.date = activity_date;
         }
 
         // Only aggregate stats for assistant messages and track models when known.
         if msg.role == MessageRole::Assistant {
+            daily.ai_message_count = daily.ai_message_count.saturating_add(1);
             accumulate_tui_stats(&mut entry.stats, &msg.stats);
+            accumulate_tui_stats(&mut daily.stats, &msg.stats);
 
             if let Some(model) = &msg.model {
-                entry.models.increment(intern_model(model), 1);
+                let model = intern_model(model);
+                entry.models.increment(model, 1);
+                daily.models.increment(model, 1);
             }
         }
 

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -1,18 +1,21 @@
 /// Tests for TUI components: table state management, upload progress, date matching, and stats accumulation.
 use crate::tui::logic::{
     accumulate_tui_stats, aggregate_daily_stats_by_month, aggregate_daily_stats_by_week,
-    aggregate_daily_stats_by_year, date_matches_buffer, filtered_aggregate_keys,
+    aggregate_daily_stats_by_year, aggregate_sessions_from_messages, date_matches_buffer,
+    filtered_aggregate_keys,
 };
 use crate::tui::{
     AggregateViewMode, PeriodFilter, build_display_stats, cost_heat,
-    create_upload_progress_callback, draw_aggregate_stats_table, format_month_for_display,
-    format_week_for_display, format_year_for_display, parse_accent, show_upload_error,
-    show_upload_success, update_period_filters, update_table_states, update_window_offsets,
+    create_upload_progress_callback, draw_aggregate_stats_table, filtered_session_count,
+    format_month_for_display, format_week_for_display, format_year_for_display, parse_accent,
+    sessions_for_period, show_upload_error, show_upload_success, update_period_filters,
+    update_table_states, update_window_offsets,
 };
 use crate::types::{
-    AgenticCodingToolStats, AnalyzerStatsView, CompactDate, DailyStats, MultiAnalyzerStats, Stats,
-    TuiStats,
+    AgenticCodingToolStats, AnalyzerStatsView, Application, CompactDate, ConversationMessage,
+    DailyStats, MessageRole, MultiAnalyzerStats, Stats, TuiStats,
 };
+use chrono::{TimeZone, Utc};
 use ratatui::Terminal;
 use ratatui::backend::TestBackend;
 use ratatui::layout::Rect;
@@ -20,6 +23,49 @@ use ratatui::style::Color;
 use ratatui::widgets::TableState;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
+
+#[test]
+fn session_detail_includes_sessions_active_after_their_start_date() {
+    let make_message = |day, input_tokens| ConversationMessage {
+        application: Application::CodexCli,
+        date: Utc.with_ymd_and_hms(2026, 7, day, 12, 0, 0).unwrap(),
+        project_hash: String::new(),
+        conversation_hash: "continued-session".into(),
+        local_hash: None,
+        global_hash: format!("message-{day}"),
+        model: Some("gpt-5.6-sol".into()),
+        stats: Stats {
+            input_tokens,
+            ..Stats::default()
+        },
+        role: MessageRole::Assistant,
+        uuid: None,
+        session_name: Some("Continued session".into()),
+    };
+    let sessions = aggregate_sessions_from_messages(
+        &[make_message(30, 10), make_message(31, 20)],
+        Arc::from("Codex CLI"),
+    );
+    let view = AnalyzerStatsView {
+        daily_stats: BTreeMap::new(),
+        session_aggregates: sessions,
+        num_conversations: 1,
+        analyzer_name: Arc::from("Codex CLI"),
+    };
+
+    assert_eq!(
+        filtered_session_count(
+            &view,
+            Some(PeriodFilter::Day(CompactDate::from_parts(2026, 7, 31)))
+        ),
+        1
+    );
+    let filtered = sessions_for_period(
+        &view.session_aggregates,
+        Some(PeriodFilter::Day(CompactDate::from_parts(2026, 7, 31))),
+    );
+    assert_eq!(filtered[0].stats.input_tokens, 20);
+}
 
 // ============================================================================
 // CONFIG-DRIVEN APPEARANCE TESTS

--- a/src/types.rs
+++ b/src/types.rs
@@ -191,6 +191,14 @@ impl ModelCounts {
 /// Pre-computed session aggregate for TUI display.
 /// Contains aggregated stats per conversation session.
 /// Note: Not serialized - view-only type for TUI. Uses `Arc<str>` for memory efficiency.
+#[derive(Debug, Clone, Default)]
+pub struct SessionPeriodAggregate {
+    pub stats: TuiStats,
+    pub models: ModelCounts,
+    pub message_count: u32,
+    pub ai_message_count: u32,
+}
+
 #[derive(Debug, Clone)]
 pub struct SessionAggregate {
     pub session_id: String,
@@ -203,6 +211,8 @@ pub struct SessionAggregate {
     pub models: ModelCounts,
     pub session_name: Option<String>,
     pub date: CompactDate,
+    /// Per-day activity used when drilling into a day, week, month, or year.
+    pub daily: BTreeMap<CompactDate, SessionPeriodAggregate>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -887,6 +897,7 @@ mod tests {
                 models: ModelCounts::from_single(intern_model(model), count),
                 session_name: None,
                 date: CompactDate::default(),
+                daily: BTreeMap::new(),
             }],
             ..Default::default()
         }


### PR DESCRIPTION
## Summary

Fix session drill-down so it reflects activity in the selected period rather than only sessions that started in that period. Also prevent Codex injected plugin metadata from becoming the displayed session title.

## Key changes

- Track per-day stats, models, and activity counts inside session aggregates.
- Include continued and archived sessions when they have activity in the selected day, week, month, or year.
- Show only usage from the selected period while preserving the original session start time.
- Keep incremental contribution-cache updates consistent across date boundaries.
- Skip `<recommended_plugins>` context when choosing Codex session names.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` (402 passed)
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet`
- Runtime TUI check with local Codex data: July 31 drill-down showed continued sessions and its total matched the daily aggregate.

## Notes

No data migration is required; per-period session aggregates are rebuilt from the existing analyzer messages at startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accurate per-day session activity tracking, including message counts, AI activity, statistics, and model usage.
  * Period-based views now show the correct activity for sessions spanning multiple dates.
* **Bug Fixes**
  * Improved session titles by ignoring `<recommended_plugins>` context and using the relevant user message.
  * Corrected daily totals when sessions are added, removed, or filtered.
* **Tests**
  * Added coverage for date-boundary activity totals and improved session naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->