### PR TITLE
Correct GPT-6 Astra cost accounting

### DIFF
--- a/src/analyzers/piebald.rs
+++ b/src/analyzers/piebald.rs
@@ -170,7 +170,11 @@ fn parse_service_tier(service_tier: Option<&str>) -> ServiceTier {
         .map(str::to_ascii_lowercase)
         .as_deref()
     {
-        Some("priority") => ServiceTier::Priority,
+        // OpenAI names its premium low-latency tier `fast`, while older
+        // records and Splitrail's provider-neutral enum use `priority`.
+        // Treat both spellings as the same billing class so current Astra
+        // traffic is not silently charged at the Standard rate.
+        Some("fast" | "priority") => ServiceTier::Priority,
         Some("flex") => ServiceTier::Flex,
         Some("batch") => ServiceTier::Batch,
         _ => ServiceTier::Standard,
@@ -410,6 +414,7 @@ mod tests {
     #[test]
     fn test_parse_service_tier_maps_known_values() {
         assert_eq!(parse_service_tier(Some("priority")), ServiceTier::Priority);
+        assert_eq!(parse_service_tier(Some(" FAST ")), ServiceTier::Priority);
         assert_eq!(parse_service_tier(Some(" flex ")), ServiceTier::Flex);
         assert_eq!(parse_service_tier(Some("BATCH")), ServiceTier::Batch);
     }

--- a/src/analyzers/piebald.rs
+++ b/src/analyzers/piebald.rs
@@ -502,6 +502,41 @@ mod tests {
     }
 
     #[test]
+    fn test_convert_messages_counts_cache_writes_toward_astra_context() {
+        let chats = vec![PiebaldChat {
+            id: 1,
+            title: Some("Long cached Astra chat".to_string()),
+            model: Some("gpt-6-astra".to_string()),
+            project_directory: Some("/tmp/project".to_string()),
+        }];
+        let messages = vec![PiebaldMessage {
+            id: 10,
+            parent_chat_id: 1,
+            role: "assistant".to_string(),
+            model: Some("gpt-6-astra".to_string()),
+            input_tokens: Some(400_000),
+            output_tokens: Some(10_000),
+            reasoning_tokens: Some(0),
+            cache_read_tokens: Some(0),
+            cache_write_tokens: Some(300_000),
+            service_tier: None,
+            created_at: "2026-09-03T12:00:00Z".to_string(),
+            updated_at: "2026-09-03T12:00:01Z".to_string(),
+        }];
+
+        let converted = convert_messages(&chats, messages, &HashMap::new());
+        let stats = &converted[0].stats;
+
+        // Piebald's raw 400K input includes the 300K cache write, leaving
+        // 100K ordinary input for billing. Reconstructing the prompt with the
+        // cache write crosses Astra's 272K boundary, so the full request uses
+        // $20/M input, $75/M output, and $25/M cache-write rates.
+        assert_eq!(stats.input_tokens, 100_000);
+        assert_eq!(stats.cache_creation_tokens, 300_000);
+        assert!((stats.cost - 10.25).abs() < 1e-9);
+    }
+
+    #[test]
     fn test_convert_messages_uses_cache_write_rate_without_double_charging() {
         let chats = vec![PiebaldChat {
             id: 1,

--- a/src/models.rs
+++ b/src/models.rs
@@ -3175,8 +3175,13 @@ pub fn calculate_total_cost_for_service_tier_at(
         Some(model_info) => {
             let (pricing, caching) =
                 pricing_for_service_tier(&model_info, service_tier, effective_at);
-            let context_tokens =
-                input_tokens.saturating_add(cache_creation_tokens.max(cache_read_tokens));
+            // OpenAI's long-context threshold is based on prompt input,
+            // including cached input. Cache writes are a billing side effect of
+            // that prompt, not additional context; counting them here can
+            // double-count newly cached tokens and incorrectly select the long
+            // bracket. Callers with an authoritative provider context length
+            // can still supply it through `calculate_total_cost_for_context_at`.
+            let context_tokens = input_tokens.saturating_add(cache_read_tokens);
             calculate_context_cost(
                 pricing,
                 caching,
@@ -3844,10 +3849,30 @@ mod tests {
 
             approx_eq(calculate_input_cost(model, 200_000), 2.0);
             approx_eq(calculate_output_cost(model, 200_000), 10.0);
-            // One million cache writes and reads below the long-context bracket
-            // cost $12.50 + $1.00 at Astra's published Standard rates.
+            // Cache-only helpers select their bracket from the cache counts,
+            // so exercise both published tiers directly: 200K writes plus
+            // reads cost $2.50 + $0.20; one million of each costs $25 + $2.
+            approx_eq(calculate_cache_cost(model, 200_000, 200_000), 2.70);
             approx_eq(calculate_cache_cost(model, 1_000_000, 1_000_000), 27.0);
         }
+    }
+
+    #[test]
+    fn gpt_6_astra_cache_writes_do_not_inflate_prompt_context() {
+        let cost = calculate_total_cost_for_service_tier_at(
+            "gpt-6-astra",
+            ServiceTier::Standard,
+            100_000,
+            10_000,
+            300_000,
+            0,
+            None,
+        );
+
+        // The 100K prompt remains below 272K even though the provider writes
+        // 300K cache tokens. Cache creation is charged, but it cannot select a
+        // higher context bracket because it is not additional prompt input.
+        approx_eq(cost, 5.25);
     }
 
     #[test]

--- a/src/models.rs
+++ b/src/models.rs
@@ -2625,7 +2625,6 @@ fn populate_defaults(
     add_alias!("gpt-5.5-pro", "gpt-5.5-pro");
     add_alias!("gpt-6", "gpt-6-astra");
     add_alias!("gpt-6-astra", "gpt-6-astra");
-    add_alias!("gpt-6-astra-2026-09-03", "gpt-6-astra");
     add_alias!("gpt-5.6", "gpt-5.6-sol");
     add_alias!("gpt-5.6-sol", "gpt-5.6-sol");
     add_alias!("gpt-5.6-sol-ultra", "gpt-5.6-sol");
@@ -3843,7 +3842,7 @@ mod tests {
 
     #[test]
     fn gpt_6_astra_aliases_map_to_official_standard_pricing() {
-        for model in ["gpt-6-astra", "gpt-6", "gpt-6-astra-2026-09-03"] {
+        for model in ["gpt-6-astra", "gpt-6"] {
             let model_info = get_model_info(model).expect("GPT-6 Astra alias should resolve");
             assert!(!model_info.is_estimated);
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -3174,13 +3174,13 @@ pub fn calculate_total_cost_for_service_tier_at(
         Some(model_info) => {
             let (pricing, caching) =
                 pricing_for_service_tier(&model_info, service_tier, effective_at);
-            // OpenAI's long-context threshold is based on prompt input,
-            // including cached input. Cache writes are a billing side effect of
-            // that prompt, not additional context; counting them here can
-            // double-count newly cached tokens and incorrectly select the long
-            // bracket. Callers with an authoritative provider context length
-            // can still supply it through `calculate_total_cost_for_context_at`.
-            let context_tokens = input_tokens.saturating_add(cache_read_tokens);
+            // Token sources report disjoint billable categories here: ordinary
+            // input excludes cached reads and writes. Reads and writes can
+            // overlap, so their maximum reconstructs the cached portion without
+            // double-counting that overlap; adding it back recovers the prompt
+            // context used to select whole-request long-context brackets.
+            let context_tokens =
+                input_tokens.saturating_add(cache_creation_tokens.max(cache_read_tokens));
             calculate_context_cost(
                 pricing,
                 caching,
@@ -3842,6 +3842,8 @@ mod tests {
 
     #[test]
     fn gpt_6_astra_aliases_map_to_official_standard_pricing() {
+        assert!(get_model_info("gpt-6-astra-2026-09-03").is_none());
+
         for model in ["gpt-6-astra", "gpt-6"] {
             let model_info = get_model_info(model).expect("GPT-6 Astra alias should resolve");
             assert!(!model_info.is_estimated);
@@ -3854,24 +3856,6 @@ mod tests {
             approx_eq(calculate_cache_cost(model, 200_000, 200_000), 2.70);
             approx_eq(calculate_cache_cost(model, 1_000_000, 1_000_000), 27.0);
         }
-    }
-
-    #[test]
-    fn gpt_6_astra_cache_writes_do_not_inflate_prompt_context() {
-        let cost = calculate_total_cost_for_service_tier_at(
-            "gpt-6-astra",
-            ServiceTier::Standard,
-            100_000,
-            10_000,
-            300_000,
-            0,
-            None,
-        );
-
-        // The 100K prompt remains below 272K even though the provider writes
-        // 300K cache tokens. Cache creation is charged, but it cannot select a
-        // higher context bracket because it is not additional prompt input.
-        approx_eq(cost, 5.25);
     }
 
     #[test]


### PR DESCRIPTION
## Why

GPT-6 Astra pricing landed in #246, but OpenAI accepts `service_tier: "fast"` while Splitrail only recognizes the legacy `priority` spelling. This causes Fast requests to fall back to Standard rates. The initial catalog entry also included a dated snapshot identifier that OpenAI has not published.

## What changed

- Treat OpenAI `fast` and legacy `priority` service-tier values as Splitrail's provider-neutral `Priority` billing class.
- Remove the unpublished `gpt-6-astra-2026-09-03` alias while preserving `gpt-6` normalization to the canonical `gpt-6-astra` model.
- Cover the `fast` spelling, short and long cache rates, and write-dominated prompts that cross Astra's 272K long-context threshold.
- Preserve the existing union-based context reconstruction so overlapping cache reads and writes are counted once.

## Validation

- `cargo build --quiet`
- `cargo test --quiet`
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet --check`
- `git diff --check`
