### PR TITLE
fix(tui): keep filtered session models in sync

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -297,6 +297,16 @@ fn model_name_matches(model: &str, filter: &str) -> bool {
     model.to_lowercase().contains(filter)
 }
 
+fn filter_model_counts(models: &ModelCounts, filter: &str) -> ModelCounts {
+    let mut filtered = ModelCounts::new();
+    for &(model, count) in models.iter() {
+        if model_name_matches(resolve_model(model), filter) {
+            filtered.increment(model, count);
+        }
+    }
+    filtered
+}
+
 fn tui_stats_from_model_stats(stats: &ModelStats) -> TuiStats {
     TuiStats {
         input_tokens: stats.input_tokens,
@@ -328,12 +338,21 @@ fn filter_analyzer_view_by_model(
         })
         .cloned()
         .map(|mut session| {
-            session.daily.retain(|_, activity| {
-                activity
-                    .models
-                    .iter()
-                    .any(|(model, _)| model_name_matches(resolve_model(*model), &filter))
-            });
+            if session.daily.is_empty() {
+                session.models = filter_model_counts(&session.models, &filter);
+            } else {
+                session.daily.retain(|_, activity| {
+                    activity.models = filter_model_counts(&activity.models, &filter);
+                    activity.models.iter().next().is_some()
+                });
+
+                session.models = ModelCounts::new();
+                for activity in session.daily.values() {
+                    for &(model, count) in activity.models.iter() {
+                        session.models.increment(model, count);
+                    }
+                }
+            }
             session
         })
         .collect();

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -14,8 +14,8 @@ use crate::tui::{
 };
 use crate::types::{
     AgenticCodingToolStats, AnalyzerStatsView, Application, CompactDate, ConversationMessage,
-    DailyStats, MessageRole, ModelCounts, ModelStats, MultiAnalyzerStats, SessionAggregate, Stats,
-    TuiStats, intern_model,
+    DailyStats, MessageRole, ModelCounts, ModelStats, MultiAnalyzerStats, SessionAggregate,
+    SessionPeriodAggregate, Stats, TuiStats, intern_model,
 };
 use chrono::{TimeZone, Utc};
 use ratatui::Terminal;
@@ -951,13 +951,36 @@ fn model_filter_recalculates_stats_and_sessions() {
         date,
         daily: BTreeMap::new(),
     };
+    let multi_models = {
+        let mut models = ModelCounts::new();
+        models.increment(intern_model("claude-sonnet-4"), 2);
+        models.increment(intern_model("gpt-5"), 1);
+        models
+    };
+    let multi_model_session = SessionAggregate {
+        session_id: "multi-model-session".to_string(),
+        first_timestamp: Utc.with_ymd_and_hms(2025, 1, 1, 12, 0, 0).unwrap(),
+        analyzer_name: Arc::from("Test"),
+        stats: TuiStats::default(),
+        models: multi_models.clone(),
+        session_name: None,
+        date,
+        daily: BTreeMap::from([(
+            date,
+            SessionPeriodAggregate {
+                models: multi_models,
+                ..Default::default()
+            },
+        )]),
+    };
     let view = AnalyzerStatsView {
         daily_stats,
         session_aggregates: vec![
+            multi_model_session,
             make_session("claude-session", "claude-sonnet-4"),
             make_session("gpt-session", "gpt-5"),
         ],
-        num_conversations: 2,
+        num_conversations: 3,
         analyzer_name: Arc::from("Test"),
     };
 
@@ -973,8 +996,32 @@ fn model_filter_recalculates_stats_and_sessions() {
     assert_eq!(day.stats.tool_calls, 3);
     assert_eq!(day.models.len(), 1);
     assert!(day.models.contains_key("claude-sonnet-4"));
-    assert_eq!(filtered.num_conversations, 1);
-    assert_eq!(filtered.session_aggregates[0].session_id, "claude-session");
+    assert_eq!(filtered.num_conversations, 2);
+    assert_eq!(
+        filtered.session_aggregates[0].session_id,
+        "multi-model-session"
+    );
+    assert_eq!(
+        filtered.session_aggregates[0]
+            .models
+            .get(intern_model("claude-sonnet-4")),
+        Some(2)
+    );
+    assert_eq!(
+        filtered.session_aggregates[0]
+            .models
+            .get(intern_model("gpt-5")),
+        None
+    );
+    assert_eq!(
+        filtered.session_aggregates[0]
+            .daily
+            .get(&date)
+            .unwrap()
+            .models
+            .get(intern_model("gpt-5")),
+        None
+    );
 
     let mut incomplete_view = view.clone();
     incomplete_view


### PR DESCRIPTION
## Summary

Fix the TUI model filter so Session rows no longer display models that do not match the active `f` filter.

## Key Changes

- Filter each session's per-day model collection.
- Rebuild the session-level model collection from the filtered daily data.
- Preserve compatibility with legacy sessions that do not have daily details.
- Add a regression test for sessions using multiple models.

## Validation

- `cargo fmt --all -- --check`
- `cargo build --quiet`
- `git diff --check`

## Notes

This PR only changes `src/tui.rs` and `src/tui/tests.rs`.
