### PR TITLE
feat(models): add Qwen3.7 Plus and Flash pricing

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1864,6 +1864,59 @@ fn populate_defaults(
         CachingSupport::None,
         true
     );
+    // Source: https://openrouter.ai/qwen/qwen3.7-plus
+    add_model!(
+        "qwen3.7-plus",
+        PricingStructure::Tiered(TieredPricing {
+            tiers: vec![
+                PricingTier {
+                    max_tokens: Some(256_000),
+                    input_per_1m: 0.32,
+                    output_per_1m: 1.28
+                },
+                PricingTier {
+                    max_tokens: None,
+                    input_per_1m: 0.96,
+                    output_per_1m: 3.84
+                },
+            ],
+            bracket_pricing: true,
+        }),
+        CachingSupport::Anthropic {
+            cache_write_per_1m: 0.40,
+            cache_read_per_1m: 0.064
+        },
+        true
+    );
+    // Source: https://openrouter.ai/qwen/qwen3.7-flash
+    add_model!(
+        "qwen3.7-flash",
+        PricingStructure::Tiered(TieredPricing {
+            tiers: vec![
+                PricingTier {
+                    max_tokens: Some(32_000),
+                    input_per_1m: 0.03,
+                    output_per_1m: 0.13
+                },
+                PricingTier {
+                    max_tokens: Some(256_000),
+                    input_per_1m: 0.10,
+                    output_per_1m: 0.40
+                },
+                PricingTier {
+                    max_tokens: None,
+                    input_per_1m: 0.20,
+                    output_per_1m: 0.80
+                },
+            ],
+            bracket_pricing: true,
+        }),
+        CachingSupport::Anthropic {
+            cache_write_per_1m: 0.038,
+            cache_read_per_1m: 0.006
+        },
+        true
+    );
 
     // Meituan Models
     // Source: https://anotherwrapper.com/tools/llm-pricing/longcat-flash-lite
@@ -2141,6 +2194,10 @@ fn populate_defaults(
     add_alias!("moonshotai.kimi-k2.5", "kimi-k2.5");
     add_alias!("qwen3.6-plus", "qwen3.6-plus");
     add_alias!("qwen.qwen3.6-plus", "qwen3.6-plus");
+    add_alias!("qwen3.7-plus", "qwen3.7-plus");
+    add_alias!("qwen.qwen3.7-plus", "qwen3.7-plus");
+    add_alias!("qwen3.7-flash", "qwen3.7-flash");
+    add_alias!("qwen.qwen3.7-flash", "qwen3.7-flash");
     add_alias!("mimo-v2.5-pro", "mimo-v2.5-pro");
     add_alias!("xiaomi.mimo-v2.5-pro", "mimo-v2.5-pro");
     add_alias!("mimo-v2-omni", "mimo-v2-omni");
@@ -3785,6 +3842,58 @@ mod tests {
             calculate_output_cost("openai.gpt-oss-safeguard-120b", 1_000_000),
             0.60,
         );
+    }
+
+    #[test]
+    fn qwen_3_7_plus_pricing_and_tiers() {
+        let info = get_model_info("qwen3.7-plus").expect("model should exist");
+        assert!(info.is_estimated);
+
+        // Base tier (<= 256k tokens)
+        approx_eq(calculate_input_cost("qwen3.7-plus", 256_000), 0.08192);
+        approx_eq(calculate_output_cost("qwen3.7-plus", 256_000), 0.32768);
+
+        // Top tier (> 256k tokens)
+        approx_eq(calculate_input_cost("qwen3.7-plus", 1_000_000), 0.96);
+        approx_eq(calculate_output_cost("qwen3.7-plus", 1_000_000), 3.84);
+
+        // Cache write + read
+        approx_eq(
+            calculate_cache_cost("qwen3.7-plus", 1_000_000, 1_000_000),
+            0.464,
+        );
+
+        // Provider-prefixed alias resolves
+        let aliased = get_model_info("qwen/qwen3.7-plus").expect("provider-prefixed alias");
+        assert!(aliased.is_estimated);
+    }
+
+    #[test]
+    fn qwen_3_7_flash_pricing_and_tiers() {
+        let info = get_model_info("qwen3.7-flash").expect("model should exist");
+        assert!(info.is_estimated);
+
+        // First tier (<= 32k tokens)
+        approx_eq(calculate_input_cost("qwen3.7-flash", 32_000), 0.00096);
+        approx_eq(calculate_output_cost("qwen3.7-flash", 32_000), 0.00416);
+
+        // Middle tier (<= 256k tokens)
+        approx_eq(calculate_input_cost("qwen3.7-flash", 256_000), 0.0256);
+        approx_eq(calculate_output_cost("qwen3.7-flash", 256_000), 0.1024);
+
+        // Top tier (> 256k tokens)
+        approx_eq(calculate_input_cost("qwen3.7-flash", 1_000_000), 0.20);
+        approx_eq(calculate_output_cost("qwen3.7-flash", 1_000_000), 0.80);
+
+        // Cache write + read
+        approx_eq(
+            calculate_cache_cost("qwen3.7-flash", 1_000_000, 1_000_000),
+            0.044,
+        );
+
+        // Provider-prefixed alias resolves
+        let aliased = get_model_info("qwen/qwen3.7-flash").expect("provider-prefixed alias");
+        assert!(aliased.is_estimated);
     }
 
     #[test]


### PR DESCRIPTION
  Summary

  Add pricing for the new Qwen3.7 Plus and Qwen3.7 Flash models, sourced from OpenRouter.

  Changes

  - qwen3.7-plus — tiered OpenRouter pricing:
    - ≤256k tokens: $0.32 / $1.28 per 1M (input / output)
    - >256k tokens: $0.96 / $3.84 per 1M
    - Cache write $0.40 / read $0.064 per 1M
  - qwen3.7-flash — tiered OpenRouter pricing:
    - ≤32k: $0.03 / $0.13 per 1M
    - ≤256k: $0.10 / $0.40 per 1M
    - >256k: $0.20 / $0.80 per 1M
    - Cache write $0.038 / read $0.006 per 1M
  - Added provider-prefixed aliases (qwen/qwen3.7-plus, qwen/qwen3.7-flash) alongside bare names.
  - Added unit tests covering tier boundaries, cache costs, and alias resolution.

  Sources

  - https://openrouter.ai/qwen/qwen3.7-plus
  - https://openrouter.ai/qwen/qwen3.7-flash

  ---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added estimated tiered pricing for `qwen3.7-plus` and `qwen3.7-flash`.
  - Added separate pricing rates for prompt cache writes and reads.
  - Added support for both canonical model names and Qwen-prefixed aliases.
  - Pricing now reflects applicable usage tiers and clearly indicates estimated rates.

- **Tests**
  - Added coverage for tier thresholds, cache pricing, estimated pricing status, and model-name resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->