### PR TITLE
fix(models): Complete Terra and Luna tiered pricing

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -363,23 +363,6 @@ fn populate_defaults(
         };
     }
 
-    macro_rules! add_flat_service_tier_pricing_with_cache_writes {
-        ($name:expr, $service_tier:expr, $input:expr, $cache_write:expr, $cache_read:expr, $output:expr) => {
-            add_service_tier_pricing!(
-                $name,
-                $service_tier,
-                PricingStructure::Flat {
-                    input_per_1m: $input,
-                    output_per_1m: $output,
-                },
-                CachingSupport::OpenAIWithWrites {
-                    cache_write_per_1m: $cache_write,
-                    cache_read_per_1m: $cache_read,
-                }
-            );
-        };
-    }
-
     macro_rules! add_tiered_service_tier_pricing_with_cache_writes {
         (
             $name:expr,
@@ -958,14 +941,36 @@ fn populate_defaults(
     );
     add_model!(
         "gpt-5.6-terra",
-        PricingStructure::Flat {
-            input_per_1m: 2.0,
-            output_per_1m: 12.0
-        },
-        CachingSupport::OpenAIWithWrites {
-            cache_write_per_1m: 2.5,
-            cache_read_per_1m: 0.20
-        },
+        PricingStructure::Tiered(TieredPricing {
+            tiers: vec![
+                PricingTier {
+                    max_tokens: Some(272_000),
+                    input_per_1m: 2.0,
+                    output_per_1m: 12.0
+                },
+                PricingTier {
+                    max_tokens: None,
+                    input_per_1m: 4.0,
+                    output_per_1m: 18.0
+                },
+            ],
+            bracket_pricing: true,
+        }),
+        CachingSupport::TieredWithWrites(TieredCachingWithWrites {
+            tiers: vec![
+                CachingTierWithWrites {
+                    max_tokens: Some(272_000),
+                    cache_write_per_1m: 2.5,
+                    cache_read_per_1m: 0.20
+                },
+                CachingTierWithWrites {
+                    max_tokens: None,
+                    cache_write_per_1m: 5.0,
+                    cache_read_per_1m: 0.40
+                },
+            ],
+            bracket_pricing: true,
+        }),
         false
     );
     add_dated_pricing!(
@@ -982,14 +987,36 @@ fn populate_defaults(
     );
     add_model!(
         "gpt-5.6-luna",
-        PricingStructure::Flat {
-            input_per_1m: 0.20,
-            output_per_1m: 1.20
-        },
-        CachingSupport::OpenAIWithWrites {
-            cache_write_per_1m: 0.25,
-            cache_read_per_1m: 0.02
-        },
+        PricingStructure::Tiered(TieredPricing {
+            tiers: vec![
+                PricingTier {
+                    max_tokens: Some(272_000),
+                    input_per_1m: 0.20,
+                    output_per_1m: 1.20
+                },
+                PricingTier {
+                    max_tokens: None,
+                    input_per_1m: 0.40,
+                    output_per_1m: 1.80
+                },
+            ],
+            bracket_pricing: true,
+        }),
+        CachingSupport::TieredWithWrites(TieredCachingWithWrites {
+            tiers: vec![
+                CachingTierWithWrites {
+                    max_tokens: Some(272_000),
+                    cache_write_per_1m: 0.25,
+                    cache_read_per_1m: 0.02
+                },
+                CachingTierWithWrites {
+                    max_tokens: None,
+                    cache_write_per_1m: 0.50,
+                    cache_read_per_1m: 0.04
+                },
+            ],
+            bracket_pricing: true,
+        }),
         false
     );
     add_dated_pricing!(
@@ -1052,21 +1079,29 @@ fn populate_defaults(
         2.0,
         90.0
     );
-    add_flat_service_tier_pricing_with_cache_writes!(
+    add_tiered_service_tier_pricing_with_cache_writes!(
         "gpt-5.6-terra",
         ServiceTier::Priority,
+        4.0,
         5.0,
-        6.25,
-        0.50,
-        30.0
+        0.40,
+        24.0,
+        8.0,
+        10.0,
+        0.80,
+        36.0
     );
-    add_flat_service_tier_pricing_with_cache_writes!(
+    add_tiered_service_tier_pricing_with_cache_writes!(
         "gpt-5.6-luna",
         ServiceTier::Priority,
-        2.0,
-        2.50,
-        0.20,
-        12.0
+        0.40,
+        0.50,
+        0.04,
+        2.40,
+        0.80,
+        1.0,
+        0.08,
+        3.60
     );
     add_flat_service_tier_pricing!("gpt-5.5", ServiceTier::Priority, 12.50, 1.25, 75.0);
     add_flat_service_tier_pricing!("gpt-5.4", ServiceTier::Priority, 5.0, 0.50, 30.0);
@@ -1085,21 +1120,29 @@ fn populate_defaults(
             0.50,
             22.50
         );
-        add_flat_service_tier_pricing_with_cache_writes!(
+        add_tiered_service_tier_pricing_with_cache_writes!(
             "gpt-5.6-terra",
             service_tier,
+            1.0,
             1.25,
-            1.5625,
-            0.125,
-            7.50
+            0.10,
+            6.0,
+            2.0,
+            2.50,
+            0.20,
+            9.0
         );
-        add_flat_service_tier_pricing_with_cache_writes!(
+        add_tiered_service_tier_pricing_with_cache_writes!(
             "gpt-5.6-luna",
             service_tier,
-            0.50,
-            0.625,
-            0.05,
-            3.0
+            0.10,
+            0.125,
+            0.01,
+            0.60,
+            0.20,
+            0.25,
+            0.02,
+            0.90
         );
         add_tiered_service_tier_pricing!(
             "gpt-5.5",
@@ -3385,6 +3428,22 @@ mod tests {
     }
 
     #[test]
+    fn gpt_5_6_terra_and_luna_use_long_context_pricing_for_full_request() {
+        for (model, expected) in [("gpt-5.6-terra", 0.66), ("gpt-5.6-luna", 0.066)] {
+            let cost = calculate_total_cost_for_service_tier_at(
+                model,
+                ServiceTier::Standard,
+                100_000,
+                10_000,
+                0,
+                200_000,
+                None,
+            );
+            approx_eq(cost, expected);
+        }
+    }
+
+    #[test]
     fn gpt_5_6_pricing_is_available() {
         let sol_info = get_model_info("gpt-5.6-sol").expect("model should exist");
         let terra_info = get_model_info("gpt-5.6-terra").expect("model should exist");
@@ -3398,20 +3457,20 @@ mod tests {
         approx_eq(calculate_cache_cost("gpt-5.6-sol", 0, 200_000), 0.10);
         approx_eq(calculate_cache_cost("gpt-5.6-sol", 100_000, 100_000), 0.675);
 
-        approx_eq(calculate_input_cost("gpt-5.6-terra", 1_000_000), 2.0);
-        approx_eq(calculate_output_cost("gpt-5.6-terra", 1_000_000), 12.0);
-        approx_eq(calculate_cache_cost("gpt-5.6-terra", 0, 1_000_000), 0.20);
+        approx_eq(calculate_input_cost("gpt-5.6-terra", 1_000_000), 4.0);
+        approx_eq(calculate_output_cost("gpt-5.6-terra", 1_000_000), 18.0);
+        approx_eq(calculate_cache_cost("gpt-5.6-terra", 0, 1_000_000), 0.40);
         approx_eq(
             calculate_cache_cost("gpt-5.6-terra", 1_000_000, 1_000_000),
-            2.70,
+            5.40,
         );
 
-        approx_eq(calculate_input_cost("gpt-5.6-luna", 1_000_000), 0.20);
-        approx_eq(calculate_output_cost("gpt-5.6-luna", 1_000_000), 1.20);
-        approx_eq(calculate_cache_cost("gpt-5.6-luna", 0, 1_000_000), 0.02);
+        approx_eq(calculate_input_cost("gpt-5.6-luna", 1_000_000), 0.40);
+        approx_eq(calculate_output_cost("gpt-5.6-luna", 1_000_000), 1.80);
+        approx_eq(calculate_cache_cost("gpt-5.6-luna", 0, 1_000_000), 0.04);
         approx_eq(
             calculate_cache_cost("gpt-5.6-luna", 1_000_000, 1_000_000),
-            0.27,
+            0.54,
         );
     }
 
@@ -3477,7 +3536,7 @@ mod tests {
     fn gpt_5_6_terra_and_luna_use_new_pricing_from_the_cut_date() {
         let cut_day = Utc.with_ymd_and_hms(2026, 7, 30, 0, 0, 0).unwrap();
 
-        for (model, input, output) in [("gpt-5.6-terra", 2.0, 12.0), ("gpt-5.6-luna", 0.20, 1.20)] {
+        for (model, input, output) in [("gpt-5.6-terra", 4.0, 18.0), ("gpt-5.6-luna", 0.40, 1.80)] {
             approx_eq(
                 calculate_input_cost_for_service_tier_at(
                     model,
@@ -3544,7 +3603,7 @@ mod tests {
                 ServiceTier::Priority,
                 1_000_000,
             ),
-            5.0,
+            8.0,
         );
         approx_eq(
             calculate_output_cost_for_service_tier(
@@ -3552,7 +3611,7 @@ mod tests {
                 ServiceTier::Priority,
                 1_000_000,
             ),
-            30.0,
+            36.0,
         );
         approx_eq(
             calculate_cache_cost_for_service_tier(
@@ -3561,7 +3620,7 @@ mod tests {
                 0,
                 1_000_000,
             ),
-            0.50,
+            0.80,
         );
         approx_eq(
             calculate_cache_cost_for_service_tier(
@@ -3570,12 +3629,12 @@ mod tests {
                 1_000_000,
                 1_000_000,
             ),
-            6.75,
+            10.80,
         );
 
         approx_eq(
             calculate_input_cost_for_service_tier("gpt-5.6-luna", ServiceTier::Priority, 1_000_000),
-            2.0,
+            0.80,
         );
         approx_eq(
             calculate_output_cost_for_service_tier(
@@ -3583,7 +3642,7 @@ mod tests {
                 ServiceTier::Priority,
                 1_000_000,
             ),
-            12.0,
+            3.60,
         );
         approx_eq(
             calculate_cache_cost_for_service_tier(
@@ -3592,7 +3651,7 @@ mod tests {
                 0,
                 1_000_000,
             ),
-            0.20,
+            0.08,
         );
         approx_eq(
             calculate_cache_cost_for_service_tier(
@@ -3601,7 +3660,7 @@ mod tests {
                 1_000_000,
                 1_000_000,
             ),
-            2.70,
+            1.08,
         );
 
         approx_eq(
@@ -3680,15 +3739,15 @@ mod tests {
 
             approx_eq(
                 calculate_input_cost_for_service_tier("gpt-5.6-terra", service_tier, 1_000_000),
-                1.25,
+                2.0,
             );
             approx_eq(
                 calculate_output_cost_for_service_tier("gpt-5.6-terra", service_tier, 1_000_000),
-                7.50,
+                9.0,
             );
             approx_eq(
                 calculate_cache_cost_for_service_tier("gpt-5.6-terra", service_tier, 0, 1_000_000),
-                0.125,
+                0.20,
             );
             approx_eq(
                 calculate_cache_cost_for_service_tier(
@@ -3697,20 +3756,20 @@ mod tests {
                     1_000_000,
                     1_000_000,
                 ),
-                1.6875,
+                2.70,
             );
 
             approx_eq(
                 calculate_input_cost_for_service_tier("gpt-5.6-luna", service_tier, 1_000_000),
-                0.50,
+                0.20,
             );
             approx_eq(
                 calculate_output_cost_for_service_tier("gpt-5.6-luna", service_tier, 1_000_000),
-                3.0,
+                0.90,
             );
             approx_eq(
                 calculate_cache_cost_for_service_tier("gpt-5.6-luna", service_tier, 0, 1_000_000),
-                0.05,
+                0.02,
             );
             approx_eq(
                 calculate_cache_cost_for_service_tier(
@@ -3719,7 +3778,7 @@ mod tests {
                     1_000_000,
                     1_000_000,
                 ),
-                0.675,
+                0.27,
             );
 
             approx_eq(

--- a/src/models.rs
+++ b/src/models.rs
@@ -123,6 +123,9 @@ pub struct DatedPricing {
     pub valid_until: NaiveDate,
     pub pricing: PricingStructure,
     pub caching: CachingSupport,
+    /// Optional service-tier rates for the same historical window.
+    #[serde(default)]
+    pub service_tiers: HashMap<ServiceTier, ServiceTierPricing>,
 }
 
 /// How a provider reports input tokens relative to cache reads.
@@ -195,10 +198,12 @@ impl Registry {
                 .service_tiers
                 .values()
                 .all(|tier| Self::validate_pricing_and_caching(&tier.pricing, &tier.caching))
-            && info
-                .dated_pricing
-                .iter()
-                .all(|dated| Self::validate_pricing_and_caching(&dated.pricing, &dated.caching))
+            && info.dated_pricing.iter().all(|dated| {
+                Self::validate_pricing_and_caching(&dated.pricing, &dated.caching)
+                    && dated.service_tiers.values().all(|tier| {
+                        Self::validate_pricing_and_caching(&tier.pricing, &tier.caching)
+                    })
+            })
     }
 
     fn validate_pricing_and_caching(pricing: &PricingStructure, caching: &CachingSupport) -> bool {
@@ -312,10 +317,31 @@ fn populate_defaults(
                     valid_until: $valid_until,
                     pricing: $pricing,
                     caching: $caching,
+                    service_tiers: HashMap::new(),
                 });
                 model_info
                     .dated_pricing
                     .sort_by_key(|dated| dated.valid_until);
+            }
+        };
+    }
+
+    macro_rules! add_dated_service_tier_pricing {
+        ($name:expr, $valid_until:expr, $service_tier:expr, $pricing:expr, $caching:expr) => {
+            if let Some(model_info) = index.get_mut($name)
+                && let Some(model_info) = Arc::get_mut(model_info)
+                && let Some(dated) = model_info
+                    .dated_pricing
+                    .iter_mut()
+                    .find(|dated| dated.valid_until == $valid_until)
+            {
+                dated.service_tiers.insert(
+                    $service_tier,
+                    ServiceTierPricing {
+                        pricing: $pricing,
+                        caching: $caching,
+                    },
+                );
             }
         };
     }
@@ -976,14 +1002,36 @@ fn populate_defaults(
     add_dated_pricing!(
         "gpt-5.6-terra",
         NaiveDate::from_ymd_opt(2026, 7, 30).expect("valid date"),
-        PricingStructure::Flat {
-            input_per_1m: 2.50,
-            output_per_1m: 15.0
-        },
-        CachingSupport::OpenAIWithWrites {
-            cache_write_per_1m: 3.125,
-            cache_read_per_1m: 0.25
-        }
+        PricingStructure::Tiered(TieredPricing {
+            tiers: vec![
+                PricingTier {
+                    max_tokens: Some(272_000),
+                    input_per_1m: 2.50,
+                    output_per_1m: 15.0
+                },
+                PricingTier {
+                    max_tokens: None,
+                    input_per_1m: 5.0,
+                    output_per_1m: 22.50
+                },
+            ],
+            bracket_pricing: true,
+        }),
+        CachingSupport::TieredWithWrites(TieredCachingWithWrites {
+            tiers: vec![
+                CachingTierWithWrites {
+                    max_tokens: Some(272_000),
+                    cache_write_per_1m: 3.125,
+                    cache_read_per_1m: 0.25
+                },
+                CachingTierWithWrites {
+                    max_tokens: None,
+                    cache_write_per_1m: 6.25,
+                    cache_read_per_1m: 0.50
+                },
+            ],
+            bracket_pricing: true,
+        })
     );
     add_model!(
         "gpt-5.6-luna",
@@ -1022,14 +1070,36 @@ fn populate_defaults(
     add_dated_pricing!(
         "gpt-5.6-luna",
         NaiveDate::from_ymd_opt(2026, 7, 30).expect("valid date"),
-        PricingStructure::Flat {
-            input_per_1m: 1.0,
-            output_per_1m: 6.0
-        },
-        CachingSupport::OpenAIWithWrites {
-            cache_write_per_1m: 1.25,
-            cache_read_per_1m: 0.10
-        }
+        PricingStructure::Tiered(TieredPricing {
+            tiers: vec![
+                PricingTier {
+                    max_tokens: Some(272_000),
+                    input_per_1m: 1.0,
+                    output_per_1m: 6.0
+                },
+                PricingTier {
+                    max_tokens: None,
+                    input_per_1m: 2.0,
+                    output_per_1m: 9.0
+                },
+            ],
+            bracket_pricing: true,
+        }),
+        CachingSupport::TieredWithWrites(TieredCachingWithWrites {
+            tiers: vec![
+                CachingTierWithWrites {
+                    max_tokens: Some(272_000),
+                    cache_write_per_1m: 1.25,
+                    cache_read_per_1m: 0.10
+                },
+                CachingTierWithWrites {
+                    max_tokens: None,
+                    cache_write_per_1m: 2.50,
+                    cache_read_per_1m: 0.20
+                },
+            ],
+            bracket_pricing: true,
+        })
     );
 
     add_model!(
@@ -1103,6 +1173,150 @@ fn populate_defaults(
         0.08,
         3.60
     );
+    let pre_cut = NaiveDate::from_ymd_opt(2026, 7, 30).expect("valid date");
+    add_dated_service_tier_pricing!(
+        "gpt-5.6-terra",
+        pre_cut,
+        ServiceTier::Priority,
+        PricingStructure::Tiered(TieredPricing {
+            tiers: vec![
+                PricingTier {
+                    max_tokens: Some(272_000),
+                    input_per_1m: 5.0,
+                    output_per_1m: 30.0,
+                },
+                PricingTier {
+                    max_tokens: None,
+                    input_per_1m: 10.0,
+                    output_per_1m: 45.0,
+                },
+            ],
+            bracket_pricing: true,
+        }),
+        CachingSupport::TieredWithWrites(TieredCachingWithWrites {
+            tiers: vec![
+                CachingTierWithWrites {
+                    max_tokens: Some(272_000),
+                    cache_write_per_1m: 6.25,
+                    cache_read_per_1m: 0.50,
+                },
+                CachingTierWithWrites {
+                    max_tokens: None,
+                    cache_write_per_1m: 12.50,
+                    cache_read_per_1m: 1.0,
+                },
+            ],
+            bracket_pricing: true,
+        })
+    );
+    add_dated_service_tier_pricing!(
+        "gpt-5.6-luna",
+        pre_cut,
+        ServiceTier::Priority,
+        PricingStructure::Tiered(TieredPricing {
+            tiers: vec![
+                PricingTier {
+                    max_tokens: Some(272_000),
+                    input_per_1m: 2.0,
+                    output_per_1m: 12.0,
+                },
+                PricingTier {
+                    max_tokens: None,
+                    input_per_1m: 4.0,
+                    output_per_1m: 18.0,
+                },
+            ],
+            bracket_pricing: true,
+        }),
+        CachingSupport::TieredWithWrites(TieredCachingWithWrites {
+            tiers: vec![
+                CachingTierWithWrites {
+                    max_tokens: Some(272_000),
+                    cache_write_per_1m: 2.50,
+                    cache_read_per_1m: 0.20,
+                },
+                CachingTierWithWrites {
+                    max_tokens: None,
+                    cache_write_per_1m: 5.0,
+                    cache_read_per_1m: 0.40,
+                },
+            ],
+            bracket_pricing: true,
+        })
+    );
+    for service_tier in [ServiceTier::Flex, ServiceTier::Batch] {
+        add_dated_service_tier_pricing!(
+            "gpt-5.6-terra",
+            pre_cut,
+            service_tier,
+            PricingStructure::Tiered(TieredPricing {
+                tiers: vec![
+                    PricingTier {
+                        max_tokens: Some(272_000),
+                        input_per_1m: 1.25,
+                        output_per_1m: 7.50,
+                    },
+                    PricingTier {
+                        max_tokens: None,
+                        input_per_1m: 2.50,
+                        output_per_1m: 11.25,
+                    },
+                ],
+                bracket_pricing: true,
+            }),
+            CachingSupport::TieredWithWrites(TieredCachingWithWrites {
+                tiers: vec![
+                    CachingTierWithWrites {
+                        max_tokens: Some(272_000),
+                        cache_write_per_1m: 1.5625,
+                        cache_read_per_1m: 0.125,
+                    },
+                    CachingTierWithWrites {
+                        max_tokens: None,
+                        cache_write_per_1m: 3.125,
+                        cache_read_per_1m: 0.25,
+                    },
+                ],
+                bracket_pricing: true,
+            })
+        );
+        add_dated_service_tier_pricing!(
+            "gpt-5.6-luna",
+            pre_cut,
+            service_tier,
+            PricingStructure::Tiered(TieredPricing {
+                tiers: vec![
+                    PricingTier {
+                        max_tokens: Some(272_000),
+                        input_per_1m: 0.50,
+                        output_per_1m: 3.0,
+                    },
+                    PricingTier {
+                        max_tokens: None,
+                        input_per_1m: 1.0,
+                        output_per_1m: 4.50,
+                    },
+                ],
+                bracket_pricing: true,
+            }),
+            CachingSupport::TieredWithWrites(TieredCachingWithWrites {
+                tiers: vec![
+                    CachingTierWithWrites {
+                        max_tokens: Some(272_000),
+                        cache_write_per_1m: 0.625,
+                        cache_read_per_1m: 0.05,
+                    },
+                    CachingTierWithWrites {
+                        max_tokens: None,
+                        cache_write_per_1m: 1.25,
+                        cache_read_per_1m: 0.10,
+                    },
+                ],
+                bracket_pricing: true,
+            })
+        );
+    }
+
     add_flat_service_tier_pricing!("gpt-5.5", ServiceTier::Priority, 12.50, 1.25, 75.0);
     add_flat_service_tier_pricing!("gpt-5.4", ServiceTier::Priority, 5.0, 0.50, 30.0);
     add_flat_service_tier_pricing!("gpt-5.4-mini", ServiceTier::Priority, 1.50, 0.15, 9.0);
@@ -2455,28 +2669,30 @@ pub fn is_model_estimated(model_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn dated_pricing_for_date(
+    model_info: &ModelInfo,
+    effective_at: Option<DateTime<Utc>>,
+) -> Option<&DatedPricing> {
+    let usage_date = effective_at?.date_naive();
+    // Pick the *nearest* matching override rather than the first one in
+    // the vector. Built-in models are kept sorted by `add_dated_pricing!`,
+    // but externally-merged `ModelInfo.dated_pricing` (from
+    // `Registry::merge`) is only validated, not sorted, so `.find(...)`
+    // could otherwise pick the wrong override depending on input order.
+    model_info
+        .dated_pricing
+        .iter()
+        .filter(|dated| usage_date < dated.valid_until)
+        .min_by_key(|dated| dated.valid_until)
+}
+
 fn standard_pricing_for_date(
     model_info: &ModelInfo,
     effective_at: Option<DateTime<Utc>>,
 ) -> (&PricingStructure, &CachingSupport) {
-    if let Some(effective_at) = effective_at {
-        let usage_date = effective_at.date_naive();
-        // Pick the *nearest* matching override rather than the first one in
-        // the vector. Built-in models are kept sorted by `add_dated_pricing!`,
-        // but externally-merged `ModelInfo.dated_pricing` (from
-        // `Registry::merge`) is only validated, not sorted, so `.find(...)`
-        // could otherwise pick the wrong override depending on input order.
-        if let Some(dated) = model_info
-            .dated_pricing
-            .iter()
-            .filter(|dated| usage_date < dated.valid_until)
-            .min_by_key(|dated| dated.valid_until)
-        {
-            return (&dated.pricing, &dated.caching);
-        }
-    }
-
-    (&model_info.pricing, &model_info.caching)
+    dated_pricing_for_date(model_info, effective_at)
+        .map(|dated| (&dated.pricing, &dated.caching))
+        .unwrap_or((&model_info.pricing, &model_info.caching))
 }
 
 fn pricing_for_service_tier(
@@ -2490,9 +2706,9 @@ fn pricing_for_service_tier(
         return standard;
     }
 
-    model_info
-        .service_tiers
-        .get(&service_tier)
+    dated_pricing_for_date(model_info, effective_at)
+        .and_then(|dated| dated.service_tiers.get(&service_tier))
+        .or_else(|| model_info.service_tiers.get(&service_tier))
         .map(|tier| (&tier.pricing, &tier.caching))
         .unwrap_or(standard)
 }
@@ -2959,12 +3175,12 @@ mod tests {
         CachingSupport, CachingTier, CachingTierWithWrites, InputTokenSemantics, ModelInfo,
         PricingStructure, PricingTier, Registry, ServiceTier, TieredCaching,
         TieredCachingWithWrites, TieredPricing, calculate_cache_cost,
-        calculate_cache_cost_for_service_tier, calculate_cache_cost_for_service_tier_at,
-        calculate_input_cost, calculate_input_cost_for_service_tier,
-        calculate_input_cost_for_service_tier_at, calculate_output_cost,
-        calculate_output_cost_for_service_tier, calculate_output_cost_for_service_tier_at,
-        calculate_total_cost_for_context_at, calculate_total_cost_for_service_tier_at,
-        get_model_info, get_registry_lock, init_external_models,
+        calculate_cache_cost_for_service_tier, calculate_input_cost,
+        calculate_input_cost_for_service_tier, calculate_input_cost_for_service_tier_at,
+        calculate_output_cost, calculate_output_cost_for_service_tier,
+        calculate_output_cost_for_service_tier_at, calculate_total_cost_for_context_at,
+        calculate_total_cost_for_service_tier_at, get_model_info, get_registry_lock,
+        init_external_models,
     };
 
     use chrono::{TimeZone, Utc};
@@ -3474,59 +3690,30 @@ mod tests {
         );
     }
 
-    /// Usage from before the 2026-07-30 cut must keep the price it was actually
-    /// billed at. Without the dated overrides the new rates are applied
-    /// retroactively, and every Luna session recorded before the cut is
-    /// suddenly reported at a fifth of what it cost.
+    /// Usage from before the 2026-07-30 cut must keep both the historical
+    /// sticker price and its long-context multiplier across every service tier.
     #[test]
     fn gpt_5_6_terra_and_luna_keep_pre_cut_pricing_for_older_usage() {
         let before_cut = Utc.with_ymd_and_hms(2026, 7, 29, 12, 0, 0).unwrap();
 
-        for (model, input, output, cache_read, cache_write_and_read) in [
-            ("gpt-5.6-terra", 2.50, 15.0, 0.25, 3.375),
-            ("gpt-5.6-luna", 1.0, 6.0, 0.10, 1.35),
+        for (service_tier, terra, luna) in [
+            (ServiceTier::Standard, 0.825, 0.33),
+            (ServiceTier::Priority, 1.65, 0.66),
+            (ServiceTier::Flex, 0.4125, 0.165),
+            (ServiceTier::Batch, 0.4125, 0.165),
         ] {
-            approx_eq(
-                calculate_input_cost_for_service_tier_at(
+            for (model, expected) in [("gpt-5.6-terra", terra), ("gpt-5.6-luna", luna)] {
+                let cost = calculate_total_cost_for_service_tier_at(
                     model,
-                    ServiceTier::Standard,
-                    1_000_000,
-                    Some(before_cut),
-                ),
-                input,
-            );
-            approx_eq(
-                calculate_output_cost_for_service_tier_at(
-                    model,
-                    ServiceTier::Standard,
-                    1_000_000,
-                    Some(before_cut),
-                ),
-                output,
-            );
-            approx_eq(
-                calculate_cache_cost_for_service_tier_at(
-                    model,
-                    ServiceTier::Standard,
+                    service_tier,
+                    100_000,
+                    10_000,
                     0,
-                    1_000_000,
+                    200_000,
                     Some(before_cut),
-                ),
-                cache_read,
-            );
-            // Cache writes are the other half of the historical cost, and the
-            // dated override carries its own `CachingSupport`. Without this the
-            // write rate could silently fall through to the post-cut value.
-            approx_eq(
-                calculate_cache_cost_for_service_tier_at(
-                    model,
-                    ServiceTier::Standard,
-                    1_000_000,
-                    1_000_000,
-                    Some(before_cut),
-                ),
-                cache_write_and_read,
-            );
+                );
+                approx_eq(cost, expected);
+            }
         }
     }
 


### PR DESCRIPTION
## Why

GPT-5.6 Terra and Luna support long-context pricing above 272K prompt tokens, but Splitrail currently treats both models as flat-priced. Their recorded Priority/Fast and Flex/Batch rates are also stale relative to OpenAI’s current pricing table.

This underreports long-context requests and can misprice short-context service-tier usage. Updating only the current tables would also retroactively reprice usage from before OpenAI’s July 30 price cut, so historical Standard, Priority, Flex, and Batch rates need to remain date-aware.

GPT-5.4 was reviewed at the same time: its Standard and Flex/Batch brackets already match OpenAI, while no long-context Priority/Fast rates are published, so this change does not invent them.

## What changed

- Model Terra and Luna Standard pricing with verified 272K short- and long-context brackets.
- Add matching tiered cache-write and cache-read rates for both models.
- Replace flat Priority/Fast and Flex/Batch entries with the complete published short/long matrices.
- Correct the current Terra and Luna short-context service-tier rates.
- Extend `DatedPricing` with optional service-tier overrides while preserving external-config compatibility through `#[serde(default)]`.
- Preserve pre–July 30 Standard, Priority, Flex, and Batch prices, including their historical long-context multipliers.
- Remove the now-unused flat service-tier cache-write helper.
- Add mixed cached/uncached coverage proving a 300K prompt selects one long-context bracket for the full request.
- Cover historical full-request costs across all four service tiers and update current Standard, Priority, Flex, and Batch assertions.

## Validation

- `cargo build --quiet`
- `cargo test --quiet` — 432 passed
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Pricing Updates**
  - Updated pricing for `gpt-5.6-terra` and `gpt-5.6-luna` to use 272K-token usage tiers.
  - Added separate tiered rates for cache reads and writes.
  - Updated Standard, Priority, Flex, and Batch service-tier pricing.
  - Improved pricing accuracy for long-context requests.
  - Added support for historically accurate rates based on the request’s effective date.
  - Ensured matching dated service-tier pricing is applied when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->