### PR TITLE
Make Sonnet 5 pricing permanent

### DIFF
--- a/src/analyzers/tests/claude_code.rs
+++ b/src/analyzers/tests/claude_code.rs
@@ -632,9 +632,9 @@ fn test_calculate_cost_from_tokens() {
 }
 
 #[test]
-fn test_parse_jsonl_file_uses_sonnet_5_dated_pricing() {
-    let jsonl_data = r#"{"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/code/test","sessionId":"sonnet-5","version":"2.0.0","message":{"id":"msg_intro","type":"message","role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"intro"}],"usage":{"input_tokens":1000000,"cache_creation_input_tokens":1000000,"cache_read_input_tokens":1000000,"output_tokens":1000000}},"requestId":"req_intro","type":"assistant","uuid":"intro-uuid","timestamp":"2026-08-31T23:59:59Z"}
-{"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/code/test","sessionId":"sonnet-5","version":"2.0.0","message":{"id":"msg_sticker","type":"message","role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"sticker"}],"usage":{"input_tokens":1000000,"cache_creation_input_tokens":1000000,"cache_read_input_tokens":1000000,"output_tokens":1000000}},"requestId":"req_sticker","type":"assistant","uuid":"sticker-uuid","timestamp":"2026-09-01T00:00:00Z"}"#;
+fn test_parse_jsonl_file_uses_sonnet_5_permanent_pricing() {
+    let jsonl_data = r#"{"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/code/test","sessionId":"sonnet-5","version":"2.0.0","message":{"id":"msg_before","type":"message","role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"before"}],"usage":{"input_tokens":1000000,"cache_creation_input_tokens":1000000,"cache_read_input_tokens":1000000,"output_tokens":1000000}},"requestId":"req_before","type":"assistant","uuid":"before-uuid","timestamp":"2026-08-31T23:59:59Z"}
+{"parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/code/test","sessionId":"sonnet-5","version":"2.0.0","message":{"id":"msg_after","type":"message","role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"after"}],"usage":{"input_tokens":1000000,"cache_creation_input_tokens":1000000,"cache_read_input_tokens":1000000,"output_tokens":1000000}},"requestId":"req_after","type":"assistant","uuid":"after-uuid","timestamp":"2026-09-01T00:00:00Z"}"#;
 
     let cursor = Cursor::new(jsonl_data);
     let mut buf_reader = BufReader::new(cursor);
@@ -648,7 +648,7 @@ fn test_parse_jsonl_file_uses_sonnet_5_dated_pricing() {
 
     assert_eq!(messages.len(), 2);
     assert!((messages[0].stats.cost - 14.7).abs() < 0.0001);
-    assert!((messages[1].stats.cost - 22.05).abs() < 0.0001);
+    assert!((messages[1].stats.cost - 14.7).abs() < 0.0001);
 }
 
 #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1032,26 +1032,14 @@ fn populate_defaults(
     add_model!(
         "claude-sonnet-5",
         PricingStructure::Flat {
-            input_per_1m: 3.0,
-            output_per_1m: 15.0
-        },
-        CachingSupport::Anthropic {
-            cache_write_per_1m: 3.75,
-            cache_read_per_1m: 0.3
-        },
-        false
-    );
-    add_dated_pricing!(
-        "claude-sonnet-5",
-        NaiveDate::from_ymd_opt(2026, 9, 1).expect("valid date"),
-        PricingStructure::Flat {
             input_per_1m: 2.0,
             output_per_1m: 10.0
         },
         CachingSupport::Anthropic {
             cache_write_per_1m: 2.5,
             cache_read_per_1m: 0.2
-        }
+        },
+        false
     );
     add_model!(
         "claude-opus-5",
@@ -2986,95 +2974,54 @@ mod tests {
     }
 
     #[test]
-    fn claude_sonnet_5_alias_maps_to_sticker_pricing_by_default() {
+    fn claude_sonnet_5_alias_maps_to_permanent_pricing() {
         let model_info = get_model_info("claude-5-sonnet").expect("model should exist");
         assert!(!model_info.is_estimated);
+        assert!(model_info.dated_pricing.is_empty());
 
         let input_cost = calculate_input_cost("claude-5-sonnet", 1_000_000);
         let output_cost = calculate_output_cost("claude-5-sonnet", 1_000_000);
         let cache_cost = calculate_cache_cost("claude-5-sonnet", 1_000_000, 1_000_000);
 
-        approx_eq(input_cost, 3.0);
-        approx_eq(output_cost, 15.0);
-        approx_eq(cache_cost, 4.05);
+        approx_eq(input_cost, 2.0);
+        approx_eq(output_cost, 10.0);
+        approx_eq(cache_cost, 2.7);
     }
 
     #[test]
-    fn claude_sonnet_5_uses_introductory_pricing_through_august_2026() {
-        let effective_at = Utc.with_ymd_and_hms(2026, 8, 31, 23, 59, 59).unwrap();
-
-        approx_eq(
-            calculate_input_cost_for_service_tier_at(
-                "claude-5-sonnet",
-                ServiceTier::Standard,
-                1_000_000,
-                Some(effective_at),
-            ),
-            2.0,
-        );
-        approx_eq(
-            calculate_output_cost_for_service_tier_at(
-                "claude-5-sonnet",
-                ServiceTier::Standard,
-                1_000_000,
-                Some(effective_at),
-            ),
-            10.0,
-        );
-        approx_eq(
-            calculate_cache_cost_for_service_tier_at(
-                "claude-5-sonnet",
-                ServiceTier::Standard,
-                1_000_000,
-                1_000_000,
-                Some(effective_at),
-            ),
-            2.7,
-        );
+    fn claude_sonnet_5_permanent_pricing_has_no_september_boundary() {
+        for effective_at in [
+            Utc.with_ymd_and_hms(2026, 8, 31, 23, 59, 59).unwrap(),
+            Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap(),
+        ] {
+            approx_eq(
+                calculate_total_cost_for_service_tier_at(
+                    "claude-5-sonnet",
+                    ServiceTier::Standard,
+                    1_000_000,
+                    1_000_000,
+                    1_000_000,
+                    1_000_000,
+                    Some(effective_at),
+                ),
+                14.7,
+            );
+        }
     }
 
     #[test]
-    fn claude_sonnet_5_uses_sticker_pricing_after_introductory_window() {
-        let effective_at = Utc.with_ymd_and_hms(2026, 9, 1, 0, 0, 0).unwrap();
-
-        approx_eq(
-            calculate_total_cost_for_service_tier_at(
-                "claude-5-sonnet",
-                ServiceTier::Standard,
-                1_000_000,
-                1_000_000,
-                1_000_000,
-                1_000_000,
-                Some(effective_at),
-            ),
-            22.05,
-        );
-    }
-
-    #[test]
-    fn claude_sonnet_5_global_anthropic_alias_maps_to_dated_pricing() {
+    fn claude_sonnet_5_global_anthropic_alias_maps_to_permanent_pricing() {
         let model_info = get_model_info("global.anthropic.claude-sonnet-5")
             .expect("global Anthropic alias should resolve");
         assert!(!model_info.is_estimated);
-
-        let effective_at = Utc.with_ymd_and_hms(2026, 8, 31, 12, 0, 0).unwrap();
+        assert!(model_info.dated_pricing.is_empty());
 
         approx_eq(
-            calculate_input_cost_for_service_tier_at(
-                "global.anthropic.claude-sonnet-5",
-                ServiceTier::Standard,
-                1_000_000,
-                Some(effective_at),
-            ),
+            calculate_input_cost("global.anthropic.claude-sonnet-5", 1_000_000),
             2.0,
         );
         approx_eq(
-            calculate_output_cost_for_service_tier_at(
-                "global.anthropic.claude-sonnet-5",
-                ServiceTier::Standard,
-                1_000_000,
-                Some(effective_at),
-            ),
+            calculate_output_cost("global.anthropic.claude-sonnet-5", 1_000_000),
             10.0,
         );
     }


### PR DESCRIPTION
## Why

Anthropic initially described Claude Sonnet 5's $2 per million input token and $10 per million output token rates as introductory pricing. Splitrail therefore retained the previous $3/$15 Sonnet rates as the durable default and scheduled the introductory rates to expire on September 1, 2026.

Anthropic updated the Sonnet 5 launch announcement on August 10, 2026 to make the introductory rates permanent, and its current API pricing documentation reports the same rates. Without this update, Splitrail would overstate Sonnet 5 costs for usage on or after September 1.

## What changed

- Make `$2/MTok` input and `$10/MTok` output the durable Sonnet 5 rates.
- Keep Anthropic prompt-cache pricing at `$2.50/MTok` for standard cache writes and `$0.20/MTok` for cache reads.
- Remove the obsolete dated override and September 1 transition to `$3/$15` pricing.
- Update canonical and global-alias coverage to assert that Sonnet 5 has no dated pricing override.
- Update model and Claude Code analyzer boundary tests so August 31 and September 1 usage both calculate to `$14.70` for one million input, output, cache-write, and cache-read tokens.

## Validation

- `TMPDIR=/var/tmp/splitrail-cargo cargo test --quiet claude_sonnet_5`
- `TMPDIR=/var/tmp/splitrail-cargo cargo test --quiet test_parse_jsonl_file_uses_sonnet_5_permanent_pricing`
- `TMPDIR=/var/tmp/splitrail-cargo cargo build --quiet`
- `TMPDIR=/var/tmp/splitrail-cargo cargo test --quiet` — 413 passed; one unrelated existing TUI model-filter test failed
- `TMPDIR=/var/tmp/splitrail-cargo cargo clippy --quiet -- -D warnings`
- `TMPDIR=/var/tmp/splitrail-cargo cargo doc --quiet`
- `cargo fmt --all --quiet`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Claude Sonnet 5 pricing to use consistent permanent rates.
  * Removed the outdated September 2026 pricing change.
  * Corrected Anthropic cache pricing and ensured totals remain consistent across the August–September boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->