### PR TITLE
fix(claude_code): keep the finished record instead of summing streaming snapshots

### DIFF
--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -821,50 +821,70 @@ pub fn merge_message_into(
         dst.session_name = src.session_name.clone();
     }
 
-    if seen_fps.contains(&src_fp) {
-        // Redundant duplicate: merge non-token stats with max()
-        dst.stats.tool_calls = dst.stats.tool_calls.max(src.stats.tool_calls);
-        dst.stats.files_read = dst.stats.files_read.max(src.stats.files_read);
-        dst.stats.files_edited = dst.stats.files_edited.max(src.stats.files_edited);
-        dst.stats.files_added = dst.stats.files_added.max(src.stats.files_added);
-        dst.stats.terminal_commands = dst.stats.terminal_commands.max(src.stats.terminal_commands);
-        dst.stats.file_searches = dst.stats.file_searches.max(src.stats.file_searches);
-        dst.stats.file_content_searches = dst
-            .stats
-            .file_content_searches
-            .max(src.stats.file_content_searches);
-        dst.stats.todo_writes = dst.stats.todo_writes.max(src.stats.todo_writes);
-        dst.stats.todo_reads = dst.stats.todo_reads.max(src.stats.todo_reads);
-        dst.stats.todos_created = dst.stats.todos_created.max(src.stats.todos_created);
-        dst.stats.todos_completed = dst.stats.todos_completed.max(src.stats.todos_completed);
-        dst.stats.todos_in_progress = dst.stats.todos_in_progress.max(src.stats.todos_in_progress);
-    } else {
-        // New fingerprint: aggregate all stats with sum()
-        seen_fps.insert(src_fp);
+    // Tool and todo counters are per-message totals restated on every record of
+    // the group rather than per-record increments, so the largest value seen is
+    // the count for the message.
+    dst.stats.tool_calls = dst.stats.tool_calls.max(src.stats.tool_calls);
+    dst.stats.files_read = dst.stats.files_read.max(src.stats.files_read);
+    dst.stats.files_edited = dst.stats.files_edited.max(src.stats.files_edited);
+    dst.stats.files_added = dst.stats.files_added.max(src.stats.files_added);
+    dst.stats.terminal_commands = dst.stats.terminal_commands.max(src.stats.terminal_commands);
+    dst.stats.file_searches = dst.stats.file_searches.max(src.stats.file_searches);
+    dst.stats.file_content_searches = dst
+        .stats
+        .file_content_searches
+        .max(src.stats.file_content_searches);
+    dst.stats.todo_writes = dst.stats.todo_writes.max(src.stats.todo_writes);
+    dst.stats.todo_reads = dst.stats.todo_reads.max(src.stats.todo_reads);
+    dst.stats.todos_created = dst.stats.todos_created.max(src.stats.todos_created);
+    dst.stats.todos_completed = dst.stats.todos_completed.max(src.stats.todos_completed);
+    dst.stats.todos_in_progress = dst.stats.todos_in_progress.max(src.stats.todos_in_progress);
 
-        dst.stats.input_tokens += src.stats.input_tokens;
-        dst.stats.output_tokens += src.stats.output_tokens;
-        dst.stats.cache_creation_tokens += src.stats.cache_creation_tokens;
-        dst.stats.cache_read_tokens += src.stats.cache_read_tokens;
-        dst.stats.cached_tokens += src.stats.cached_tokens;
+    // Records sharing a key are one message written several times while it
+    // streamed, not separate work. The streaming protocol delivers usage as
+    // cumulative snapshots of a single billed request: `message_delta` carries
+    // running totals for the message and the final event is the bill. Only
+    // `output_tokens` grows between snapshots; the input and cache fields are
+    // identical on every record of the group, so adding them would count the
+    // same tokens once per snapshot.
+    //
+    // That is the assumption to revisit first if these numbers ever look wrong.
+    // It holds because no writer path emits two separately billable chunks under
+    // one key. If one ever does, those chunks need distinguishing from a
+    // streaming snapshot rather than being summed blindly.
+    //
+    // Keep the more complete record whole instead of combining fields. A
+    // per-field maximum would assemble a record that was never written, and
+    // `cost` is derived from those fields, so the resulting cost would
+    // correspond to no observation.
+    if seen_fps.insert(src_fp) && replaces_existing(&dst.stats, &src.stats) {
+        dst.stats.input_tokens = src.stats.input_tokens;
+        dst.stats.output_tokens = src.stats.output_tokens;
+        dst.stats.cache_creation_tokens = src.stats.cache_creation_tokens;
+        dst.stats.cache_read_tokens = src.stats.cache_read_tokens;
+        dst.stats.cached_tokens = src.stats.cached_tokens;
 
-        dst.stats.tool_calls += src.stats.tool_calls;
-        dst.stats.files_read += src.stats.files_read;
-        dst.stats.files_edited += src.stats.files_edited;
-        dst.stats.files_added += src.stats.files_added;
-        dst.stats.terminal_commands += src.stats.terminal_commands;
-        dst.stats.file_searches += src.stats.file_searches;
-        dst.stats.file_content_searches += src.stats.file_content_searches;
-        dst.stats.todo_writes += src.stats.todo_writes;
-        dst.stats.todo_reads += src.stats.todo_reads;
-        dst.stats.todos_created += src.stats.todos_created;
-        dst.stats.todos_completed += src.stats.todos_completed;
-        dst.stats.todos_in_progress += src.stats.todos_in_progress;
-
-        // Preserve each message's timestamp-aware price: `dst.stats.cost` was
-        // already priced at `dst.date`, and `src.stats.cost` was already
-        // priced at `src.date`, so just accumulate rather than recomputing
-        // the whole total at `dst.date` (which would reprice `src`'s tokens).
-        dst.stats.cost += src.stats.cost;
+        // Each record was already priced at its own timestamp, so take the
+        // winner's cost rather than repricing its tokens at `dst.date`.
+        dst.stats.cost = src.stats.cost;
     }
+}
+
+/// Whether `candidate` is the more complete record of a streaming group.
+///
+/// Higher `output_tokens` wins, since that is the only field that grows between
+/// snapshots of one message. A tie falls back to the four-field total so the
+/// choice stays deterministic instead of depending on traversal order, which is
+/// not defined across files. `cached_tokens` is left out of that total because it
+/// is derived from the two cache fields and would count them twice.
+fn replaces_existing(current: &Stats, candidate: &Stats) -> bool {
+    if candidate.output_tokens != current.output_tokens {
+        return candidate.output_tokens > current.output_tokens;
+    }
+
+    token_total(candidate) > token_total(current)
+}
+
+fn token_total(stats: &Stats) -> u64 {
+    stats.input_tokens + stats.output_tokens + stats.cache_creation_tokens + stats.cache_read_tokens
 }

--- a/src/analyzers/tests/claude_code.rs
+++ b/src/analyzers/tests/claude_code.rs
@@ -80,7 +80,7 @@ static DUPLICATE_MESSAGES_DATA: LazyLock<String> = LazyLock::new(|| {
 });
 
 #[test]
-fn test_deduplicate_messages_merges_same_local_hash_across_uuids() {
+fn test_deduplicate_messages_resolves_same_local_hash_across_uuids() {
     let mut first = ConversationMessage {
         application: Application::ClaudeCode,
         date: Utc.with_ymd_and_hms(2025, 8, 2, 16, 0, 0).unwrap(),
@@ -102,14 +102,59 @@ fn test_deduplicate_messages_merges_same_local_hash_across_uuids() {
     second.uuid = Some("uuid-b".to_string());
     second.stats.input_tokens = 20;
 
+    // Output is tied at zero here, so the four-field total decides and the second
+    // record is kept whole: 20, not 10 + 20.
     let deduplicated = deduplicate_messages(vec![first.clone(), second]);
     assert_eq!(deduplicated.len(), 1);
-    assert_eq!(deduplicated[0].stats.input_tokens, 30);
+    assert_eq!(deduplicated[0].stats.input_tokens, 20);
 
     first.stats.input_tokens = 10;
     let duplicate_fingerprint = deduplicate_messages(vec![first.clone(), first]);
     assert_eq!(duplicate_fingerprint.len(), 1);
     assert_eq!(duplicate_fingerprint[0].stats.input_tokens, 10);
+}
+
+#[test]
+fn test_streaming_snapshots_do_not_inflate_identical_fields() {
+    // The shape a streaming assistant message actually takes on disk: several
+    // records under one `(requestId, message.id)` key where only `output_tokens`
+    // grows, while the input and cache fields are identical on every record of
+    // the group. Two distinct fingerprints per group is the whole of it.
+    let partial = ConversationMessage {
+        application: Application::ClaudeCode,
+        date: Utc.with_ymd_and_hms(2025, 8, 2, 16, 0, 0).unwrap(),
+        project_hash: "project".to_string(),
+        conversation_hash: "conversation".to_string(),
+        local_hash: Some("streaming-local-hash".to_string()),
+        global_hash: "uuid-partial".to_string(),
+        model: Some("claude-sonnet-4-20250514".to_string()),
+        stats: Stats {
+            input_tokens: 2,
+            output_tokens: 4,
+            cache_creation_tokens: 53_554,
+            cache_read_tokens: 0,
+            cached_tokens: 53_554,
+            ..Stats::default()
+        },
+        role: MessageRole::Assistant,
+        uuid: Some("uuid-partial".to_string()),
+        session_name: None,
+    };
+    let mut finished = partial.clone();
+    finished.global_hash = "uuid-finished".to_string();
+    finished.uuid = Some("uuid-finished".to_string());
+    finished.stats.output_tokens = 248;
+
+    let deduplicated = deduplicate_messages(vec![partial, finished]);
+
+    // The finished record, whole. Input is not 2 + 2 and cache creation is not
+    // 53,554 counted twice.
+    assert_eq!(deduplicated.len(), 1);
+    assert_eq!(deduplicated[0].stats.input_tokens, 2);
+    assert_eq!(deduplicated[0].stats.output_tokens, 248);
+    assert_eq!(deduplicated[0].stats.cache_creation_tokens, 53_554);
+    assert_eq!(deduplicated[0].stats.cache_read_tokens, 0);
+    assert_eq!(deduplicated[0].stats.cached_tokens, 53_554);
 }
 
 #[test]
@@ -357,11 +402,12 @@ fn test_deduplicate_messages_by_local_hash() {
 
     let deduplicated = deduplicate_messages_by_local_hash(messages);
 
-    // Deduplication now aggregates messages with the same local_hash
+    // Deduplication resolves messages with the same local_hash to one record
     assert_eq!(deduplicated.len(), 1);
 
-    // Should sum the tokens from both entries: 10 + 15 = 25
-    assert_eq!(deduplicated[0].stats.input_tokens, 25);
+    // The second record has the higher output, so it is kept whole: 15, not
+    // 10 + 15
+    assert_eq!(deduplicated[0].stats.input_tokens, 15);
 
     // Test with manually created messages that should be deduplicated
     let mut test_messages = Vec::new();
@@ -405,16 +451,14 @@ fn test_deduplicate_messages_by_local_hash() {
     test_messages.push(duplicate_msg.clone());
 
     let deduplicated_test = deduplicate_messages_by_local_hash(test_messages);
-    // Aggregation logic merges messages with the same local_hash
+    // Selection resolves messages with the same local_hash to one record
     assert_eq!(deduplicated_test.len(), 1);
-    // Should keep the first message's metadata but aggregate the tokens
+    // Should keep the first message's metadata and the winning record's tokens
     assert_eq!(deduplicated_test[0].global_hash, "global1");
-    // Should sum the tokens from both entries: 10 + 15 = 25
-    assert_eq!(deduplicated_test[0].stats.input_tokens, 25);
-    // Should sum output tokens: 5 + 8 = 13
-    assert_eq!(deduplicated_test[0].stats.output_tokens, 13);
-    // Should sum cache tokens: 3 + 5 = 8
-    assert_eq!(deduplicated_test[0].stats.cached_tokens, 8);
+    // The duplicate has the higher output, so its record is kept whole
+    assert_eq!(deduplicated_test[0].stats.input_tokens, 15);
+    assert_eq!(deduplicated_test[0].stats.output_tokens, 8);
+    assert_eq!(deduplicated_test[0].stats.cached_tokens, 5);
     // Should preserve session name
     assert_eq!(
         deduplicated_test[0].session_name,


### PR DESCRIPTION
Fixes the deduplication half of #220.

## Problem

`merge_message_into` summed every token field whenever a record shared a `(requestId, message.id)` key with an earlier one and carried a usage fingerprint not seen before. A streaming assistant message is written as several records under one key, and only `output_tokens` grows between them: the input and cache fields are identical on every record of the group. Summing therefore added those identical values once more per snapshot, and `cost` followed the tokens.

Main transcripts repeat the final usage on every record, so the fingerprint never changes there and the rule was harmless. Subagent transcripts do not, and they became reachable when #209 lifted the depth cap. The change that made the files visible is what armed this.

## The rule

Keep the whole record with the higher `output_tokens`, falling back to the four-field total when output ties.

Whole record rather than per-field maximum: a per-field maximum would assemble a record that was never written, and since `cost` is derived from those fields the resulting cost would correspond to no observation. Maximum rather than last-read: traversal order is not defined across files, so last-read would make the result depend on which file the filesystem hands over first. ccusage (`should_replace_deduped_entry`) and Claude-Code-Usage-Monitor (`_replaces_existing`) settled on the same shape independently.

The open question in #220 was whether the summing served a real case: two records under one key that are genuinely two separately billable chunks. @lizhuojunx86 answered it from the protocol side rather than the corpus. Streaming delivers usage as cumulative snapshots of a single billed request, `message_delta` carries running totals for the message and the final event is the bill, so on the current protocol such chunks have no emitter. The code comment states that assumption explicitly, so a future writer path that ever does emit additive chunks has an obvious place to start rather than a silent wrong answer.

## What changed

`merge_message_into` loses the two-branch structure. The non-token counters were merged with `max` on one path and summed on the other; they are per-message totals restated on every record rather than per-record increments, so they are merged with `max` on both paths now. The token fields and `cost` are taken from the winning record whole. Selection lives in a small `replaces_existing` helper with the reasoning attached.

The fingerprint set no longer decides the outcome. I left the parameter in place to keep this diff to one function; it can come out along with `TokenFingerprint` in a follow-up if you would rather not carry it.

## Tests

Three existing assertions changed with the rule, in `test_deduplicate_messages_resolves_same_local_hash_across_uuids` and `test_deduplicate_messages_by_local_hash`. Both fixtures give the two records under one key different input and cache values. That shape does not occur in real transcripts, where those fields are byte-identical across the group and only output grows, so the assertions were pinning behaviour derived from a case the writer does not produce. The first test was also renamed, since the records are now resolved rather than merged.

`test_streaming_snapshots_do_not_inflate_identical_fields` is new and uses the real shape: one partial snapshot and one finished record, identical input and cache, output growing from 4 to 248. It asserts that input stays at 2 rather than becoming 4, and that cache creation stays at 53,554 rather than being counted twice. Two distinct fingerprints per group is the whole of the behaviour, so this fixture covers it: @lizhuojunx86 measured the k-distribution as {1: 5,622, 2: 13,205} with no group above two.

## Verification

401 passed, 0 failed. `cargo clippy --locked --all-targets -- -D warnings` and `cargo fmt --check` both clean.

`checks.yml` does not run `cargo test`, so I ran it on a temporary workflow on my fork rather than claim the suite passes without evidence: [run 30642066207](https://github.com/NickAme03/splitrail/actions/runs/30642066207). That run is on the same tree as this branch plus the temporary workflow file, which is not part of this change. The branch it ran on is kept at `NickAme03/splitrail@verify-ci` so the link stays resolvable.

Worth saying plainly as a separate observation: those 401 tests are never executed by the project's own CI. `checks.yml` runs `cargo metadata`, clippy, `cargo fmt --check`, license checks and `cargo audit`. Clippy with `--all-targets` compiles the test targets, so a test that fails to build is caught, but a test whose assertion is wrong passes unnoticed. That is part of why this rule survived: it is pinned by tests that nothing runs.

## Measurement

Two independent corpora, mine and @lizhuojunx86's, on subagent transcripts:

| field | mine | his |
|---|---|---|
| input | +63% | +62.4% |
| output | +0.4% | +0.36% |
| cache_creation | +47% | +74.8% |
| cache_read | +61% | +68.8% |

Main transcripts sit at 1.0000x on all four fields in both. `cache_creation` differs between the two because its inflation scales with how many affected groups actually create cache, which is a property of the workload rather than of the rule.

Happy to adjust the shape if you would rather keep the summing for a case I have not accounted for. @lizhuojunx86 has offered to rerun his corpus against this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streaming usage records to prevent token and cost totals from being double-counted.
  * Preserved the most complete usage snapshot when duplicate records are detected.
  * Accurately combines tool and todo statistics across records.
* **Tests**
  * Expanded coverage for duplicate and streaming usage scenarios, including shared input and cache data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->