### PR TITLE
feat(tui): add hourly usage statistics

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -321,6 +321,13 @@ fn add_new_sessions_to_view(
             activity.message_count = 0;
             activity.ai_message_count = 0;
         }
+        for activity in session.hourly.values_mut() {
+            activity.stats = TuiStats::default();
+            activity.models = ModelCounts::new();
+            activity.model_stats.clear();
+            activity.message_count = 0;
+            activity.ai_message_count = 0;
+        }
         let date = session.date;
         view.session_aggregates.push(session);
         view.num_conversations += 1;

--- a/src/config.rs
+++ b/src/config.rs
@@ -104,7 +104,7 @@ pub struct TuiConfig {
     pub reverse_sort_default: bool,
     #[serde(default)]
     pub hide_empty_periods: bool,
-    /// Aggregation the TUI opens in: "daily" | "weekly" | "monthly" | "yearly".
+    /// Aggregation the TUI opens in: "hourly" | "daily" | "weekly" | "monthly" | "yearly".
     #[serde(default = "default_view")]
     pub default_view: String,
     /// Tab the TUI opens on, by tool name (e.g. "Claude Code"). Empty / "All

--- a/src/contribution_cache/mod.rs
+++ b/src/contribution_cache/mod.rs
@@ -19,14 +19,38 @@ use std::path::Path;
 use dashmap::DashMap;
 use xxhash_rust::xxh3::xxh3_64;
 
-use crate::types::{AnalyzerStatsView, CompactDate, DailyStats, SessionPeriodAggregate};
+use crate::types::{
+    AnalyzerStatsView, CompactDate, DailyStats, ModelStats, SessionPeriodAggregate, TuiStats,
+    resolve_model,
+};
 
-fn merge_daily_add(
-    dst: &mut BTreeMap<CompactDate, SessionPeriodAggregate>,
-    src: &BTreeMap<CompactDate, SessionPeriodAggregate>,
+fn single_message_model_stats(
+    contrib: &SingleMessageContribution,
+    stats: TuiStats,
+) -> Option<(String, ModelStats)> {
+    let model = resolve_model(contrib.model?);
+    Some((
+        model.to_string(),
+        ModelStats {
+            model: model.to_string(),
+            message_count: 1,
+            input_tokens: stats.input_tokens,
+            output_tokens: stats.output_tokens,
+            reasoning_tokens: stats.reasoning_tokens,
+            cached_tokens: stats.cached_tokens,
+            cost: stats.cost(),
+            tool_calls: stats.tool_calls,
+            ..Default::default()
+        },
+    ))
+}
+
+fn merge_period_add<K: Ord + Clone>(
+    dst: &mut BTreeMap<K, SessionPeriodAggregate>,
+    src: &BTreeMap<K, SessionPeriodAggregate>,
 ) {
-    for (date, activity) in src {
-        let daily = dst.entry(*date).or_default();
+    for (period, activity) in src {
+        let daily = dst.entry(period.clone()).or_default();
         daily.message_count = daily.message_count.saturating_add(activity.message_count);
         daily.ai_message_count = daily
             .ai_message_count
@@ -45,12 +69,12 @@ fn merge_daily_add(
     }
 }
 
-fn merge_daily_subtract(
-    dst: &mut BTreeMap<CompactDate, SessionPeriodAggregate>,
-    src: &BTreeMap<CompactDate, SessionPeriodAggregate>,
+fn merge_period_subtract<K: Ord>(
+    dst: &mut BTreeMap<K, SessionPeriodAggregate>,
+    src: &BTreeMap<K, SessionPeriodAggregate>,
 ) {
-    for (date, activity) in src {
-        if let Some(daily) = dst.get_mut(date) {
+    for (period, activity) in src {
+        if let Some(daily) = dst.get_mut(period) {
             daily.message_count = daily.message_count.saturating_sub(activity.message_count);
             daily.ai_message_count = daily
                 .ai_message_count
@@ -275,12 +299,24 @@ impl AnalyzerStatsView {
             let stats = contrib.to_tui_stats();
             existing.stats += stats;
             let daily = existing.daily.entry(date).or_default();
+            let hourly = existing.hourly.entry(contrib.hour_key()).or_default();
             daily.message_count = daily.message_count.saturating_add(1);
+            hourly.message_count = hourly.message_count.saturating_add(1);
             daily.stats += stats;
+            hourly.stats += stats;
             if let Some(model) = contrib.model {
                 daily.ai_message_count = daily.ai_message_count.saturating_add(1);
+                hourly.ai_message_count = hourly.ai_message_count.saturating_add(1);
                 existing.models.increment(model, 1);
                 daily.models.increment(model, 1);
+                hourly.models.increment(model, 1);
+                if let Some((model, model_stats)) = single_message_model_stats(contrib, stats) {
+                    hourly
+                        .model_stats
+                        .entry(model.clone())
+                        .or_insert_with(|| ModelStats::new(model))
+                        .add_model_stats(&model_stats);
+                }
             }
         }
         // Note: We don't create new sessions here - they should already exist from initial load.
@@ -319,11 +355,30 @@ impl AnalyzerStatsView {
                     daily.models.decrement(model, 1);
                 }
             }
+            if let Some(hourly) = existing.hourly.get_mut(&contrib.hour_key()) {
+                hourly.message_count = hourly.message_count.saturating_sub(1);
+                hourly.stats -= stats;
+                if let Some(model) = contrib.model {
+                    hourly.ai_message_count = hourly.ai_message_count.saturating_sub(1);
+                    hourly.models.decrement(model, 1);
+                    if let Some((model, model_stats)) = single_message_model_stats(contrib, stats)
+                        && let Some(existing) = hourly.model_stats.get_mut(&model)
+                    {
+                        existing.sub_model_stats(&model_stats);
+                    }
+                    hourly
+                        .model_stats
+                        .retain(|_, stats| stats.message_count > 0);
+                }
+            }
             if let Some(model) = contrib.model {
                 existing.models.decrement(model, 1);
             }
             existing
                 .daily
+                .retain(|_, activity| activity.message_count > 0);
+            existing
+                .hourly
                 .retain(|_, activity| activity.message_count > 0);
         }
     }
@@ -369,7 +424,8 @@ impl AnalyzerStatsView {
             for &(model, count) in contrib.models.iter() {
                 existing.models.increment(model, count);
             }
-            merge_daily_add(&mut existing.daily, &contrib.daily);
+            merge_period_add(&mut existing.daily, &contrib.daily);
+            merge_period_add(&mut existing.hourly, &contrib.hourly);
         }
     }
 
@@ -419,7 +475,8 @@ impl AnalyzerStatsView {
             for &(model, count) in contrib.models.iter() {
                 existing.models.decrement(model, count);
             }
-            merge_daily_subtract(&mut existing.daily, &contrib.daily);
+            merge_period_subtract(&mut existing.daily, &contrib.daily);
+            merge_period_subtract(&mut existing.hourly, &contrib.hourly);
         }
     }
 
@@ -448,7 +505,8 @@ impl AnalyzerStatsView {
                 for &(model, count) in new_session.models.iter() {
                     existing.models.increment(model, count);
                 }
-                merge_daily_add(&mut existing.daily, &new_session.daily);
+                merge_period_add(&mut existing.daily, &new_session.daily);
+                merge_period_add(&mut existing.hourly, &new_session.hourly);
                 if new_session.first_timestamp < existing.first_timestamp {
                     existing.first_timestamp = new_session.first_timestamp;
                     existing.date = new_session.date;
@@ -495,7 +553,8 @@ impl AnalyzerStatsView {
                 for &(model, count) in old_session.models.iter() {
                     existing.models.decrement(model, count);
                 }
-                merge_daily_subtract(&mut existing.daily, &old_session.daily);
+                merge_period_subtract(&mut existing.daily, &old_session.daily);
+                merge_period_subtract(&mut existing.hourly, &old_session.hourly);
             }
         }
 

--- a/src/contribution_cache/single_message.rs
+++ b/src/contribution_cache/single_message.rs
@@ -3,6 +3,7 @@
 //! Optimized to 32 bytes for cache alignment using bitfield packing.
 
 use c2rust_bitfields::BitfieldStruct;
+use chrono::{Local, Timelike};
 
 use super::SessionHash;
 use crate::cache::ModelKey;
@@ -25,7 +26,8 @@ use crate::types::{CompactDate, ConversationMessage, TuiStats, intern_model};
 // | year_offset       | 2025-2026    | 6         | 63 (2020-2083)    |
 // | month             | 1-12         | 4         | 15                |
 // | day               | 1-31         | 5         | 31                |
-// | duration_ms       | —            | 11        | 2,047 (~2s)       |
+// | hour              | 0-23         | 5         | 31                |
+// | duration_ms       | —            | 6         | 63ms              |
 //
 // Total: 176 bits = 22 bytes
 
@@ -41,7 +43,8 @@ use crate::types::{CompactDate, ConversationMessage, TuiStats, intern_model};
 /// - year_offset:      bits 150-155 (6 bits, years 2020-2083)
 /// - month:            bits 156-159 (4 bits, 1-12)
 /// - day:              bits 160-164 (5 bits, 1-31)
-/// - duration_ms:      bits 165-175 (11 bits; reserved for future use)
+/// - hour:             bits 165-169 (5 bits, 0-23)
+/// - duration_ms:      bits 170-175 (6 bits; reserved for future use)
 #[repr(C, align(1))]
 #[derive(BitfieldStruct, Clone, Copy, Default)]
 #[allow(clippy::duplicated_attributes)]
@@ -55,7 +58,8 @@ pub struct PackedStatsDate {
     #[bitfield(name = "year_offset", ty = "u8", bits = "150..=155")]
     #[bitfield(name = "month", ty = "u8", bits = "156..=159")]
     #[bitfield(name = "day", ty = "u8", bits = "160..=164")]
-    #[bitfield(name = "duration_ms", ty = "u16", bits = "165..=175")]
+    #[bitfield(name = "hour", ty = "u8", bits = "165..=169")]
+    #[bitfield(name = "duration_ms", ty = "u8", bits = "170..=175")]
     data: [u8; 22],
 }
 
@@ -71,6 +75,7 @@ impl std::fmt::Debug for PackedStatsDate {
             .field("year_offset", &self.year_offset())
             .field("month", &self.month())
             .field("day", &self.day())
+            .field("hour", &self.hour())
             .field("duration_ms", &self.duration_ms())
             .finish()
     }
@@ -82,7 +87,7 @@ const BASE_YEAR: u16 = 2020;
 impl PackedStatsDate {
     /// Pack stats and date into the bitfield.
     #[inline]
-    pub fn pack(stats: &crate::types::Stats, date: CompactDate) -> Self {
+    pub fn pack(stats: &crate::types::Stats, date: CompactDate, hour: u8) -> Self {
         let mut packed = Self::default();
 
         // Pack stats (with saturation for safety)
@@ -100,6 +105,7 @@ impl PackedStatsDate {
         packed.set_year_offset(year_offset);
         packed.set_month(date.month());
         packed.set_day(date.day());
+        packed.set_hour(hour.min(23));
 
         // duration_ms reserved for future use
         packed.set_duration_ms(0);
@@ -161,7 +167,11 @@ impl SingleMessageContribution {
         Self {
             session_hash: SessionHash::from_str(&msg.conversation_hash),
             model: msg.model.as_ref().map(|m| intern_model(m)),
-            packed: PackedStatsDate::pack(&msg.stats, CompactDate::from_local(&msg.date)),
+            packed: PackedStatsDate::pack(
+                &msg.stats,
+                CompactDate::from_local(&msg.date),
+                msg.date.with_timezone(&Local).hour() as u8,
+            ),
         }
     }
 
@@ -169,6 +179,12 @@ impl SingleMessageContribution {
     #[inline]
     pub fn date(&self) -> CompactDate {
         self.packed.unpack_date()
+    }
+
+    /// Get the local hour bucket key (`YYYY-MM-DDTHH`).
+    #[inline]
+    pub fn hour_key(&self) -> String {
+        format!("{}T{:02}", self.date(), self.packed.hour())
     }
 
     /// Convert packed stats to TuiStats for display.
@@ -234,7 +250,7 @@ mod size_tests {
         };
         let date = CompactDate::from_parts(2025, 6, 15);
 
-        let packed = PackedStatsDate::pack(&stats, date);
+        let packed = PackedStatsDate::pack(&stats, date, 17);
 
         assert_eq!(packed.input_tokens(), 170_749);
         assert_eq!(packed.output_tokens(), 31_999);
@@ -242,6 +258,7 @@ mod size_tests {
         assert_eq!(packed.cached_tokens(), 186_677);
         assert_eq!(packed.cost_micros(), 3_560_000);
         assert_eq!(packed.tool_calls(), 73);
+        assert_eq!(packed.hour(), 17);
 
         let unpacked_date = packed.unpack_date();
         assert_eq!(unpacked_date.year(), 2025);
@@ -265,7 +282,7 @@ mod size_tests {
         };
         let date = CompactDate::from_parts(2083, 12, 31); // Max year (2020 + 63)
 
-        let packed = PackedStatsDate::pack(&stats, date);
+        let packed = PackedStatsDate::pack(&stats, date, 0);
 
         assert_eq!(packed.input_tokens(), 134_217_727);
         assert_eq!(packed.output_tokens(), 67_108_863);

--- a/src/contribution_cache/single_session.rs
+++ b/src/contribution_cache/single_session.rs
@@ -3,6 +3,8 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use chrono::{Local, Timelike};
+
 use super::SessionHash;
 use crate::types::{
     CompactDate, ConversationMessage, MessageRole, ModelCounts, ModelStats, SessionPeriodAggregate,
@@ -34,6 +36,8 @@ pub struct SingleSessionContribution {
     pub ai_message_count: u32,
     /// Per-day session activity for period drill-down and incremental updates.
     pub daily: BTreeMap<CompactDate, SessionPeriodAggregate>,
+    /// Per-hour session activity keyed by local time as `YYYY-MM-DDTHH`.
+    pub hourly: BTreeMap<String, SessionPeriodAggregate>,
 }
 
 impl SingleSessionContribution {
@@ -45,6 +49,7 @@ impl SingleSessionContribution {
         let mut first_date = CompactDate::default();
         let mut session_hash = SessionHash::default();
         let mut daily = BTreeMap::new();
+        let mut hourly = BTreeMap::new();
 
         for (i, msg) in messages.iter().enumerate() {
             let date = CompactDate::from_local(&msg.date);
@@ -57,18 +62,30 @@ impl SingleSessionContribution {
                 .entry(date)
                 .or_insert_with(SessionPeriodAggregate::default);
             day.message_count = day.message_count.saturating_add(1);
+            let local = msg.date.with_timezone(&Local);
+            let hour = hourly
+                .entry(format!("{}T{:02}", date, local.hour()))
+                .or_insert_with(SessionPeriodAggregate::default);
+            hour.message_count = hour.message_count.saturating_add(1);
             if msg.role == MessageRole::Assistant {
                 ai_message_count += 1;
                 day.ai_message_count = day.ai_message_count.saturating_add(1);
+                hour.ai_message_count = hour.ai_message_count.saturating_add(1);
                 let message_stats = TuiStats::from(&msg.stats);
                 stats += message_stats;
                 day.stats += message_stats;
+                hour.stats += message_stats;
 
                 if let Some(model) = &msg.model {
                     let model_key = intern_model(model);
                     models.increment(model_key, 1);
                     day.models.increment(model_key, 1);
+                    hour.models.increment(model_key, 1);
                     day.model_stats
+                        .entry(model.to_string())
+                        .or_insert_with(|| ModelStats::new(model.to_string()))
+                        .add_message(&msg.stats);
+                    hour.model_stats
                         .entry(model.to_string())
                         .or_insert_with(|| ModelStats::new(model.to_string()))
                         .add_message(&msg.stats);
@@ -98,6 +115,7 @@ impl SingleSessionContribution {
             session_hash,
             ai_message_count,
             daily,
+            hourly,
         }
     }
 }

--- a/src/contribution_cache/tests/basic_operations.rs
+++ b/src/contribution_cache/tests/basic_operations.rs
@@ -58,6 +58,7 @@ fn test_contribution_cache_single_session_insert_get() {
         session_hash: SessionHash::from_str("session1"),
         ai_message_count: 5,
         daily: Default::default(),
+        hourly: Default::default(),
     };
 
     cache.insert_single_session(path_hash, contrib);
@@ -112,6 +113,7 @@ fn test_contribution_cache_remove_any() {
             session_hash: SessionHash::from_str("s2"),
             ai_message_count: 0,
             daily: Default::default(),
+            hourly: Default::default(),
         },
     );
     cache.insert_multi_session(

--- a/src/contribution_cache/tests/compact_stats.rs
+++ b/src/contribution_cache/tests/compact_stats.rs
@@ -16,7 +16,7 @@ fn test_packed_stats_date_from_stats() {
     };
     let date = CompactDate::from_parts(2025, 6, 15);
 
-    let packed = PackedStatsDate::pack(&stats, date);
+    let packed = PackedStatsDate::pack(&stats, date, 0);
 
     assert_eq!(packed.input_tokens(), 1000);
     assert_eq!(packed.output_tokens(), 500);
@@ -44,7 +44,7 @@ fn test_packed_stats_date_to_tui_stats() {
     };
     let date = CompactDate::from_parts(2025, 1, 1);
 
-    let packed = PackedStatsDate::pack(&stats, date);
+    let packed = PackedStatsDate::pack(&stats, date, 0);
     let tui = packed.to_tui_stats();
 
     assert_eq!(tui.input_tokens, 1000);
@@ -62,7 +62,7 @@ fn test_packed_stats_date_preserves_subcent_cost() {
         ..Default::default()
     };
 
-    let packed = PackedStatsDate::pack(&stats, CompactDate::from_parts(2025, 1, 1));
+    let packed = PackedStatsDate::pack(&stats, CompactDate::from_parts(2025, 1, 1), 0);
     let tui = packed.to_tui_stats();
 
     assert!((tui.cost() - 0.004).abs() < f64::EPSILON);
@@ -83,7 +83,7 @@ fn test_packed_stats_date_max_values() {
     };
     let date = CompactDate::from_parts(2083, 12, 31); // Max year (2020 + 63)
 
-    let packed = PackedStatsDate::pack(&stats, date);
+    let packed = PackedStatsDate::pack(&stats, date, 0);
 
     assert_eq!(packed.input_tokens(), 134_217_727);
     assert_eq!(packed.output_tokens(), 67_108_863);
@@ -112,7 +112,7 @@ fn test_packed_stats_date_saturation() {
     };
     let date = CompactDate::from_parts(2100, 1, 1); // Exceeds max year
 
-    let packed = PackedStatsDate::pack(&stats, date);
+    let packed = PackedStatsDate::pack(&stats, date, 0);
 
     // Values should be saturated to max
     assert_eq!(packed.input_tokens(), 0x7FF_FFFF); // 27-bit max
@@ -138,7 +138,7 @@ fn test_packed_stats_date_observed_values() {
     };
     let date = CompactDate::from_parts(2025, 6, 15);
 
-    let packed = PackedStatsDate::pack(&stats, date);
+    let packed = PackedStatsDate::pack(&stats, date, 0);
 
     assert_eq!(packed.input_tokens(), 170_749);
     assert_eq!(packed.output_tokens(), 31_999);
@@ -158,7 +158,7 @@ fn test_packed_stats_date_zero_values() {
     let stats = Stats::default();
     let date = CompactDate::from_parts(2020, 1, 1); // Minimum year
 
-    let packed = PackedStatsDate::pack(&stats, date);
+    let packed = PackedStatsDate::pack(&stats, date, 0);
 
     assert_eq!(packed.input_tokens(), 0);
     assert_eq!(packed.output_tokens(), 0);

--- a/src/contribution_cache/tests/mod.rs
+++ b/src/contribution_cache/tests/mod.rs
@@ -95,6 +95,7 @@ pub fn make_view_with_session(analyzer_name: &str, session_id: &str) -> Analyzer
             session_name: Some(format!("Session {}", session_id)),
             date: CompactDate::from_str("2025-01-01").unwrap(),
             daily: BTreeMap::new(),
+            hourly: BTreeMap::new(),
         }],
         num_conversations: 0,
         analyzer_name,

--- a/src/contribution_cache/tests/single_message.rs
+++ b/src/contribution_cache/tests/single_message.rs
@@ -89,6 +89,15 @@ fn test_view_add_single_message_contribution() {
     let session = &view.session_aggregates[0];
     assert_eq!(session.stats.input_tokens, 1000);
     assert_eq!(session.stats.output_tokens, 500);
+    assert_eq!(session.hourly.len(), 1);
+    assert_eq!(
+        session.hourly.values().next().unwrap().stats.input_tokens,
+        1000
+    );
+    assert_eq!(
+        session.hourly.values().next().unwrap().model_stats["claude-3-5-sonnet"].input_tokens,
+        1000
+    );
 }
 
 #[test]
@@ -120,6 +129,7 @@ fn test_view_subtract_single_message_contribution() {
     // Session stats should be zeroed
     let session = &view.session_aggregates[0];
     assert_eq!(session.stats.input_tokens, 0);
+    assert!(session.hourly.is_empty());
 }
 
 #[test]

--- a/src/contribution_cache/tests/single_session.rs
+++ b/src/contribution_cache/tests/single_session.rs
@@ -167,6 +167,11 @@ fn test_view_add_single_session_contribution() {
     // Check session stats
     let session = &view.session_aggregates[0];
     assert_eq!(session.stats.input_tokens, 1300);
+    assert_eq!(session.hourly.len(), 1);
+    assert_eq!(
+        session.hourly.values().next().unwrap().stats.input_tokens,
+        1300
+    );
 }
 
 #[test]
@@ -204,6 +209,7 @@ fn test_view_subtract_single_session_contribution() {
     // Session stats should be zeroed
     let session = &view.session_aggregates[0];
     assert_eq!(session.stats.input_tokens, 0);
+    assert!(session.hourly.is_empty());
 }
 
 #[test]

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -22,12 +22,12 @@ use crossterm::terminal::{
 use crossterm::{ExecutableCommand, execute};
 use logic::{
     SessionAggregate, aggregate_daily_stats_by_month, aggregate_daily_stats_by_week,
-    aggregate_daily_stats_by_year, date_matches_buffer, filtered_aggregate_keys, has_data_shared,
-    is_empty_period,
+    aggregate_daily_stats_by_year, aggregate_session_stats_by_hour, date_matches_buffer,
+    filtered_aggregate_keys, has_data_shared, is_empty_period,
 };
 use parking_lot::Mutex;
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, Cell, Paragraph, Row, Table, TableState, Tabs};
@@ -57,6 +57,7 @@ pub enum UploadStatus {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum AggregateViewMode {
+    Hourly,
     Daily,
     Weekly,
     Monthly,
@@ -67,6 +68,7 @@ impl AggregateViewMode {
     /// Parse the configured startup view (tui.default_view).
     fn from_config(s: &str) -> Self {
         match s.trim().to_lowercase().as_str() {
+            "hourly" | "hour" => Self::Hourly,
             "weekly" | "week" => Self::Weekly,
             "monthly" | "month" => Self::Monthly,
             "yearly" | "year" => Self::Yearly,
@@ -79,13 +81,15 @@ impl AggregateViewMode {
             Self::Daily => Self::Weekly,
             Self::Weekly => Self::Monthly,
             Self::Monthly => Self::Yearly,
-            Self::Yearly => Self::Daily,
+            Self::Yearly => Self::Hourly,
+            Self::Hourly => Self::Daily,
         }
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PeriodFilter {
+    Hour { date: CompactDate, hour: u8 },
     Day(CompactDate),
     Week { iso_year: i32, iso_week: u32 },
     Month { year: u16, month: u8 },
@@ -95,6 +99,13 @@ enum PeriodFilter {
 impl PeriodFilter {
     fn from_period_key(period: &str, aggregate_view_mode: AggregateViewMode) -> Option<Self> {
         match aggregate_view_mode {
+            AggregateViewMode::Hourly => {
+                let (date, hour) = period.split_once('T')?;
+                Some(Self::Hour {
+                    date: CompactDate::from_str(date)?,
+                    hour: hour.parse().ok()?,
+                })
+            }
             AggregateViewMode::Daily => CompactDate::from_str(period).map(Self::Day),
             AggregateViewMode::Weekly => {
                 let (year, week) = period.split_once("-W")?;
@@ -118,6 +129,9 @@ impl PeriodFilter {
 
     fn matches_compact_date(self, date: CompactDate) -> bool {
         match self {
+            Self::Hour {
+                date: hour_date, ..
+            } => hour_date == date,
             Self::Day(day) => day == date,
             Self::Week { iso_year, iso_week } => compact_date_to_naive(date)
                 .map(|date| {
@@ -130,8 +144,19 @@ impl PeriodFilter {
         }
     }
 
+    fn matches_hour_key(self, key: &str) -> bool {
+        match self {
+            Self::Hour { date, hour } => key == format!("{date}T{hour:02}"),
+            _ => key
+                .get(..10)
+                .and_then(CompactDate::from_str)
+                .is_some_and(|date| self.matches_compact_date(date)),
+        }
+    }
+
     fn display_key(self) -> String {
         match self {
+            Self::Hour { date, hour } => format!("{date}T{hour:02}"),
             Self::Day(day) => day.to_string(),
             Self::Week { iso_year, iso_week } => format!("{iso_year:04}-W{iso_week:02}"),
             Self::Month { year, month } => format!("{year:04}-{month:02}"),
@@ -141,6 +166,7 @@ impl PeriodFilter {
 
     fn view_mode(self) -> AggregateViewMode {
         match self {
+            Self::Hour { .. } => AggregateViewMode::Hourly,
             Self::Day(_) => AggregateViewMode::Daily,
             Self::Week { .. } => AggregateViewMode::Weekly,
             Self::Month { .. } => AggregateViewMode::Monthly,
@@ -174,6 +200,10 @@ fn get_aggregate_stats<'a>(
     aggregate_view_mode: AggregateViewMode,
 ) -> AggregateStatsData<'a> {
     match aggregate_view_mode {
+        AggregateViewMode::Hourly => AggregateStatsData::Owned(aggregate_session_stats_by_hour(
+            &view.session_aggregates,
+            view.analyzer_name.as_ref() == "All Tools",
+        )),
         AggregateViewMode::Daily => AggregateStatsData::Borrowed(&view.daily_stats),
         AggregateViewMode::Weekly => {
             AggregateStatsData::Owned(aggregate_daily_stats_by_week(&view.daily_stats))
@@ -235,7 +265,12 @@ fn filtered_session_count(view: &AnalyzerStatsView, period_filter: Option<Period
             view.session_aggregates
                 .iter()
                 .filter(|session| {
-                    if session.daily.is_empty() {
+                    if matches!(filter, PeriodFilter::Hour { .. }) {
+                        session
+                            .hourly
+                            .keys()
+                            .any(|hour| filter.matches_hour_key(hour))
+                    } else if session.daily.is_empty() {
                         filter.matches_compact_date(session.date)
                     } else {
                         session
@@ -260,6 +295,29 @@ fn sessions_for_period(
     sessions
         .iter()
         .filter_map(|session| {
+            if matches!(filter, PeriodFilter::Hour { .. }) {
+                let mut filtered = SessionAggregate {
+                    session_id: session.session_id.clone(),
+                    first_timestamp: session.first_timestamp,
+                    analyzer_name: Arc::clone(&session.analyzer_name),
+                    stats: TuiStats::default(),
+                    models: ModelCounts::new(),
+                    project_id: session.project_id.clone(),
+                    project_path: session.project_path.clone(),
+                    session_name: session.session_name.clone(),
+                    date: session.date,
+                    daily: BTreeMap::new(),
+                    hourly: BTreeMap::new(),
+                };
+                let activity = session
+                    .hourly
+                    .iter()
+                    .find(|(hour, _)| filter.matches_hour_key(hour))?;
+                filtered.stats = activity.1.stats;
+                filtered.models = activity.1.models.clone();
+                return Some(filtered);
+            }
+
             if session.daily.is_empty() {
                 return filter
                     .matches_compact_date(session.date)
@@ -277,6 +335,7 @@ fn sessions_for_period(
                 session_name: session.session_name.clone(),
                 date: session.date,
                 daily: BTreeMap::new(),
+                hourly: BTreeMap::new(),
             };
 
             let mut has_activity = false;
@@ -323,6 +382,37 @@ fn tui_stats_from_model_stats(stats: &ModelStats) -> TuiStats {
     tui_stats
 }
 
+fn filter_session_period_by_model(
+    activity: &mut crate::types::SessionPeriodAggregate,
+    filter: &str,
+) -> bool {
+    let original_models = activity.models.clone();
+    let original_stats = activity.stats;
+    let original_ai_messages = activity.ai_message_count;
+    let original_user_messages = activity.message_count.saturating_sub(original_ai_messages);
+    activity.models = filter_model_counts(&activity.models, filter);
+    activity
+        .model_stats
+        .retain(|model, _| model_name_matches(model, filter));
+    activity.ai_message_count = activity.models.iter().map(|(_, count)| count).sum();
+    activity.stats = TuiStats::default();
+    for model_stats in activity.model_stats.values() {
+        activity.stats += tui_stats_from_model_stats(model_stats);
+    }
+
+    let all_models_match = original_models
+        .iter()
+        .all(|(model, _)| model_name_matches(resolve_model(*model), filter));
+    let modeled_messages: u32 = original_models.iter().map(|(_, count)| count).sum();
+    if modeled_messages == original_ai_messages && all_models_match {
+        activity.ai_message_count = original_ai_messages;
+        activity.stats = original_stats;
+    }
+    activity.message_count = original_user_messages.saturating_add(activity.ai_message_count);
+
+    activity.models.iter().next().is_some() || !activity.model_stats.is_empty()
+}
+
 fn filter_analyzer_view_by_model(
     view: &AnalyzerStatsView,
     model_filter: &str,
@@ -343,6 +433,9 @@ fn filter_analyzer_view_by_model(
         })
         .cloned()
         .map(|mut session| {
+            session
+                .hourly
+                .retain(|_, activity| filter_session_period_by_model(activity, &filter));
             if session.daily.is_empty() {
                 session.models = filter_model_counts(&session.models, &filter);
             } else {
@@ -802,6 +895,12 @@ fn format_aggregate_period_for_display(
     aggregate_view_mode: AggregateViewMode,
 ) -> String {
     match aggregate_view_mode {
+        AggregateViewMode::Hourly => {
+            let Some((date, hour)) = period.split_once('T') else {
+                return period.to_string();
+            };
+            format!("{} {hour}:00", format_date_for_display(date))
+        }
         AggregateViewMode::Daily => format_date_for_display(period),
         AggregateViewMode::Weekly => format_week_for_display(period),
         AggregateViewMode::Monthly => format_month_for_display(period),
@@ -913,6 +1012,11 @@ const TOKEN_COL_WIDTH: u16 = 12;
 /// Keeping both count columns at this width prevents right-aligned totals from
 /// being clipped on the left.
 const COUNT_COL_WIDTH: u16 = 7;
+
+const APPS_COL_MIN_WIDTH: usize = 4;
+const APPS_COL_MAX_WIDTH: usize = 32;
+const MODELS_COL_MIN_WIDTH: usize = 6;
+const MODELS_COL_MAX_WIDTH: usize = 48;
 
 pub fn run_tui(
     stats_receiver: watch::Receiver<MultiAnalyzerStatsView>,
@@ -2057,6 +2161,7 @@ fn draw_ui(
             let base_help_text = match ui_state.stats_view_mode {
                 StatsViewMode::Aggregate => {
                     let jump_label = match ui_state.aggregate_view_mode {
+                        AggregateViewMode::Hourly => "hour jump",
                         AggregateViewMode::Daily => "date jump",
                         AggregateViewMode::Weekly => "week jump",
                         AggregateViewMode::Monthly => "month jump",
@@ -2064,11 +2169,11 @@ fn draw_ui(
                     };
 
                     format!(
-                        "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • p for projects • f to filter models • r to reverse sort • e to toggle empty periods • s to toggle summary • / for {jump_label} • m to cycle day/week/month/year • Enter to drill into period • Ctrl+T for all sessions • q to quit"
+                        "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • p for projects • f to filter models • r to reverse sort • e to toggle empty periods • s to toggle summary • / for {jump_label} • m to cycle hour/day/week/month/year • Enter to drill into period • Ctrl+T for all sessions • q to quit"
                     )
                 }
                 StatsViewMode::Session => {
-                    "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • p for projects • f to filter models • r to reverse sort • e to toggle empty periods • s to toggle summary • m to cycle day/week/month/year • Esc or Ctrl+T for aggregate view • q to quit".to_string()
+                    "Use ←/→ or h/l to switch tabs • ↑/↓ or j/k to navigate • p for projects • f to filter models • r to reverse sort • e to toggle empty periods • s to toggle summary • m to cycle hour/day/week/month/year • Esc or Ctrl+T for aggregate view • q to quit".to_string()
                 }
             };
 
@@ -2396,10 +2501,16 @@ fn draw_aggregate_stats_table(
     color_costs: bool,
 ) -> (usize, bool) {
     let period_header = match aggregate_view_mode {
+        AggregateViewMode::Hourly => "Hour",
         AggregateViewMode::Daily => "Date",
         AggregateViewMode::Weekly => "Week",
         AggregateViewMode::Monthly => "Month",
         AggregateViewMode::Yearly => "Year",
+    };
+    let period_width = if aggregate_view_mode == AggregateViewMode::Hourly {
+        17
+    } else {
+        11
     };
 
     let aggregate_stats = get_aggregate_stats(stats, aggregate_view_mode);
@@ -2519,6 +2630,8 @@ fn draw_aggregate_stats_table(
     let mut total_models = BTreeMap::new();
     let mut total_model_stats = BTreeMap::new();
     let mut all_apps = std::collections::BTreeSet::new();
+    let mut max_apps_width = APPS_COL_MIN_WIDTH;
+    let mut max_models_width = MODELS_COL_MIN_WIDTH;
 
     for (i, period) in visible_periods.iter().enumerate() {
         let period_stats = aggregate_stats
@@ -2547,10 +2660,12 @@ fn draw_aggregate_stats_table(
                 .add_model_stats(stats);
         }
         let models = format_model_usage_shares(&period_stats.models, &period_stats.model_stats);
+        max_models_width = max_models_width.max(models.chars().count());
 
         let mut apps_vec: Vec<String> = period_stats.apps.keys().cloned().collect();
         apps_vec.sort();
         let apps = apps_vec.join(", ");
+        max_apps_width = max_apps_width.max(apps.chars().count());
         all_apps.extend(period_stats.apps.keys().cloned());
 
         // Check if this is an empty row
@@ -2752,6 +2867,49 @@ fn draw_aggregate_stats_table(
         .any(|model| is_model_estimated(model));
     let all_apps_text = all_apps.into_iter().collect::<Vec<_>>().join(", ");
     let all_models_text = format_model_usage_shares(&total_models, &total_model_stats);
+    let mut apps_column_width = max_apps_width
+        .max(all_apps_text.chars().count())
+        .clamp(APPS_COL_MIN_WIDTH, APPS_COL_MAX_WIDTH);
+    let mut models_column_width = max_models_width
+        .max(all_models_text.chars().count())
+        .clamp(MODELS_COL_MIN_WIDTH, MODELS_COL_MAX_WIDTH);
+
+    let mut fixed_width = 1usize + period_width as usize + 10;
+    let mut column_count = 3usize;
+    for (column, width) in [
+        ("cached", TOKEN_COL_WIDTH),
+        ("input", TOKEN_COL_WIDTH),
+        ("output", TOKEN_COL_WIDTH),
+        ("reason", TOKEN_COL_WIDTH),
+        ("convs", COUNT_COL_WIDTH),
+        ("tools", COUNT_COL_WIDTH),
+    ] {
+        if show(column) {
+            fixed_width += width as usize;
+            column_count += 1;
+        }
+    }
+    column_count += usize::from(show("apps")) + usize::from(show("models"));
+    let column_spacing = column_count.saturating_sub(1) * 2;
+    let available_text_width = (area.width as usize)
+        .saturating_sub(fixed_width)
+        .saturating_sub(column_spacing);
+    let desired_text_width = if show("apps") { apps_column_width } else { 0 }
+        + if show("models") {
+            models_column_width
+        } else {
+            0
+        };
+    let mut overflow = desired_text_width.saturating_sub(available_text_width);
+    if show("apps") {
+        let shrink = overflow.min(apps_column_width.saturating_sub(APPS_COL_MIN_WIDTH));
+        apps_column_width -= shrink;
+        overflow -= shrink;
+    }
+    if show("models") && overflow > 0 {
+        let shrink = overflow.min(models_column_width.saturating_sub(MODELS_COL_MIN_WIDTH));
+        models_column_width -= shrink;
+    }
 
     // Add separator row before totals
     let token_sep = "─".repeat(TOKEN_COL_WIDTH as usize);
@@ -2763,7 +2921,7 @@ fn draw_aggregate_stats_table(
     };
     let mut sep_cells = vec![
         dim(String::new()),
-        dim("───────────".into()),
+        dim("─".repeat(period_width as usize)),
         dim("──────────".into()),
     ];
     if show("cached") {
@@ -2786,10 +2944,10 @@ fn draw_aggregate_stats_table(
         sep_cells.push(dim(count_sep));
     }
     if show("apps") {
-        sep_cells.push(dim("─".repeat(all_apps_text.len().max(16))));
+        sep_cells.push(dim("─".repeat(apps_column_width)));
     }
     if show("models") {
-        sep_cells.push(dim("─".repeat(all_models_text.len().max(18))));
+        sep_cells.push(dim("─".repeat(models_column_width)));
     }
     rows.push(Row::new(sep_cells));
 
@@ -2808,6 +2966,7 @@ fn draw_aggregate_stats_table(
         },
         Line::from(Span::styled(
             match aggregate_view_mode {
+                AggregateViewMode::Hourly => format!("Total ({}h)", visible_periods.len()),
                 AggregateViewMode::Daily => format!("Total ({}d)", visible_periods.len()),
                 AggregateViewMode::Weekly => format!("Total ({}w)", visible_periods.len()),
                 AggregateViewMode::Monthly => format!("Total ({}m)", visible_periods.len()),
@@ -2903,8 +3062,8 @@ fn draw_aggregate_stats_table(
     let total_rows = rows.len();
 
     let mut widths = vec![
-        Constraint::Length(1),  // Arrow
-        Constraint::Length(11), // Date/Month
+        Constraint::Length(1), // Arrow
+        Constraint::Length(period_width),
         Constraint::Length(10), // Cost
     ];
     if show("cached") {
@@ -2926,15 +3085,16 @@ fn draw_aggregate_stats_table(
         widths.push(Constraint::Length(COUNT_COL_WIDTH));
     }
     if show("apps") {
-        widths.push(Constraint::Min(16));
+        widths.push(Constraint::Length(apps_column_width as u16));
     }
     if show("models") {
-        widths.push(Constraint::Min(10));
+        widths.push(Constraint::Length(models_column_width as u16));
     }
     let table = Table::new(rows, widths)
         .header(header)
         .block(Block::default().title(""))
         .row_highlight_style(Style::default().fg(accent))
+        .flex(Flex::Start)
         .column_spacing(2);
 
     frame.render_stateful_widget(table, area, table_state);
@@ -3401,12 +3561,25 @@ fn draw_summary_stats(
 
     for stats_arc in filtered_stats {
         let stats = stats_arc.read();
-        // Iterate directly - filter inline if a period filter is set
-        for day_stats in stats.daily_stats.values() {
-            if let Some(filter) = period_filter
-                && !filter.matches_compact_date(day_stats.date)
-            {
-                continue;
+        let period_stats = if matches!(period_filter, Some(PeriodFilter::Hour { .. })) {
+            AggregateStatsData::Owned(aggregate_session_stats_by_hour(
+                &stats.session_aggregates,
+                false,
+            ))
+        } else {
+            AggregateStatsData::Borrowed(&stats.daily_stats)
+        };
+
+        for (period, day_stats) in period_stats.as_map() {
+            if let Some(filter) = period_filter {
+                let matches = if matches!(filter, PeriodFilter::Hour { .. }) {
+                    filter.matches_hour_key(period)
+                } else {
+                    filter.matches_compact_date(day_stats.date)
+                };
+                if !matches {
+                    continue;
+                }
             }
 
             total_cost_cents += day_stats.stats.cost_cents as u64;

--- a/src/tui/logic.rs
+++ b/src/tui/logic.rs
@@ -3,9 +3,9 @@
 /// Provides functions to aggregate statistics, filter dates, and check for data presence.
 use crate::types::{
     CompactDate, ConversationMessage, DailyStats, MessageRole, ModelCounts, Stats, TuiStats,
-    intern_model,
+    intern_model, resolve_model,
 };
-use chrono::{Datelike, NaiveDate, Weekday};
+use chrono::{Datelike, Local, NaiveDate, Weekday};
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -21,6 +21,67 @@ pub fn accumulate_tui_stats(dst: &mut TuiStats, src: &Stats) {
     dst.cached_tokens = dst.cached_tokens.saturating_add(src.cached_tokens);
     dst.add_cost(src.cost);
     dst.tool_calls = dst.tool_calls.saturating_add(src.tool_calls);
+}
+
+/// Format a timestamp as a local hourly bucket key (`YYYY-MM-DDTHH`).
+pub fn local_hour_key(timestamp: &chrono::DateTime<chrono::Utc>) -> String {
+    timestamp
+        .with_timezone(&Local)
+        .format("%Y-%m-%dT%H")
+        .to_string()
+}
+
+/// Aggregate per-session hourly activity for TUI display.
+pub fn aggregate_session_stats_by_hour(
+    sessions: &[SessionAggregate],
+    include_apps: bool,
+) -> BTreeMap<String, DailyStats> {
+    let mut result = BTreeMap::new();
+
+    for session in sessions {
+        let start_hour = session.hourly.keys().next().cloned();
+        for (hour_key, activity) in &session.hourly {
+            let Some(date) = hour_key.get(..10).and_then(CompactDate::from_str) else {
+                continue;
+            };
+            let hour = result
+                .entry(hour_key.clone())
+                .or_insert_with(|| DailyStats {
+                    date,
+                    ..Default::default()
+                });
+            hour.user_messages = hour.user_messages.saturating_add(
+                activity
+                    .message_count
+                    .saturating_sub(activity.ai_message_count),
+            );
+            hour.ai_messages = hour.ai_messages.saturating_add(activity.ai_message_count);
+            hour.stats += activity.stats;
+            if Some(hour_key) == start_hour.as_ref() {
+                hour.conversations = hour.conversations.saturating_add(1);
+            }
+            for &(model, count) in activity.models.iter() {
+                *hour
+                    .models
+                    .entry(resolve_model(model).to_string())
+                    .or_insert(0) += count;
+            }
+            for (model, stats) in &activity.model_stats {
+                hour.model_stats
+                    .entry(model.clone())
+                    .or_insert_with(|| crate::types::ModelStats::new(model.clone()))
+                    .add_model_stats(stats);
+            }
+            if include_apps && activity.message_count > 0 {
+                *hour
+                    .apps
+                    .entry(session.analyzer_name.to_string())
+                    .or_insert(0) += 1;
+            }
+        }
+    }
+
+    result
 }
 
 fn parse_period_parts(day: &str) -> Option<(u32, u32, Option<u32>)> {
@@ -148,6 +209,13 @@ fn month_name_to_number(lower: &str) -> Option<u32> {
 pub fn date_matches_buffer(day: &str, buffer: &str) -> bool {
     if buffer.is_empty() {
         return true;
+    }
+
+    if let Some((date, hour)) = day.split_once('T') {
+        let normalized = buffer.trim().replace(' ', "T");
+        return day.contains(&normalized)
+            || hour == normalized
+            || date_matches_buffer(date, buffer);
     }
 
     if let Some((week_year, iso_week)) = parse_week_key(day) {
@@ -420,11 +488,14 @@ pub fn aggregate_sessions_from_messages(
                 session_name: None,
                 date: CompactDate::from_local(&msg.date),
                 daily: BTreeMap::new(),
+                hourly: BTreeMap::new(),
             });
 
         let activity_date = CompactDate::from_local(&msg.date);
         let daily = entry.daily.entry(activity_date).or_default();
         daily.message_count = daily.message_count.saturating_add(1);
+        let hourly = entry.hourly.entry(local_hour_key(&msg.date)).or_default();
+        hourly.message_count = hourly.message_count.saturating_add(1);
 
         if msg.date < entry.first_timestamp {
             entry.first_timestamp = msg.date;
@@ -434,14 +505,22 @@ pub fn aggregate_sessions_from_messages(
         // Only aggregate stats for assistant messages and track models when known.
         if msg.role == MessageRole::Assistant {
             daily.ai_message_count = daily.ai_message_count.saturating_add(1);
+            hourly.ai_message_count = hourly.ai_message_count.saturating_add(1);
             accumulate_tui_stats(&mut entry.stats, &msg.stats);
             accumulate_tui_stats(&mut daily.stats, &msg.stats);
+            accumulate_tui_stats(&mut hourly.stats, &msg.stats);
 
             if let Some(model) = &msg.model {
                 let model_key = intern_model(model);
                 entry.models.increment(model_key, 1);
                 daily.models.increment(model_key, 1);
+                hourly.models.increment(model_key, 1);
                 daily
+                    .model_stats
+                    .entry(model.to_string())
+                    .or_insert_with(|| crate::types::ModelStats::new(model.to_string()))
+                    .add_message(&msg.stats);
+                hourly
                     .model_stats
                     .entry(model.to_string())
                     .or_insert_with(|| crate::types::ModelStats::new(model.to_string()))
@@ -469,7 +548,65 @@ pub fn aggregate_sessions_from_messages(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::AnalyzerStatsView;
+    use crate::types::{AnalyzerStatsView, Application};
+    use chrono::{TimeZone, Utc};
+
+    fn message_at(hour: u32, conversation: &str, input_tokens: u64) -> ConversationMessage {
+        ConversationMessage {
+            application: Application::CodexCli,
+            date: Utc.with_ymd_and_hms(2025, 1, 15, hour, 30, 0).unwrap(),
+            project_hash: String::new(),
+            project_path: None,
+            conversation_hash: conversation.to_string(),
+            local_hash: None,
+            global_hash: format!("{conversation}-{hour}"),
+            model: Some("gpt-test".to_string()),
+            stats: Stats {
+                input_tokens,
+                ..Default::default()
+            },
+            role: MessageRole::Assistant,
+            uuid: None,
+            session_name: None,
+        }
+    }
+
+    #[test]
+    fn aggregates_session_activity_by_local_hour() {
+        let messages = vec![
+            message_at(9, "session-a", 100),
+            message_at(10, "session-a", 200),
+            message_at(10, "session-b", 300),
+        ];
+        let sessions = aggregate_sessions_from_messages(&messages, Arc::from("Codex CLI"));
+
+        let hourly = aggregate_session_stats_by_hour(&sessions, false);
+        let hour_09 = Utc
+            .with_ymd_and_hms(2025, 1, 15, 9, 30, 0)
+            .unwrap()
+            .with_timezone(&Local)
+            .format("%Y-%m-%dT%H")
+            .to_string();
+        let hour_10 = Utc
+            .with_ymd_and_hms(2025, 1, 15, 10, 30, 0)
+            .unwrap()
+            .with_timezone(&Local)
+            .format("%Y-%m-%dT%H")
+            .to_string();
+
+        assert_eq!(hourly[&hour_09].stats.input_tokens, 100);
+        assert_eq!(hourly[&hour_09].conversations, 1);
+        assert_eq!(hourly[&hour_10].stats.input_tokens, 500);
+        assert_eq!(hourly[&hour_10].conversations, 1);
+        assert_eq!(hourly[&hour_10].ai_messages, 2);
+
+        let mut filtered_sessions = sessions.clone();
+        for session in &mut filtered_sessions {
+            session.hourly.retain(|hour, _| hour == &hour_10);
+        }
+        let filtered_hourly = aggregate_session_stats_by_hour(&filtered_sessions, false);
+        assert_eq!(filtered_hourly[&hour_10].conversations, 2);
+    }
 
     #[test]
     fn has_data_view_returns_true_for_non_empty() {

--- a/src/tui/tests.rs
+++ b/src/tui/tests.rs
@@ -117,6 +117,10 @@ fn aggregate_sessions_splits_conversation_when_project_changes() {
 #[test]
 fn aggregate_view_from_config() {
     assert!(matches!(
+        AggregateViewMode::from_config("hour"),
+        AggregateViewMode::Hourly
+    ));
+    assert!(matches!(
         AggregateViewMode::from_config("daily"),
         AggregateViewMode::Daily
     ));
@@ -1174,6 +1178,7 @@ fn model_filter_recalculates_stats_and_sessions() {
         session_name: None,
         date,
         daily: BTreeMap::new(),
+        hourly: BTreeMap::new(),
     };
     let multi_models = {
         let mut models = ModelCounts::new();
@@ -1198,6 +1203,7 @@ fn model_filter_recalculates_stats_and_sessions() {
                 ..Default::default()
             },
         )]),
+        hourly: BTreeMap::new(),
     };
     let view = AnalyzerStatsView {
         daily_stats,

--- a/src/types.rs
+++ b/src/types.rs
@@ -218,6 +218,8 @@ pub struct SessionAggregate {
     pub date: CompactDate,
     /// Per-day activity used when drilling into a day, week, month, or year.
     pub daily: BTreeMap<CompactDate, SessionPeriodAggregate>,
+    /// Per-hour activity, keyed by local time as `YYYY-MM-DDTHH`.
+    pub hourly: BTreeMap<String, SessionPeriodAggregate>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -954,6 +956,7 @@ mod tests {
                 session_name: None,
                 date: CompactDate::default(),
                 daily: BTreeMap::new(),
+                hourly: BTreeMap::new(),
             }],
             ..Default::default()
         }


### PR DESCRIPTION
## Summary

Add an hourly TUI aggregation view so usage can be inspected by local-time hour alongside the existing daily, weekly, monthly, and yearly views.

## Changes

- retain per-session hourly activity across contribution cache strategies and incremental updates
- add hourly navigation, filtering, summaries, and session drill-down to the TUI
- keep model and project filters consistent in hourly views
- size the Apps and Models columns from table content with bounded widths and start-aligned excess space

## Verification

- `cargo test --quiet` (446 passed)
- `cargo build --quiet`
- `cargo clippy --quiet -- -D warnings`
- `cargo doc --quiet`
- `cargo fmt --all --quiet -- --check`
- `git diff --check`
- manually launched the TUI and verified hourly aggregation and drill-down at multiple terminal widths

## Notes

- Hour buckets use the local timezone.
- Upload payloads and MCP APIs are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an hourly activity view to the aggregate dashboard.
  * Hourly statistics now include messages, AI activity, token usage, and model-specific metrics.
  * Added hourly filtering, period navigation, configuration support, and model filtering.
  * Improved aggregate table sizing for apps and models.

* **Documentation**
  * Updated configuration documentation to list hourly aggregation as a valid option.

* **Bug Fixes**
  * Hourly statistics now reset correctly when starting a new analyzer session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->