### PR TITLE
feat(models): add Claude Opus 5 pricing

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1030,6 +1030,18 @@ fn populate_defaults(
         }
     );
     add_model!(
+        "claude-opus-5",
+        PricingStructure::Flat {
+            input_per_1m: 5.0,
+            output_per_1m: 25.0
+        },
+        CachingSupport::Anthropic {
+            cache_write_per_1m: 6.25,
+            cache_read_per_1m: 0.5
+        },
+        false
+    );
+    add_model!(
         "claude-opus-4-8",
         PricingStructure::Flat {
             input_per_1m: 5.0,
@@ -1917,6 +1929,11 @@ fn populate_defaults(
     add_alias!("claude-5-sonnet", "claude-sonnet-5");
     add_alias!("claude-5.0-sonnet", "claude-sonnet-5");
     add_alias!("global.anthropic.claude-sonnet-5", "claude-sonnet-5");
+    add_alias!("claude-opus-5", "claude-opus-5");
+    add_alias!("claude-opus-5.0", "claude-opus-5");
+    add_alias!("claude-5-opus", "claude-opus-5");
+    add_alias!("claude-5.0-opus", "claude-opus-5");
+    add_alias!("global.anthropic.claude-opus-5", "claude-opus-5");
     add_alias!("claude-opus-4.8", "claude-opus-4-8");
     add_alias!("claude-4.8-opus", "claude-opus-4-8");
     add_alias!("claude-opus-4-8", "claude-opus-4-8");
@@ -2752,6 +2769,20 @@ mod tests {
         assert!(get_model_info("review-invalid-tier-alias").is_none());
 
         reset_global_registry();
+    }
+
+    #[test]
+    fn claude_opus_5_alias_maps_to_pricing() {
+        let model_info = get_model_info("claude-5-opus").expect("model should exist");
+        assert!(!model_info.is_estimated);
+
+        let input_cost = calculate_input_cost("claude-5-opus", 1_000_000);
+        let output_cost = calculate_output_cost("claude-5-opus", 1_000_000);
+        let cache_cost = calculate_cache_cost("claude-5-opus", 1_000_000, 1_000_000);
+
+        approx_eq(input_cost, 5.0);
+        approx_eq(output_cost, 25.0);
+        approx_eq(cache_cost, 6.75);
     }
 
     #[test]


### PR DESCRIPTION
Closes #221.

`claude-opus-5` had no entry, so `get_model_info` returned `None` and every Opus 5 message priced to $0 after a `warn_once`. On the corpus in #221 that was $108.60 of usage reported as free.

Rates are $5 per million input and $25 per million output, the same as Claude Opus 4.8, which puts cache write at 6.25 and cache read at 0.5 under the multipliers this file uses throughout. The entry sits between `claude-sonnet-5` and `claude-opus-4-8`, matching the existing ordering.

Aliases follow the shape already used for the other 5-generation models. One line is a judgement rather than a deduction: `global.anthropic.claude-opus-5` matches what `claude-sonnet-5` carries, while `claude-fable-5` has no such alias, so the file is not consistent on that point today. Easy to drop if you would rather it were not there.

The test mirrors `claude_opus_4_8_alias_maps_to_pricing`.

**Verification.** 402 passed, 0 failed, including the new test. `cargo clippy --locked --all-targets -- -D warnings` and `cargo fmt --check` clean. Run: [30646415635](https://github.com/NickAme03/splitrail/actions/runs/30646415635), on the same tree as this branch plus a temporary workflow that is not part of the change, since `checks.yml` does not run `cargo test`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude Opus 5 model.
  * Added recognition for canonical, versioned, alternate-format, and Bedrock model names.
  * Added pricing for input, output, and cached usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->