### PR TITLE
fix(tui): show only active apps per period

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -592,7 +592,9 @@ pub(crate) fn build_display_stats(
                 });
             *entry += day_stats;
             // Record which app contributed this period (for the Apps column).
-            *entry.apps.entry(app_name.clone()).or_insert(0) += 1;
+            if !is_empty_period(day_stats) {
+                *entry.apps.entry(app_name.clone()).or_insert(0) += 1;
+            }
         }
 
         combined_sessions.extend(view.session_aggregates.iter().cloned().map(|mut session| {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -388,6 +388,55 @@ fn test_build_display_stats_prepends_all_tools_view() {
     );
 }
 
+#[test]
+fn test_all_tools_apps_only_include_tools_used_that_day() {
+    let empty_day = |date: &str| DailyStats {
+        date: CompactDate::from_str(date).unwrap(),
+        ..DailyStats::default()
+    };
+
+    let mut tool_a = make_tool_stats("tool-a", true);
+    tool_a
+        .daily_stats
+        .insert("2025-01-02".to_string(), empty_day("2025-01-02"));
+
+    let mut tool_b = make_tool_stats("tool-b", true);
+    let mut tool_b_activity = tool_b.daily_stats.remove("2025-01-01").unwrap();
+    tool_b_activity.date = CompactDate::from_str("2025-01-02").unwrap();
+    tool_b
+        .daily_stats
+        .insert("2025-01-01".to_string(), empty_day("2025-01-01"));
+    tool_b
+        .daily_stats
+        .insert("2025-01-02".to_string(), tool_b_activity);
+
+    let display_stats = build_display_stats(
+        &MultiAnalyzerStats {
+            analyzer_stats: vec![tool_a, tool_b],
+        }
+        .into_view()
+        .analyzer_stats,
+    );
+    let all_tools = display_stats[0].read();
+
+    assert_eq!(
+        all_tools.daily_stats["2025-01-01"]
+            .apps
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec!["tool-a"]
+    );
+    assert_eq!(
+        all_tools.daily_stats["2025-01-02"]
+            .apps
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>(),
+        vec!["tool-b"]
+    );
+}
+
 // ============================================================================
 // UPLOAD PROGRESS & MESSAGES (tui.rs helpers)
 // ============================================================================


### PR DESCRIPTION
## Summary

Show only tools that had actual activity in each Apps column period instead of including analyzers whose gap-filled daily row was empty.

## Key changes

- Skip empty analyzer-day rows when recording Apps in the combined All Tools view.
- Preserve empty period rows and existing daily/weekly/monthly/yearly aggregation behavior.
- Add a regression test with two tools active on different days.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` (410 passed)
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “All Tools” view no longer displays empty daily entries in the Apps column.
  * Analyzer activity is now shown only for dates with recorded contributions, improving the accuracy of contribution summaries.

* **Tests**
  * Added regression coverage to verify correct handling of inactive dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->