### PR TITLE
feat(models): reflect the 2026-07-30 Terra and Luna price cut

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -856,17 +856,42 @@ fn populate_defaults(
     add_model!(
         "gpt-5.6-terra",
         PricingStructure::Flat {
+            input_per_1m: 2.0,
+            output_per_1m: 12.0
+        },
+        CachingSupport::OpenAIWithWrites {
+            cache_write_per_1m: 2.5,
+            cache_read_per_1m: 0.20
+        },
+        false
+    );
+    add_dated_pricing!(
+        "gpt-5.6-terra",
+        NaiveDate::from_ymd_opt(2026, 7, 30).expect("valid date"),
+        PricingStructure::Flat {
             input_per_1m: 2.50,
             output_per_1m: 15.0
         },
         CachingSupport::OpenAIWithWrites {
             cache_write_per_1m: 3.125,
             cache_read_per_1m: 0.25
-        },
-        false
+        }
     );
     add_model!(
         "gpt-5.6-luna",
+        PricingStructure::Flat {
+            input_per_1m: 0.20,
+            output_per_1m: 1.20
+        },
+        CachingSupport::OpenAIWithWrites {
+            cache_write_per_1m: 0.25,
+            cache_read_per_1m: 0.02
+        },
+        false
+    );
+    add_dated_pricing!(
+        "gpt-5.6-luna",
+        NaiveDate::from_ymd_opt(2026, 7, 30).expect("valid date"),
         PricingStructure::Flat {
             input_per_1m: 1.0,
             output_per_1m: 6.0
@@ -874,8 +899,7 @@ fn populate_defaults(
         CachingSupport::OpenAIWithWrites {
             cache_write_per_1m: 1.25,
             cache_read_per_1m: 0.10
-        },
-        false
+        }
     );
 
     add_model!(
@@ -2988,21 +3012,105 @@ mod tests {
             6.75,
         );
 
-        approx_eq(calculate_input_cost("gpt-5.6-terra", 1_000_000), 2.50);
-        approx_eq(calculate_output_cost("gpt-5.6-terra", 1_000_000), 15.0);
-        approx_eq(calculate_cache_cost("gpt-5.6-terra", 0, 1_000_000), 0.25);
+        approx_eq(calculate_input_cost("gpt-5.6-terra", 1_000_000), 2.0);
+        approx_eq(calculate_output_cost("gpt-5.6-terra", 1_000_000), 12.0);
+        approx_eq(calculate_cache_cost("gpt-5.6-terra", 0, 1_000_000), 0.20);
         approx_eq(
             calculate_cache_cost("gpt-5.6-terra", 1_000_000, 1_000_000),
-            3.375,
+            2.70,
         );
 
-        approx_eq(calculate_input_cost("gpt-5.6-luna", 1_000_000), 1.0);
-        approx_eq(calculate_output_cost("gpt-5.6-luna", 1_000_000), 6.0);
-        approx_eq(calculate_cache_cost("gpt-5.6-luna", 0, 1_000_000), 0.10);
+        approx_eq(calculate_input_cost("gpt-5.6-luna", 1_000_000), 0.20);
+        approx_eq(calculate_output_cost("gpt-5.6-luna", 1_000_000), 1.20);
+        approx_eq(calculate_cache_cost("gpt-5.6-luna", 0, 1_000_000), 0.02);
         approx_eq(
             calculate_cache_cost("gpt-5.6-luna", 1_000_000, 1_000_000),
-            1.35,
+            0.27,
         );
+    }
+
+    /// Usage from before the 2026-07-30 cut must keep the price it was actually
+    /// billed at. Without the dated overrides the new rates are applied
+    /// retroactively, and every Luna session recorded before the cut is
+    /// suddenly reported at a fifth of what it cost.
+    #[test]
+    fn gpt_5_6_terra_and_luna_keep_pre_cut_pricing_for_older_usage() {
+        let before_cut = Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).unwrap();
+
+        for (model, input, output, cache_read, cache_write_and_read) in [
+            ("gpt-5.6-terra", 2.50, 15.0, 0.25, 3.375),
+            ("gpt-5.6-luna", 1.0, 6.0, 0.10, 1.35),
+        ] {
+            approx_eq(
+                calculate_input_cost_for_service_tier_at(
+                    model,
+                    ServiceTier::Standard,
+                    1_000_000,
+                    Some(before_cut),
+                ),
+                input,
+            );
+            approx_eq(
+                calculate_output_cost_for_service_tier_at(
+                    model,
+                    ServiceTier::Standard,
+                    1_000_000,
+                    Some(before_cut),
+                ),
+                output,
+            );
+            approx_eq(
+                calculate_cache_cost_for_service_tier_at(
+                    model,
+                    ServiceTier::Standard,
+                    0,
+                    1_000_000,
+                    Some(before_cut),
+                ),
+                cache_read,
+            );
+            // Cache writes are the other half of the historical cost, and the
+            // dated override carries its own `CachingSupport`. Without this the
+            // write rate could silently fall through to the post-cut value.
+            approx_eq(
+                calculate_cache_cost_for_service_tier_at(
+                    model,
+                    ServiceTier::Standard,
+                    1_000_000,
+                    1_000_000,
+                    Some(before_cut),
+                ),
+                cache_write_and_read,
+            );
+        }
+    }
+
+    /// The cut took effect on 2026-07-30, so that day is already billed at the
+    /// new rates: `standard_pricing_for_date` treats `valid_until` as exclusive.
+    #[test]
+    fn gpt_5_6_terra_and_luna_use_new_pricing_from_the_cut_date() {
+        let cut_day = Utc.with_ymd_and_hms(2026, 7, 30, 0, 0, 0).unwrap();
+
+        for (model, input, output) in [("gpt-5.6-terra", 2.0, 12.0), ("gpt-5.6-luna", 0.20, 1.20)] {
+            approx_eq(
+                calculate_input_cost_for_service_tier_at(
+                    model,
+                    ServiceTier::Standard,
+                    1_000_000,
+                    Some(cut_day),
+                ),
+                input,
+            );
+            approx_eq(
+                calculate_output_cost_for_service_tier_at(
+                    model,
+                    ServiceTier::Standard,
+                    1_000_000,
+                    Some(cut_day),
+                ),
+                output,
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Closes #227.

Terra goes from $2.50/$15.00 to $2.00/$12.00 per 1M input/output tokens, Luna from $1.00/$6.00 to $0.20/$1.20, effective 2026-07-30. Sol is unchanged. ([CNBC](https://www.cnbc.com/2026/07/30/open-ai-price-cut-gpt.html), [Axios](https://www.axios.com/2026/07/30/openai-cuts-prices-gpt-terra-luna5))

The old rates move into `dated_pricing` with `valid_until = 2026-07-30` instead of being overwritten. Overwriting re-costs everything recorded before the cut: a Luna session that actually cost $7.00 per 1M combined tokens gets reported at $1.40 on the next run. `claude-sonnet-5` already uses this mechanism the same way.

Two tests cover the boundary. Usage on 2026-07-29 keeps the old price, usage on 2026-07-30 gets the new one, since `valid_until` is exclusive.

**Cached-token rates here are derived, not quoted.** OpenAI did not publish cached-input prices alongside the new rates. I applied the rule this registry already uses for the GPT-5.6 family, cache writes at 1.25x the uncached input rate and reads at one tenth of it, which reproduces the existing Terra and Luna entries exactly. If you have official numbers, use those instead of my derivation.

I ran the suite in my fork, since `checks.yml` does not run `cargo test` (#231). The runs below are on fork branches that add a temporary `cargo test` workflow. `src/models.rs` on those branches is byte-identical to this one; the only difference is that workflow file.

| | |
|---|---|
| base, unmodified | [green](https://github.com/NickAme03/splitrail/actions/runs/30715424970) |
| this branch's code | [green](https://github.com/NickAme03/splitrail/actions/runs/30715326630) |
| new prices, dated overrides removed | [fails](https://github.com/NickAme03/splitrail/actions/runs/30715433919) on `gpt_5_6_terra_and_luna_keep_pre_cut_pricing_for_older_usage`, `left=2, right=2.5` |

The third row is why this uses dated entries rather than editing the numbers in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lower standard pricing for GPT-5.6 Terra and GPT-5.6 Luna, including cache read and write rates.
  * Preserved previous pricing through July 30, 2026, with date-based pricing behavior.

* **Tests**
  * Added coverage confirming pricing before and on the pricing change date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->