### PR TITLE
Support old and new Piebald database schemas

### DIFF
--- a/src/analyzers/piebald.rs
+++ b/src/analyzers/piebald.rs
@@ -95,10 +95,56 @@ fn query_chats(conn: &Connection) -> Result<Vec<PiebaldChat>> {
     Ok(chats)
 }
 
-/// Query all messages from the database.
-fn query_messages(conn: &Connection) -> Result<Vec<PiebaldMessage>> {
-    let mut stmt = conn.prepare(
-        "SELECT m.id, m.parent_chat_id, m.role, m.model, m.input_tokens, m.output_tokens,
+/// Database layout before or after Piebald's typed-message-parts migration.
+#[derive(Clone, Copy)]
+enum PiebaldSchema {
+    Legacy,
+    TypedParts,
+}
+
+impl PiebaldSchema {
+    /// Detect the layout from storage rather than an application version. The migration
+    /// creates and backfills generation rows before dropping the legacy columns, all
+    /// in one transaction, so readers see either complete layout. SQL failures must
+    /// still propagate rather than being mistaken for an older schema.
+    fn detect(conn: &Connection) -> Result<Self> {
+        let typed_parts: bool = conn.query_row(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master
+             WHERE type = 'table' AND name = 'message_generations')",
+            [],
+            |row| row.get(0),
+        )?;
+        Ok(if typed_parts {
+            Self::TypedParts
+        } else {
+            Self::Legacy
+        })
+    }
+}
+
+/// Query messages using the matching generation layout, retaining user messages
+/// without generation rows while excluding non-conversational context containers.
+fn query_messages(conn: &Connection, schema: PiebaldSchema) -> Result<Vec<PiebaldMessage>> {
+    let sql = match schema {
+        PiebaldSchema::TypedParts => {
+            // Generation metadata is one-to-one with assistant messages, not user
+            // messages. Keep the outer join and the original message timestamps so
+            // migration does not change deduplication identities or streaming dates.
+            "SELECT m.id, m.parent_chat_id, m.role, g.model, g.input_tokens, g.output_tokens,
+                    g.reasoning_tokens, g.cache_read_tokens, g.cache_write_tokens,
+                    COALESCE(responses.service_tier, completions.service_tier) AS service_tier,
+                    m.created_at, m.updated_at
+             FROM messages m
+             LEFT JOIN message_generations g ON g.message_id = m.id
+             LEFT JOIN override_gen_cfg_data_openai_responses responses
+                    ON responses.gen_cfg_id = g.config_id
+             LEFT JOIN override_gen_cfg_data_openai_completions completions
+                    ON completions.gen_cfg_id = g.config_id
+             WHERE m.message_kind = 'normal'
+             ORDER BY m.updated_at"
+        }
+        PiebaldSchema::Legacy => {
+            "SELECT m.id, m.parent_chat_id, m.role, m.model, m.input_tokens, m.output_tokens,
                 m.reasoning_tokens, m.cache_read_tokens, m.cache_write_tokens,
                 COALESCE(responses.service_tier, completions.service_tier) AS service_tier,
                 m.created_at, m.updated_at
@@ -107,8 +153,10 @@ fn query_messages(conn: &Connection) -> Result<Vec<PiebaldMessage>> {
                 ON responses.gen_cfg_id = m.config_id
          LEFT JOIN override_gen_cfg_data_openai_completions completions
                 ON completions.gen_cfg_id = m.config_id
-         ORDER BY m.updated_at",
-    )?;
+         ORDER BY m.updated_at"
+        }
+    };
+    let mut stmt = conn.prepare(sql)?;
 
     let messages = stmt
         .query_map([], |row| {
@@ -135,15 +183,26 @@ fn query_messages(conn: &Connection) -> Result<Vec<PiebaldMessage>> {
 
 /// Query tool call counts per message.
 ///
-/// Joins `message_parts` → `message_part_tool_call` to count how many tool calls
-/// each message made. Returns a map from message ID to tool call count.
-fn query_tool_call_counts(conn: &Connection) -> Result<HashMap<i64, u32>> {
-    let mut stmt = conn.prepare(
-        "SELECT mp.parent_chat_message_id, COUNT(*) as tool_call_count
-         FROM message_parts mp
-         JOIN message_part_tool_call tc ON tc.message_part_id = mp.id
-         GROUP BY mp.parent_chat_message_id",
-    )?;
+/// Returns counts by owning message ID. Typed tools share one execution-context
+/// row per part; counting that row avoids enumerating subtype tables and includes
+/// MCP, legacy, invalid, and still-streaming calls without double counting results.
+fn query_tool_call_counts(conn: &Connection, schema: PiebaldSchema) -> Result<HashMap<i64, u32>> {
+    let sql = match schema {
+        PiebaldSchema::Legacy => {
+            "SELECT mp.parent_chat_message_id, COUNT(*) as tool_call_count
+             FROM message_parts mp
+             JOIN message_part_tool_call tc ON tc.message_part_id = mp.id
+             GROUP BY mp.parent_chat_message_id"
+        }
+        PiebaldSchema::TypedParts => {
+            "SELECT mp.parent_chat_message_id, COUNT(*) as tool_call_count
+             FROM message_parts mp
+             JOIN tool_execution_context tc ON tc.message_part_id = mp.id
+             WHERE mp.part_type = 'tool'
+             GROUP BY mp.parent_chat_message_id"
+        }
+    };
+    let mut stmt = conn.prepare(sql)?;
 
     let counts = stmt
         .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, u32>(1)?)))?
@@ -352,10 +411,17 @@ impl Analyzer for PiebaldAnalyzer {
     }
 
     fn parse_source(&self, source: &DataSource) -> Result<Vec<ConversationMessage>> {
-        let conn = open_piebald_db(&source.path)?;
-        let chats = query_chats(&conn)?;
-        let messages = query_messages(&conn)?;
-        let tool_call_counts = query_tool_call_counts(&conn)?;
+        let mut conn = open_piebald_db(&source.path)?;
+        // Pin schema detection and all reads to one snapshot. Piebald may migrate
+        // or stream new usage while Splitrail is running; mixing snapshots could
+        // select a dropped table or combine usage and tool counts from different turns.
+        // This is a deferred read transaction on a read-only connection, never a write.
+        let tx = conn.transaction()?;
+        let schema = PiebaldSchema::detect(&tx)?;
+        let chats = query_chats(&tx)?;
+        let messages = query_messages(&tx, schema)?;
+        let tool_call_counts = query_tool_call_counts(&tx, schema)?;
+        tx.commit()?;
         Ok(convert_messages(&chats, messages, &tool_call_counts))
     }
 
@@ -385,6 +451,10 @@ impl Analyzer for PiebaldAnalyzer {
         ContributionStrategy::MultiSession
     }
 }
+
+#[cfg(test)]
+#[path = "piebald_schema_tests.rs"]
+mod schema_tests;
 
 #[cfg(test)]
 mod tests {

--- a/src/analyzers/piebald.rs
+++ b/src/analyzers/piebald.rs
@@ -103,14 +103,18 @@ enum PiebaldSchema {
 }
 
 impl PiebaldSchema {
-    /// Detect the layout from storage rather than an application version. The migration
-    /// creates and backfills generation rows before dropping the legacy columns, all
-    /// in one transaction, so readers see either complete layout. SQL failures must
-    /// still propagate rather than being mistaken for an older schema.
+    /// Detect finalized storage rather than an application version. Piebald commits
+    /// the additive schema before backfilling tools, so the generation table can
+    /// coexist with authoritative legacy calls and an empty execution-context table.
+    /// Keep legacy reads until finalization drops the old tool table atomically with
+    /// the old message columns. This also covers a failed or in-progress backfill.
+    /// SQL failures still propagate rather than being mistaken for an older schema.
     fn detect(conn: &Connection) -> Result<Self> {
         let typed_parts: bool = conn.query_row(
             "SELECT EXISTS(SELECT 1 FROM sqlite_master
-             WHERE type = 'table' AND name = 'message_generations')",
+             WHERE type = 'table' AND name = 'message_generations')
+             AND NOT EXISTS(SELECT 1 FROM sqlite_master
+             WHERE type = 'table' AND name = 'message_part_tool_call')",
             [],
             |row| row.get(0),
         )?;

--- a/src/analyzers/piebald_schema_tests.rs
+++ b/src/analyzers/piebald_schema_tests.rs
@@ -1,0 +1,188 @@
+//! On-disk fixtures exercise the public read-only parser against both Piebald
+//! layouts. The typed fixture deliberately omits the dropped columns and table:
+//! retaining them would let accidental legacy queries pass unnoticed.
+
+use super::*;
+use tempfile::TempDir;
+
+/// Create equivalent usage histories in either layout. User and metadata-less
+/// assistant rows exercise outer joins; a NULL generation model exercises the
+/// existing chat-model fallback. Both provider config tables must remain usable.
+fn fixture(schema: PiebaldSchema) -> (TempDir, DataSource) {
+    let directory = tempfile::tempdir().unwrap();
+    let source = DataSource {
+        path: directory.path().join("app.db"),
+    };
+    let conn = Connection::open(&source.path).unwrap();
+    conn.execute_batch(
+        "CREATE TABLE projects (id INTEGER PRIMARY KEY, directory TEXT);
+         CREATE TABLE chats (id INTEGER PRIMARY KEY, title TEXT, model TEXT,
+                             project_id INTEGER, created_at TEXT);
+         CREATE TABLE messages (id INTEGER PRIMARY KEY, parent_chat_id INTEGER,
+                                role TEXT, created_at TEXT, updated_at TEXT);
+         CREATE TABLE message_parts (id INTEGER PRIMARY KEY,
+                                     parent_chat_message_id INTEGER, part_type TEXT);
+         CREATE TABLE override_gen_cfg_data_openai_responses
+             (gen_cfg_id INTEGER PRIMARY KEY, service_tier TEXT);
+         CREATE TABLE override_gen_cfg_data_openai_completions
+             (gen_cfg_id INTEGER PRIMARY KEY, service_tier TEXT);
+         INSERT INTO projects VALUES (1, '/tmp/piebald-project');
+         INSERT INTO chats VALUES (1, 'Schema compatibility', 'gpt-5.4', 1,
+                                   '2026-05-01T12:00:00Z');
+         INSERT INTO messages VALUES
+             (1, 1, 'user', '2026-05-01T12:00:00Z', '2026-05-01T12:00:00Z'),
+             (2, 1, 'assistant', '2026-05-01T12:00:01Z', '2026-05-01T12:00:05Z'),
+             (3, 1, 'assistant', '2026-05-01T12:00:02Z', '2026-05-01T12:00:06Z'),
+             (4, 1, 'assistant', '2026-05-01T12:00:03Z', '2026-05-01T12:00:07Z');
+         INSERT INTO override_gen_cfg_data_openai_responses VALUES (20, 'priority');
+         INSERT INTO override_gen_cfg_data_openai_completions VALUES (20, 'flex'), (30, 'flex');
+         INSERT INTO message_parts VALUES (1, 2, 'text'), (2, 2, 'tool'),
+                                         (3, 2, 'tool'), (4, 3, 'tool');",
+    )
+    .unwrap();
+
+    let usage_columns = "model TEXT, config_id INTEGER, input_tokens INTEGER,
+                         output_tokens INTEGER, reasoning_tokens INTEGER,
+                         cache_read_tokens INTEGER, cache_write_tokens INTEGER";
+    match schema {
+        PiebaldSchema::Legacy => {
+            // Splitting this fixed fixture declaration is safe: no user input is SQL.
+            for column in usage_columns.split(',') {
+                conn.execute_batch(&format!("ALTER TABLE messages ADD COLUMN {column};"))
+                    .unwrap();
+            }
+            conn.execute_batch(
+                "UPDATE messages SET model = 'gpt-5.5', config_id = 20,
+                     input_tokens = 1000, output_tokens = 200, reasoning_tokens = 30,
+                     cache_read_tokens = 100, cache_write_tokens = 50 WHERE id = 2;
+                 UPDATE messages SET config_id = 30,
+                     input_tokens = 500, output_tokens = 100, reasoning_tokens = 10,
+                     cache_read_tokens = 0, cache_write_tokens = 0 WHERE id = 3;
+                 CREATE TABLE message_part_tool_call (message_part_id INTEGER PRIMARY KEY);
+                 INSERT INTO message_part_tool_call VALUES (2), (3), (4);",
+            )
+            .unwrap();
+        }
+        PiebaldSchema::TypedParts => {
+            conn.execute_batch(&format!(
+                "ALTER TABLE messages ADD COLUMN message_kind TEXT NOT NULL DEFAULT 'normal';
+                 CREATE TABLE message_generations (message_id INTEGER PRIMARY KEY, {usage_columns});
+                 INSERT INTO message_generations VALUES
+                     (2, 'gpt-5.5', 20, 1000, 200, 30, 100, 50),
+                     (3, NULL, 30, 500, 100, 10, 0, 0);
+                 CREATE TABLE tool_execution_context (message_part_id INTEGER PRIMARY KEY);
+                 INSERT INTO tool_execution_context VALUES (2), (3), (4);
+                 ALTER TABLE message_parts ADD COLUMN part_subtype TEXT;
+                 UPDATE message_parts SET part_subtype = 'read_file' WHERE id = 2;
+                 UPDATE message_parts SET part_subtype = 'mcp' WHERE id = 3;
+                 UPDATE message_parts SET part_subtype = 'streaming' WHERE id = 4;
+                 INSERT INTO messages VALUES
+                     (5, 1, 'user', '2026-05-01T12:00:04Z', '2026-05-01T12:00:08Z', 'context_container');
+                 INSERT INTO message_parts VALUES (5, 5, 'context', 'agent_rules');"
+            ))
+            .unwrap();
+        }
+    }
+    (directory, source)
+}
+
+/// Assert accounting, provider tier precedence, identity, and zero-usage rows
+/// independently of schema parity, so a shared regression cannot pass both sides.
+fn assert_history(messages: &[ConversationMessage]) {
+    assert_eq!(messages.len(), 4);
+    let user = &messages[0];
+    assert_eq!(user.role, MessageRole::User);
+    assert!(user.model.is_none());
+    assert_eq!(user.stats.input_tokens, 0);
+    assert_eq!(user.stats.tool_calls, 0);
+
+    let assistant = &messages[1];
+    assert_eq!(assistant.model.as_deref(), Some("gpt-5.5"));
+    assert_eq!(assistant.stats.input_tokens, 900);
+    assert_eq!(assistant.stats.output_tokens, 200);
+    assert_eq!(assistant.stats.reasoning_tokens, 30);
+    assert_eq!(assistant.stats.cache_read_tokens, 100);
+    assert_eq!(assistant.stats.cache_creation_tokens, 50);
+    assert_eq!(assistant.stats.tool_calls, 2);
+    assert_eq!(
+        assistant.project_path.as_deref(),
+        Some("/tmp/piebald-project")
+    );
+    assert_eq!(
+        assistant.session_name.as_deref(),
+        Some("Schema compatibility")
+    );
+    assert_eq!(
+        assistant.date,
+        parse_timestamp("2026-05-01T12:00:05Z").unwrap()
+    );
+    assert_eq!(
+        assistant.global_hash,
+        hash_text("piebald_2026-05-01T12:00:01Z_2")
+    );
+    let priority_cost = calculate_total_cost_for_service_tier_at(
+        "gpt-5.5",
+        ServiceTier::Priority,
+        900,
+        230,
+        50,
+        100,
+        Some(assistant.date),
+    );
+    assert!(priority_cost > 0.0);
+    assert_eq!(assistant.stats.cost, priority_cost);
+
+    let fallback = &messages[2];
+    assert_eq!(fallback.model.as_deref(), Some("gpt-5.4"));
+    assert_eq!(fallback.stats.tool_calls, 1);
+    let flex_cost = calculate_total_cost_for_service_tier_at(
+        "gpt-5.4",
+        ServiceTier::Flex,
+        500,
+        110,
+        0,
+        0,
+        Some(fallback.date),
+    );
+    assert!(flex_cost > 0.0);
+    assert_eq!(fallback.stats.cost, flex_cost);
+    assert_eq!(messages[3].stats.input_tokens, 0);
+    assert_eq!(messages[3].stats.cost, 0.0);
+    assert_eq!(messages[3].stats.tool_calls, 0);
+}
+
+#[test]
+fn legacy_schema_preserves_usage_and_tools() {
+    let (_directory, source) = fixture(PiebaldSchema::Legacy);
+    assert_history(&PiebaldAnalyzer::new().parse_source(&source).unwrap());
+}
+
+#[test]
+fn typed_schema_preserves_usage_and_tools_without_context_containers() {
+    let (_directory, source) = fixture(PiebaldSchema::TypedParts);
+    assert_history(&PiebaldAnalyzer::new().parse_source(&source).unwrap());
+}
+
+#[test]
+fn schema_migration_preserves_normalized_history() {
+    let (_legacy_directory, legacy) = fixture(PiebaldSchema::Legacy);
+    let (_typed_directory, typed) = fixture(PiebaldSchema::TypedParts);
+    let analyzer = PiebaldAnalyzer::new();
+    let old = analyzer.parse_source(&legacy).unwrap();
+    let new = analyzer.parse_source(&typed).unwrap();
+    assert_eq!(
+        simd_json::to_string(&old).unwrap(),
+        simd_json::to_string(&new).unwrap()
+    );
+}
+
+#[test]
+fn broken_typed_schema_is_an_error_not_empty_history_or_legacy_fallback() {
+    let (_directory, source) = fixture(PiebaldSchema::TypedParts);
+    let conn = Connection::open(&source.path).unwrap();
+    // Only this disposable fixture is damaged; production databases are read-only.
+    conn.execute_batch("ALTER TABLE message_generations RENAME COLUMN model TO missing_model;")
+        .unwrap();
+    let error = PiebaldAnalyzer::new().parse_source(&source).unwrap_err();
+    assert!(error.to_string().contains("g.model"), "{error}");
+}

--- a/src/analyzers/piebald_schema_tests.rs
+++ b/src/analyzers/piebald_schema_tests.rs
@@ -186,3 +186,29 @@ fn broken_typed_schema_is_an_error_not_empty_history_or_legacy_fallback() {
     let error = PiebaldAnalyzer::new().parse_source(&source).unwrap_err();
     assert!(error.to_string().contains("g.model"), "{error}");
 }
+
+#[test]
+fn additive_schema_keeps_legacy_tools_until_finalization() {
+    let (_directory, source) = fixture(PiebaldSchema::Legacy);
+    let analyzer = PiebaldAnalyzer::new();
+    let before = analyzer.parse_source(&source).unwrap();
+    let conn = Connection::open(&source.path).unwrap();
+    // Piebald commits these additions before its separate backfill transaction.
+    // The copied generations exist, but legacy calls remain authoritative until
+    // finalization: the new execution table is still empty if backfill fails.
+    conn.execute_batch(
+        "CREATE TABLE message_generations AS
+             SELECT id AS message_id, model, config_id, input_tokens, output_tokens,
+                    reasoning_tokens, cache_read_tokens, cache_write_tokens
+             FROM messages WHERE role = 'assistant';
+         CREATE TABLE tool_execution_context (message_part_id INTEGER PRIMARY KEY);
+         ALTER TABLE messages ADD COLUMN message_kind TEXT NOT NULL DEFAULT 'normal';",
+    )
+    .unwrap();
+    let intermediate = analyzer.parse_source(&source).unwrap();
+    assert_history(&intermediate);
+    assert_eq!(
+        simd_json::to_string(&before).unwrap(),
+        simd_json::to_string(&intermediate).unwrap()
+    );
+}


### PR DESCRIPTION
## Why

Piebald's typed-message-parts migration moves model, token, and generation configuration fields out of `messages` and removes `message_part_tool_call`. Splitrail still queries those legacy locations, so updated databases fail with `no such column: m.model` and their usage cannot be parsed.

Support the new layout without requiring users on older Piebald versions to migrate.

## What changed

- Detect finalized typed-parts storage using `message_generations` and removal of `message_part_tool_call`. Keep legacy reads during the committed additive migration state, before tool backfill finishes.
- Read normalized generation metadata and service-tier configuration while preserving message timestamps, deduplication identities, and chat-model fallback.
- Count typed tool calls through `tool_execution_context` and exclude context-container messages.
- Keep schema detection and all queries in one read-only transaction.
- Add five on-disk fixture tests covering legacy, additive, and finalized layouts, equivalent normalized output, and malformed-schema errors.

## Validation

- `cargo build --quiet` — passed.
- `cargo test --quiet` — 451 passed.
- `cargo clippy --quiet -- -D warnings` — passed.
- `cargo doc --quiet` — passed.
- `cargo fmt --all --quiet` — passed.
- `git diff --check` — passed.

### CLI before/after

Ran `/usr/local/bin/splitrail stats --include-messages` (released 3.9.0) and the PR debug binary with `stats --include-messages` against identical synthetic SQLite histories. Each layout used a temporary `HOME` and isolated `XDG_DATA_HOME`, `XDG_CONFIG_HOME`, and `XDG_CACHE_HOME`; no real usage database or cloud upload was involved. The harness command was `python3 /tmp/splitrail-8833-cli-proof.py`.

```text
legacy / release-3.9.0: messages=1 input_tokens=900 tool_calls=1
legacy / PR: messages=1 input_tokens=900 tool_calls=1
additive / release-3.9.0: messages=1 input_tokens=900 tool_calls=1
additive / PR: messages=1 input_tokens=900 tool_calls=1
typed / release-3.9.0: messages=0 (Piebald source could not be parsed)
typed / PR: messages=1 input_tokens=900 tool_calls=1
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for reading both legacy and typed-message-parts Piebald database formats.
  * Improved message and tool-call usage parsing, including generation metadata, service tiers, identities, and zero-usage records.
  * Ensured database reads use a consistent snapshot for reliable results.
  * Added clearer errors for invalid typed database schemas.
  * Improved reliability during in-progress schema migrations by preserving accurate legacy usage and tool-call data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->