### PR TITLE
fix(analyzers): respect custom config directories

### DIFF
--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -94,7 +94,9 @@ impl ClaudeCodeAnalyzer {
     }
 
     pub(crate) fn parse_live_source(source: &DataSource) -> Result<Vec<ConversationMessage>> {
-        let project_hash = extract_and_hash_project_id(&source.path);
+        let project_hash = Self::data_dir()
+            .map(|projects_dir| extract_and_hash_project_id_in(&projects_dir, &source.path))
+            .unwrap_or_else(|| extract_and_hash_project_id(&source.path));
         let conversation_hash = crate::utils::hash_text(&source.path.to_string_lossy());
         let file = File::open(&source.path)?;
         let (mut messages, summaries, _uuids, fallback) =
@@ -369,6 +371,16 @@ pub fn extract_and_hash_project_id(file_path: &Path) -> String {
     project_id
         .map(hash_text)
         .unwrap_or_else(|| hash_text(&file_path.to_string_lossy()))
+}
+
+pub(crate) fn extract_and_hash_project_id_in(projects_dir: &Path, file_path: &Path) -> String {
+    file_path
+        .strip_prefix(projects_dir)
+        .ok()
+        .and_then(|relative| relative.components().next())
+        .and_then(|project_id| project_id.as_os_str().to_str())
+        .map(hash_text)
+        .unwrap_or_else(|| extract_and_hash_project_id(file_path))
 }
 
 // CLAUDE CODE JSONL FILES SCHEMA

--- a/src/analyzers/claude_code.rs
+++ b/src/analyzers/claude_code.rs
@@ -5,6 +5,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use simd_json::prelude::*;
 use std::collections::{HashMap, HashSet};
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -25,6 +26,17 @@ type ParseResult = (
     Option<String>,
 );
 
+pub(crate) fn claude_projects_dir(
+    config_dir: Option<&OsStr>,
+    home_dir: Option<&Path>,
+) -> Option<PathBuf> {
+    config_dir
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| home_dir.map(|home| home.join(".claude")))
+        .map(|config_dir| config_dir.join("projects"))
+}
+
 pub struct ClaudeCodeAnalyzer {
     discovery_was_complete: AtomicBool,
 }
@@ -39,7 +51,9 @@ impl ClaudeCodeAnalyzer {
     }
 
     fn data_dir() -> Option<PathBuf> {
-        dirs::home_dir().map(|h| h.join(".claude").join("projects"))
+        let config_dir = std::env::var_os("CLAUDE_CONFIG_DIR");
+        let home_dir = dirs::home_dir();
+        claude_projects_dir(config_dir.as_deref(), home_dir.as_deref())
     }
 
     pub(crate) fn discover_sources_in(&self, projects_dir: &Path) -> Vec<DataSource> {
@@ -110,12 +124,10 @@ impl Analyzer for ClaudeCodeAnalyzer {
     fn get_data_glob_patterns(&self) -> Vec<String> {
         let mut patterns = Vec::new();
 
-        if let Some(home_dir) = dirs::home_dir() {
-            let home_str = home_dir.to_string_lossy();
-            patterns.push(format!("{home_str}/.claude/projects/*/*.jsonl"));
-            patterns.push(format!(
-                "{home_str}/.claude/projects/*/*/subagents/**/*.jsonl"
-            ));
+        if let Some(projects_dir) = Self::data_dir() {
+            let projects_str = projects_dir.to_string_lossy();
+            patterns.push(format!("{projects_str}/*/*.jsonl"));
+            patterns.push(format!("{projects_str}/*/*/subagents/**/*.jsonl"));
         }
 
         patterns

--- a/src/analyzers/codex_cli.rs
+++ b/src/analyzers/codex_cli.rs
@@ -22,9 +22,19 @@ const DEFAULT_FALLBACK_MODEL: &str = "gpt-5";
 
 static FALLBACK_MODEL: OnceLock<String> = OnceLock::new();
 
-pub(crate) fn get_fallback_model_with_home(home_dir: Option<PathBuf>) -> String {
-    home_dir
-        .map(|h| h.join(".codex").join("config.toml"))
+fn codex_home_with_roots(codex_home: Option<&OsStr>, home_dir: Option<&Path>) -> Option<PathBuf> {
+    codex_home
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| home_dir.map(|home| home.join(".codex")))
+}
+
+pub(crate) fn get_fallback_model_with_roots(
+    codex_home: Option<&OsStr>,
+    home_dir: Option<&Path>,
+) -> String {
+    codex_home_with_roots(codex_home, home_dir)
+        .map(|codex_home| codex_home.join("config.toml"))
         .filter(|p| p.is_file())
         .and_then(|p| std::fs::read_to_string(p).ok())
         .and_then(|content| {
@@ -46,7 +56,9 @@ fn get_fallback_model() -> &'static str {
         if cfg!(test) {
             DEFAULT_FALLBACK_MODEL.to_string()
         } else {
-            get_fallback_model_with_home(dirs::home_dir())
+            let codex_home = std::env::var_os("CODEX_HOME");
+            let home_dir = dirs::home_dir();
+            get_fallback_model_with_roots(codex_home.as_deref(), home_dir.as_deref())
         }
     })
 }
@@ -59,17 +71,21 @@ impl CodexCliAnalyzer {
     }
 
     fn data_dirs() -> Vec<PathBuf> {
-        data_dirs_with_home(dirs::home_dir())
+        let codex_home = std::env::var_os("CODEX_HOME");
+        let home_dir = dirs::home_dir();
+        data_dirs_with_roots(codex_home.as_deref(), home_dir.as_deref())
     }
 }
 
-pub(crate) fn data_dirs_with_home(home_dir: Option<PathBuf>) -> Vec<PathBuf> {
-    home_dir
-        .map(|home| {
-            let codex_dir = home.join(".codex");
+pub(crate) fn data_dirs_with_roots(
+    codex_home: Option<&OsStr>,
+    home_dir: Option<&Path>,
+) -> Vec<PathBuf> {
+    codex_home_with_roots(codex_home, home_dir)
+        .map(|codex_home| {
             vec![
-                codex_dir.join("sessions"),
-                codex_dir.join("archived_sessions"),
+                codex_home.join("sessions"),
+                codex_home.join("archived_sessions"),
             ]
         })
         .unwrap_or_default()
@@ -142,15 +158,10 @@ impl Analyzer for CodexCliAnalyzer {
     }
 
     fn get_data_glob_patterns(&self) -> Vec<String> {
-        let mut patterns = Vec::new();
-
-        if let Some(home_dir) = dirs::home_dir() {
-            let home_str = home_dir.to_string_lossy();
-            patterns.push(format!("{home_str}/.codex/sessions/**/*.jsonl"));
-            patterns.push(format!("{home_str}/.codex/archived_sessions/**/*.jsonl"));
-        }
-
-        patterns
+        Self::data_dirs()
+            .into_iter()
+            .map(|data_dir| format!("{}/**/*.jsonl", data_dir.to_string_lossy()))
+            .collect()
     }
 
     fn discover_data_sources(&self) -> Result<Vec<DataSource>> {

--- a/src/analyzers/tests/claude_code.rs
+++ b/src/analyzers/tests/claude_code.rs
@@ -1,8 +1,8 @@
 use crate::analyzer::{Analyzer, DataSource};
 use crate::analyzers::claude_code::{
-    ClaudeCodeAnalyzer, TokenFingerprint, calculate_cost_from_tokens, deduplicate_grouped_messages,
-    deduplicate_messages, extract_and_hash_project_id, is_claude_transcript_path,
-    merge_message_into, parse_jsonl_file,
+    ClaudeCodeAnalyzer, TokenFingerprint, calculate_cost_from_tokens, claude_projects_dir,
+    deduplicate_grouped_messages, deduplicate_messages, extract_and_hash_project_id,
+    is_claude_transcript_path, merge_message_into, parse_jsonl_file,
 };
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use chrono::{TimeZone, Utc};
@@ -10,7 +10,7 @@ use simd_json::json;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufReader, Cursor};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
 /// Test helper: Sequential deduplication using merge_message_into
@@ -285,6 +285,22 @@ fn test_claude_transcript_path_classification() {
         projects,
         &projects.join("project/session.jsonl/extra.jsonl")
     ));
+}
+
+#[test]
+fn test_claude_projects_dir_respects_config_override() {
+    let home = Path::new("/home/user");
+    let custom = Path::new("/custom/claude");
+
+    assert_eq!(
+        claude_projects_dir(Some(custom.as_os_str()), Some(home)),
+        Some(PathBuf::from("/custom/claude/projects"))
+    );
+    assert_eq!(
+        claude_projects_dir(Some(Path::new("").as_os_str()), Some(home)),
+        Some(PathBuf::from("/home/user/.claude/projects"))
+    );
+    assert_eq!(claude_projects_dir(None, None), None);
 }
 
 #[test]

--- a/src/analyzers/tests/claude_code.rs
+++ b/src/analyzers/tests/claude_code.rs
@@ -2,7 +2,8 @@ use crate::analyzer::{Analyzer, DataSource};
 use crate::analyzers::claude_code::{
     ClaudeCodeAnalyzer, TokenFingerprint, calculate_cost_from_tokens, claude_projects_dir,
     deduplicate_grouped_messages, deduplicate_messages, extract_and_hash_project_id,
-    is_claude_transcript_path, merge_message_into, parse_jsonl_file,
+    extract_and_hash_project_id_in, is_claude_transcript_path, merge_message_into,
+    parse_jsonl_file,
 };
 use crate::types::{Application, ConversationMessage, MessageRole, Stats};
 use chrono::{TimeZone, Utc};
@@ -254,6 +255,21 @@ fn test_extract_and_hash_project_id() {
     // Hashes should not be empty.
     assert!(!hash1.is_empty());
     assert!(!hash3.is_empty());
+}
+
+#[test]
+fn test_extract_project_hash_from_custom_projects_dir() {
+    let projects = Path::new("/custom/config-root/projects");
+    let first = projects.join("project-a/session-1.jsonl");
+    let second = projects.join("project-a/session-2/subagents/agent-1.jsonl");
+    let other = projects.join("project-b/session-3.jsonl");
+
+    let first_hash = extract_and_hash_project_id_in(projects, &first);
+    assert_eq!(
+        first_hash,
+        extract_and_hash_project_id_in(projects, &second)
+    );
+    assert_ne!(first_hash, extract_and_hash_project_id_in(projects, &other));
 }
 
 #[test]

--- a/src/analyzers/tests/codex_cli.rs
+++ b/src/analyzers/tests/codex_cli.rs
@@ -29,7 +29,25 @@ fn test_codex_data_dirs_include_active_and_archived_sessions() {
     let home = std::path::PathBuf::from("/home/test");
 
     assert_eq!(
-        data_dirs_with_home(Some(home.clone())),
+        data_dirs_with_roots(None, Some(&home)),
+        vec![
+            home.join(".codex/sessions"),
+            home.join(".codex/archived_sessions")
+        ]
+    );
+}
+
+#[test]
+fn test_codex_data_dirs_respect_codex_home() {
+    let home = std::path::Path::new("/home/test");
+    let custom = std::path::Path::new("/custom/codex");
+
+    assert_eq!(
+        data_dirs_with_roots(Some(custom.as_os_str()), Some(home)),
+        vec![custom.join("sessions"), custom.join("archived_sessions")]
+    );
+    assert_eq!(
+        data_dirs_with_roots(Some(std::ffi::OsStr::new("")), Some(home)),
         vec![
             home.join(".codex/sessions"),
             home.join(".codex/archived_sessions")
@@ -473,59 +491,72 @@ fn test_codex_availability() {
 }
 
 #[test]
-fn test_get_fallback_model_with_home() {
+fn test_get_fallback_model_with_roots() {
     let dir = tempfile::tempdir().unwrap();
     let codex_dir = dir.path().join(".codex");
     std::fs::create_dir(&codex_dir).unwrap();
     let config_path = codex_dir.join("config.toml");
 
     // Test case 1: no config file
-    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    let model = get_fallback_model_with_roots(None, Some(dir.path()));
     assert_eq!(model, "gpt-5");
 
     // Test case 2: empty config file
     let mut file = std::fs::File::create(&config_path).unwrap();
     file.write_all(b"").unwrap();
     drop(file);
-    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    let model = get_fallback_model_with_roots(None, Some(dir.path()));
     assert_eq!(model, "gpt-5");
 
     // Test case 3: model configured in config file
     let mut file = std::fs::File::create(&config_path).unwrap();
     file.write_all(b"model = \"gpt-5.5\"\n").unwrap();
     drop(file);
-    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    let model = get_fallback_model_with_roots(None, Some(dir.path()));
     assert_eq!(model, "gpt-5.5");
 
     // Test case 4: empty string in config
     let mut file = std::fs::File::create(&config_path).unwrap();
     file.write_all(b"model = \"\"\n").unwrap();
     drop(file);
-    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    let model = get_fallback_model_with_roots(None, Some(dir.path()));
     assert_eq!(model, "gpt-5");
 
     // Test case 5: None home directory
-    let model = get_fallback_model_with_home(None);
+    let model = get_fallback_model_with_roots(None, None);
     assert_eq!(model, "gpt-5");
 
     // Test case 6: whitespace-only model
     let mut file = std::fs::File::create(&config_path).unwrap();
     file.write_all(b"model = \"   \"\n").unwrap();
     drop(file);
-    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    let model = get_fallback_model_with_roots(None, Some(dir.path()));
     assert_eq!(model, "gpt-5");
 
     // Test case 7: invalid TOML syntax
     let mut file = std::fs::File::create(&config_path).unwrap();
     file.write_all(b"model = \n").unwrap();
     drop(file);
-    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    let model = get_fallback_model_with_roots(None, Some(dir.path()));
     assert_eq!(model, "gpt-5");
 
     // Test case 8: config file exists but model key is omitted
     let mut file = std::fs::File::create(&config_path).unwrap();
     file.write_all(b"other_key = \"value\"\n").unwrap();
     drop(file);
-    let model = get_fallback_model_with_home(Some(dir.path().to_path_buf()));
+    let model = get_fallback_model_with_roots(None, Some(dir.path()));
     assert_eq!(model, "gpt-5");
+}
+
+#[test]
+fn test_fallback_model_respects_codex_home() {
+    let dir = tempfile::tempdir().unwrap();
+    let custom = dir.path().join("custom-codex");
+    std::fs::create_dir(&custom).unwrap();
+    std::fs::write(custom.join("config.toml"), "model = \"gpt-5.5\"\n").unwrap();
+
+    assert_eq!(
+        get_fallback_model_with_roots(Some(custom.as_os_str()), Some(dir.path())),
+        "gpt-5.5"
+    );
 }


### PR DESCRIPTION
## Summary

Respect the configuration directory overrides used by Claude Code and Codex instead of always reading from their default home-directory locations.

Closes #4.

## Key changes

- Read Claude transcripts from `$CLAUDE_CONFIG_DIR/projects` when the variable is non-empty.
- Read Codex active and archived sessions from `$CODEX_HOME`, and load the fallback model from `$CODEX_HOME/config.toml`.
- Preserve the existing `~/.claude` and `~/.codex` defaults when overrides are unset or empty.
- Apply the resolved paths consistently to discovery, glob patterns, file watching, availability, and path validation.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` (408 passed)
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom Claude Code configuration locations through `CLAUDE_CONFIG_DIR`.
  * Added support for custom Codex CLI data locations through `CODEX_HOME`.
  * Improved discovery of projects, sessions, archived data, and fallback model settings in custom locations.

* **Bug Fixes**
  * Corrected handling of empty or missing configuration paths.
  * Improved fallback behavior when configuration files are missing, invalid, or incomplete.

* **Tests**
  * Added coverage for default and custom configuration paths and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->