### PR TITLE
test(codex_cli): build session paths component by component so hashes match on Windows

### DIFF
--- a/src/analyzers/tests/codex_cli.rs
+++ b/src/analyzers/tests/codex_cli.rs
@@ -106,8 +106,18 @@ fn test_valid_codex_data_paths_must_be_inside_watched_directories() {
 #[test]
 fn test_message_hashes_remain_stable_after_archiving() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let active_dir = temp_dir.path().join(".codex/sessions/2026/07/22");
-    let archived_dir = temp_dir.path().join(".codex/archived_sessions");
+    // Built one component at a time: a single join with embedded forward slashes
+    // keeps them in the string on Windows, while canonical_session_path rebuilds
+    // the archived path with native separators. conversation_hash hashes the
+    // string form, so the two sides would hash different strings.
+    let active_dir = temp_dir
+        .path()
+        .join(".codex")
+        .join("sessions")
+        .join("2026")
+        .join("07")
+        .join("22");
+    let archived_dir = temp_dir.path().join(".codex").join("archived_sessions");
     std::fs::create_dir_all(&active_dir).unwrap();
     std::fs::create_dir_all(&archived_dir).unwrap();
     let active_path = active_dir.join(SESSION_FILE_NAME);


### PR DESCRIPTION
Closes #225.

`test_message_hashes_remain_stable_after_archiving` built the active session
directory with a single `join(".codex/sessions/2026/07/22")`. On Windows those
forward slashes stay inside the path string, while `canonical_session_path`
rebuilds the archived path one component at a time and gets native separators.
`conversation_hash` hashes the string form of the path, so the two sides hashed
different strings and the assertion failed.

Both paths are now built component by component, which produces the same string
on either platform. The comment above them says why, so the next person editing
this fixture does not undo it.

The other nine `join` calls in this file that embed slashes are left alone. They
only create directories, and Windows accepts forward slashes there, so changing
them would widen the diff without fixing anything.

Verification. 409 passed, 0 failed on both `ubuntu-latest` and `windows-latest`,
on the same tree as this branch plus a temporary workflow that is not part of the
change: https://github.com/NickAme03/splitrail/actions/runs/30660532341

The failure this fixes is visible in the run reported in #225, taken on `main`
before this branch existed: 404 passed and 1 failed, with Windows the only red
job. https://github.com/NickAme03/splitrail/actions/runs/30655673828

This is a test fixture fix. It does not change any counting behaviour, and the
production path stays as it was: `WalkDir` already yields native separators on
both sides, which is why the numbers splitrail reports were never affected.

One thing this does not do, since it belongs to you and not to a fix: `checks.yml`
runs only on `ubuntu-latest` and never runs `cargo test`, so nothing in CI would
have caught this and nothing will catch the next one. I am happy to add a Windows
test job in a separate pull request if you want it.
