### PR TITLE
Add Claude Fable 5.1 pricing

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1509,10 +1509,9 @@ fn populate_defaults(
         },
         false
     );
-    // Anthropic's Batch API halves base input and output prices. Prompt-cache
-    // billing is intentionally omitted from this tier because Anthropic says
-    // pricing modifiers stack, while Splitrail cannot yet identify cache TTLs
-    // or represent the combined Batch-plus-cache rate without guessing.
+    // Anthropic's Batch discount stacks with prompt-caching prices. Apply its
+    // 50% discount to the same default five-minute write approximation used by
+    // standard pricing so Batch usage with cache tokens is not undercounted.
     add_service_tier_pricing!(
         "claude-fable-5-1",
         ServiceTier::Batch,
@@ -1520,7 +1519,10 @@ fn populate_defaults(
             input_per_1m: 5.0,
             output_per_1m: 25.0
         },
-        CachingSupport::None
+        CachingSupport::Anthropic {
+            cache_write_per_1m: 6.25,
+            cache_read_per_1m: 0.125
+        }
     );
     add_model!(
         "claude-fable-5",
@@ -3641,18 +3643,20 @@ mod tests {
     }
 
     #[test]
-    fn claude_fable_5_1_batch_tier_uses_half_price_base_tokens() {
+    fn claude_fable_5_1_batch_tier_stacks_with_cache_discount() {
+        // Anthropic applies Batch's 50% discount to base and prompt-cache
+        // prices, so every token category must participate in this assertion.
         approx_eq(
             calculate_total_cost_for_service_tier_at(
                 "claude-fable-5-1",
                 ServiceTier::Batch,
                 1_000_000,
                 1_000_000,
-                0,
-                0,
+                1_000_000,
+                1_000_000,
                 None,
             ),
-            30.0,
+            36.375,
         );
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1494,6 +1494,35 @@ fn populate_defaults(
 
     // Anthropic Models
     add_model!(
+        "claude-fable-5-1",
+        PricingStructure::Flat {
+            input_per_1m: 10.0,
+            output_per_1m: 50.0
+        },
+        // Splitrail receives one undifferentiated cache-creation count, so use
+        // Anthropic's default 5-minute write rate here. The optional one-hour
+        // cache write remains $20/MTok, but cannot be selected without losing
+        // the token source's TTL information before pricing.
+        CachingSupport::Anthropic {
+            cache_write_per_1m: 12.5,
+            cache_read_per_1m: 0.25
+        },
+        false
+    );
+    // Anthropic's Batch API halves base input and output prices. Prompt-cache
+    // billing is intentionally omitted from this tier because Anthropic says
+    // pricing modifiers stack, while Splitrail cannot yet identify cache TTLs
+    // or represent the combined Batch-plus-cache rate without guessing.
+    add_service_tier_pricing!(
+        "claude-fable-5-1",
+        ServiceTier::Batch,
+        PricingStructure::Flat {
+            input_per_1m: 5.0,
+            output_per_1m: 25.0
+        },
+        CachingSupport::None
+    );
+    add_model!(
         "claude-fable-5",
         PricingStructure::Flat {
             input_per_1m: 10.0,
@@ -2527,6 +2556,10 @@ fn populate_defaults(
     add_alias!("openai.gpt-oss-safeguard-120b", "gpt-oss-safeguard-120b");
 
     // Anthropic aliases
+    add_alias!("claude-fable-5-1", "claude-fable-5-1");
+    add_alias!("claude-fable-5.1", "claude-fable-5-1");
+    add_alias!("claude-5.1-fable", "claude-fable-5-1");
+    add_alias!("anthropic.claude-fable-5-1", "claude-fable-5-1");
     add_alias!("claude-fable-5", "claude-fable-5");
     add_alias!("claude-fable-5.0", "claude-fable-5");
     add_alias!("claude-5-fable", "claude-fable-5");
@@ -3585,6 +3618,42 @@ mod tests {
         approx_eq(input_cost, 5.0);
         approx_eq(output_cost, 25.0);
         approx_eq(cache_cost, 6.75);
+    }
+
+    #[test]
+    fn claude_fable_5_1_aliases_map_to_official_pricing() {
+        for model in [
+            "claude-fable-5-1",
+            "claude-fable-5.1",
+            "claude-5.1-fable",
+            "anthropic.claude-fable-5-1",
+        ] {
+            let model_info = get_model_info(model).expect("Fable 5.1 alias should resolve");
+            assert!(!model_info.is_estimated);
+
+            approx_eq(calculate_input_cost(model, 1_000_000), 10.0);
+            approx_eq(calculate_output_cost(model, 1_000_000), 50.0);
+            // One million default 5-minute cache writes plus one million reads
+            // cost $12.50 + $0.25. This assertion locks in Fable 5.1's special
+            // 0.025x read multiplier rather than Anthropic's usual 0.1x rate.
+            approx_eq(calculate_cache_cost(model, 1_000_000, 1_000_000), 12.75);
+        }
+    }
+
+    #[test]
+    fn claude_fable_5_1_batch_tier_uses_half_price_base_tokens() {
+        approx_eq(
+            calculate_total_cost_for_service_tier_at(
+                "claude-fable-5-1",
+                ServiceTier::Batch,
+                1_000_000,
+                1_000_000,
+                0,
+                0,
+                None,
+            ),
+            30.0,
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Claude Fable 5.1 is available under a new model identifier and retains Fable 5's base token prices, but its cache reads cost one quarter as much: `$0.25/MTok` instead of `$1/MTok`. Without a dedicated registry entry, Splitrail cannot resolve the new model or calculate that lower cache-read rate.

Splitrail receives a single undifferentiated cache-creation token count. It therefore cannot distinguish Anthropic's `$12.50/MTok` five-minute writes from `$20/MTok` one-hour writes after the usage source has discarded the TTL. This change follows the registry's existing convention and uses the default five-minute write rate rather than guessing.

## What changed

- Register `claude-fable-5-1` with official `$10/MTok` input and `$50/MTok` output pricing.
- Price five-minute cache writes at `$12.50/MTok` and cache reads at `$0.25/MTok`, preserving Fable 5.1's special `0.025x` read multiplier.
- Add the documented Batch API tier at `$5/MTok` input and `$25/MTok` output.
- Resolve canonical, dotted, reordered, and Amazon Bedrock model identifiers to the new entry.
- Add focused tests covering aliases, published pricing, non-estimated status, cache costs, and Batch pricing.
- Leave one-hour cache-write accounting out of scope until analyzer data preserves cache TTLs.

## Validation

- `cargo build --quiet`
- `cargo test --quiet`
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Claude Fable 5.1 model.
  * Added model aliases for easier selection.
  * Added Anthropic-style prompt caching.
  * Added discounted Batch pricing, including cached token usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->